### PR TITLE
Expected Values for CV & EoC Measures

### DIFF
--- a/app/assets/javascripts/templates/measure_calculation.hbs
+++ b/app/assets/javascripts/templates/measure_calculation.hbs
@@ -64,30 +64,32 @@
               {{#ifCond name "==" "OBSERV"}}
                 {{expected}}%
               {{else}}
-                {{#if ../../../episode_of_care}}
+                {{!-- FIXME Uncomment below to enable EoC measure results--}}
+                {{!-- {{#if ../../../episode_of_care}}
                   <span class="default">{{expected}}</span>
-                {{else}}
+                {{else}} --}}
                   {{#if expected}}
                     <i class="fa fa-check-square-o default"></i>
                   {{else}}
                     <i class="fa fa-square-o default"></i>
                   {{/if}}
-                {{/if}}
+                {{!-- {{/if}} --}}
               {{/ifCond}}
             </td>
             <td style="text-align: center;">
               {{#ifCond name "==" "OBSERV"}}
                 <span class="fail">{{result}}%</span>
               {{else}}
-                {{#if ../../../episode_of_care}}
+                {{!-- FIXME Uncomment below to enable EoC measure results --}}
+                {{!-- {{#if ../../../episode_of_care}}
                   <span class="fail">{{result}}</span>
-                {{else}}
+                {{else}} --}}
                   {{#if result}}
                     <i class="fa fa-check-square-o default"></i>
                   {{else}}
                     <i class="fa fa-square-o default"></i>
                   {{/if}}
-                {{/if}}
+                {{!-- {{/if}} --}}
               {{/ifCond}}
             </td>
           </tr>

--- a/app/assets/javascripts/templates/measure_calculation.hbs
+++ b/app/assets/javascripts/templates/measure_calculation.hbs
@@ -61,18 +61,34 @@
             </td>
             <td>{{name}}</td>
             <td style="text-align: center;">
-              {{#if expected}}
-                <i class="fa fa-check"></i>
+              {{#ifCond name "==" "OBSERV"}}
+                {{expected}}%
               {{else}}
-                <i class="fa fa-minus"></i>
-              {{/if}}
+                {{#if ../../../episode_of_care}}
+                  <span class="default">{{expected}}</span>
+                {{else}}
+                  {{#if expected}}
+                    <i class="fa fa-check-square-o default"></i>
+                  {{else}}
+                    <i class="fa fa-square-o default"></i>
+                  {{/if}}
+                {{/if}}
+              {{/ifCond}}
             </td>
             <td style="text-align: center;">
-              {{#if result}}
-                <i class="fa fa-check"></i>
+              {{#ifCond name "==" "OBSERV"}}
+                <span class="fail">{{result}}%</span>
               {{else}}
-                <i class="fa fa-minus"></i>
-              {{/if}}
+                {{#if ../../../episode_of_care}}
+                  <span class="fail">{{result}}</span>
+                {{else}}
+                  {{#if result}}
+                    <i class="fa fa-check-square-o default"></i>
+                  {{else}}
+                    <i class="fa fa-square-o default"></i>
+                  {{/if}}
+                {{/if}}
+              {{/ifCond}}
             </td>
           </tr>
         {{/each}}

--- a/app/assets/javascripts/templates/patient_builder/expected_value.hbs
+++ b/app/assets/javascripts/templates/patient_builder/expected_value.hbs
@@ -2,11 +2,27 @@
   <h2>EXPECTED VALUE</h2>
   <form class="form-inline" role="form">
     {{#each currentCriteria}}
-      <div class="checkbox {{#if @index}}checkbox-divider{{/if}}">
-        <label class="checkbox-population">
-          <input type="checkbox" id="{{key}}"> {{displayName}}
-        </label>
-      </div>
+      {{#ifCond key "==" "OBSERV"}}
+        <div class="checkbox {{#if @index}}checkbox-divider{{/if}}">
+          <label class="checkbox-population {{cid}}">
+            {{displayName}} <input class="checkbox-number" type="number" id="{{key}}" value="{{value}}">
+          </label>
+        </div>
+      {{else}}
+        {{#if isEoC}}
+          <div class="checkbox {{#if @index}}checkbox-divider{{/if}}">
+            <label class="checkbox-population {{cid}}">
+              <input class="checkbox-number" type="number" id="{{key}}" value="{{value}}"> {{displayName}}
+            </label>
+          </div>
+        {{else}}
+          <div class="checkbox {{#if @index}}checkbox-divider{{/if}}">
+            <label class="checkbox-population {{cid}}">
+              <input type="checkbox" id="{{key}}" {{#if value}}checked="checked"{{/if}}> <span>{{displayName}}</span>
+            </label>
+          </div>
+        {{/if}}
+      {{/ifCond}}
     {{/each}}
   </form>
 </div>

--- a/app/assets/javascripts/views/measure_calculation_view.js.coffee
+++ b/app/assets/javascripts/views/measure_calculation_view.js.coffee
@@ -36,10 +36,10 @@ class Thorax.Views.MeasureCalculation extends Thorax.View
     combinedResults = {}
     patientStatus = @population.isExactlyMatching(patient)
     for p in validPopulations
-      combinedResults[p] = {}
-      combinedResults[p]['name'] = p
-      combinedResults[p]['expected'] = expectedValues?[p]
-      combinedResults[p]['result'] = result.get(p)
+      resultValue = if p is 'OBSERV' then result.get('values')?[0] else result.get(p)
+      combinedResults[p] = { name: p, expected: expectedValues?[p], result: resultValue }
+    console.log result
+    console.log combinedResults
     _(result.toJSON()).extend
       measure_id: @model.get('hqmf_set_id')
       populationTitle: popTitle ?= @population.get('sub_id')

--- a/app/assets/javascripts/views/measure_calculation_view.js.coffee
+++ b/app/assets/javascripts/views/measure_calculation_view.js.coffee
@@ -38,8 +38,8 @@ class Thorax.Views.MeasureCalculation extends Thorax.View
     for p in validPopulations
       resultValue = if p is 'OBSERV' then result.get('values')?[0] else result.get(p)
       combinedResults[p] = { name: p, expected: expectedValues?[p], result: resultValue }
-    console.log result
-    console.log combinedResults
+    # console.log result
+    # console.log combinedResults
     _(result.toJSON()).extend
       measure_id: @model.get('hqmf_set_id')
       populationTitle: popTitle ?= @population.get('sub_id')

--- a/app/assets/javascripts/views/measures_view.js.coffee
+++ b/app/assets/javascripts/views/measures_view.js.coffee
@@ -7,6 +7,8 @@ class MeasureRowView extends Thorax.View
       unless @model.get('patients').isEmpty()
         @percentage = ((@matching / @model.get('patients').length) * 100).toFixed(0)
       @success = @matching is @model.get('patients').length
+    # if @model.get('continuous_variable') is true then console.log "CV: #{@model.get('measure_id')}"
+    # if @model.get('episode_of_care') is true then console.log "EoC: #{@model.get('measure_id')}"
   context: ->
     s = @status()
     _(super).extend

--- a/app/assets/javascripts/views/patient_builder.js.coffee
+++ b/app/assets/javascripts/views/patient_builder.js.coffee
@@ -247,8 +247,14 @@ class Thorax.Views.ExpectedValuesView extends Thorax.View
         for key in (pop for pop in _.keys(pc) when p.has(pop))
         # selections = @$("##{p.get('sub_id')} > div > .expected-values > form > .checkbox > label > input")
           # console.log @$("##{p.get('sub_id')} > div > .expected-values > form > .checkbox > label > ##{key}")
-          checkedValue = @$("#expected-#{p.get('sub_id')} > div > .expected-values > form > .checkbox > label > ##{key}").prop('checked')
-          if checkedValue is true then pevHash[key] = 1 else pevHash[key] = 0
+          # checkedValue = @$("#expected-#{p.get('sub_id')} > div > .expected-values > form > .checkbox > label > ##{key}").prop('checked')
+          if key is 'OBSERV'
+            pevHash[key] = parseFloat(@$(".#{p.get('sub_id')}-#{key} > ##{key}").prop('value'))
+          else if m.get('episode_of_care') is true
+            pevHash[key] = parseFloat(@$(".#{p.get('sub_id')}-#{key} > ##{key}").prop('value'))
+          else
+            checkedValue = @$(".#{p.get('sub_id')}-#{key} > ##{key}").prop('checked')
+            if checkedValue is true then pevHash[key] = 1 else pevHash[key] = 0
         parsedValues[m.get('hqmf_set_id')][p.get('sub_id')] = pevHash
       attr.expected_values = _.extend({}, parsedValues)
 
@@ -270,14 +276,11 @@ class Thorax.Views.ExpectedValueView extends Thorax.View
       NUMER: 'NUMERATOR'
       DENEXCEP: 'EXCEPTION'
       DENEX: 'EXCLUSION'
-      MSRPOPL: 'MSRPOPL'
-      OBSERV: 'OBSERVATION'
+      MSRPOPL: 'MEASURE POPULATION'
+      OBSERV: 'MEASURE OBSERVATIONS'
     @currentCriteria = []
     for mc in matchingCriteria
-      criteriaHash = {}
-      criteriaHash.key = mc
-      criteriaHash.displayName = criteriaMap[mc]
-      @currentCriteria.push criteriaHash
+      @currentCriteria.push { cid: "#{p.sub_id}-#{mc}", key: mc, displayName: criteriaMap[mc], value: @modelValues[@measure.get('hqmf_set_id')]?[@population.sub_id][mc], isEoC: @measure.get('episode_of_care') }
 
   events: ->
     'rendered': 'setValues'
@@ -285,7 +288,5 @@ class Thorax.Views.ExpectedValueView extends Thorax.View
   setValues: ->
     for c in _.keys(@currentCriteria)
       criteria = @currentCriteria[c].key
-      if @modelValues[@measure.get('hqmf_set_id')]?[@population.sub_id][criteria] is 1
-        @$('#' + criteria).prop('checked', true)
       if @editFlag is false
         @$('#' + criteria).prop('disabled', true)

--- a/app/assets/javascripts/views/patient_builder.js.coffee
+++ b/app/assets/javascripts/views/patient_builder.js.coffee
@@ -250,8 +250,9 @@ class Thorax.Views.ExpectedValuesView extends Thorax.View
           # checkedValue = @$("#expected-#{p.get('sub_id')} > div > .expected-values > form > .checkbox > label > ##{key}").prop('checked')
           if key is 'OBSERV'
             pevHash[key] = parseFloat(@$(".#{p.get('sub_id')}-#{key} > ##{key}").prop('value'))
-          else if m.get('episode_of_care') is true
-            pevHash[key] = parseFloat(@$(".#{p.get('sub_id')}-#{key} > ##{key}").prop('value'))
+          # FIXME If enabling EoC measures, uncomment the following two lines to save values correctly
+          # else if m.get('episode_of_care') is true
+          #   pevHash[key] = parseFloat(@$(".#{p.get('sub_id')}-#{key} > ##{key}").prop('value'))
           else
             checkedValue = @$(".#{p.get('sub_id')}-#{key} > ##{key}").prop('checked')
             if checkedValue is true then pevHash[key] = 1 else pevHash[key] = 0
@@ -280,7 +281,13 @@ class Thorax.Views.ExpectedValueView extends Thorax.View
       OBSERV: 'MEASURE OBSERVATIONS'
     @currentCriteria = []
     for mc in matchingCriteria
-      @currentCriteria.push { cid: "#{p.sub_id}-#{mc}", key: mc, displayName: criteriaMap[mc], value: @modelValues[@measure.get('hqmf_set_id')]?[@population.sub_id][mc], isEoC: @measure.get('episode_of_care') }
+      # FIXME If enabling EoC measures, replace isEoC with @measure.get('episode_of_care') instead of false
+      @currentCriteria.push 
+        cid: "#{p.sub_id}-#{mc}"
+        key: mc
+        displayName: criteriaMap[mc]
+        value: @modelValues[@measure.get('hqmf_set_id')]?[@population.sub_id][mc]
+        isEoC: false
 
   events: ->
     'rendered': 'setValues'

--- a/app/assets/stylesheets/builder.less
+++ b/app/assets/stylesheets/builder.less
@@ -230,6 +230,24 @@
     .checkbox-population {
       font-size: 9px;
       font-weight: bold;
+      input[type="checkbox"] {
+        display:none;
+      }
+      input[type="checkbox"] + span:before {
+        font-family: 'FontAwesome';
+        padding-right: 3px;
+        font-size: 16px;
+        color: @brand-primary;
+      }
+      input[type="checkbox"] + span:before {
+        content: "\f096"; /* check-empty */
+      }
+      input[type="checkbox"]:checked + span:before {
+        content: "\f046"; /* check */
+      }
+      .checkbox-number {
+        width: 15%;
+      }
     }
   }
 

--- a/app/assets/stylesheets/measure_calculation.less
+++ b/app/assets/stylesheets/measure_calculation.less
@@ -49,5 +49,14 @@
       background-color: @btn-danger-color;
       border-color: @btn-danger-border;
     }
+    .pass {
+      .text-success;
+    }
+    .fail {
+      .text-danger;
+    }
+    .default {
+      color: @brand-primary;
+    }
   }
 }

--- a/lib/tasks/bonnie.rake
+++ b/lib/tasks/bonnie.rake
@@ -110,10 +110,10 @@ namespace :bonnie do
 
     desc "Updated source_data_criteria to include title and description from measure(s)"
     task :update_source_data_criteria=> :environment do
-
+      puts "Updating patient source_data_criteria to include title and description"
       Record.each do |patient|
         measures = Measure.in(hqmf_set_id:  patient.measure_ids).to_a
-        puts "Updating source data criteria for record #{patient.first} #{patient.last}"
+        puts "\tUpdating source data criteria for record #{patient.first} #{patient.last}"
         patient.source_data_criteria.each do |patient_data_criteria|
           measures.each do |measure|
             measure_data_criteria = measure.source_data_criteria[patient_data_criteria['id']]


### PR DESCRIPTION
I believe I have a working version of the expected values update for CV and EoC measures.

It allows explicit value specification via an updated patient builder, and also renders them accordingly using the interim mockups.

The obvious issues include styling tweaks, where I would like to request review for resizing the number inputs and/or checkboxes, as well as my choice of CSS-only checkbox styling.
## Default
### Builder

![default_builder](https://f.cloud.github.com/assets/456952/1718242/b957fc62-61da-11e3-9de2-5d4525f8dc6f.png)
### Results

![default_results](https://f.cloud.github.com/assets/456952/1718233/92fd22f4-61da-11e3-99a9-707822f0df4c.png)
## CV
### Builder

![cv_builder](https://f.cloud.github.com/assets/456952/1718251/d7dd6370-61da-11e3-9ff3-84840bd642fa.png)
### Results

![cv_results2](https://f.cloud.github.com/assets/456952/1721287/1f2d6904-621d-11e3-815f-4084f5d65675.png)
## EoC
### Builder

![eoc_builder](https://f.cloud.github.com/assets/456952/1718256/dc0ee22a-61da-11e3-9914-e3ea6b3d4a9e.png)
### Results

![eoc_results](https://f.cloud.github.com/assets/456952/1718257/de2f4b6c-61da-11e3-82a2-48421ef631ca.png)
