### PR TITLE
NQF Highlighting bugfix

### DIFF
--- a/app/assets/javascripts/models/result.js.coffee
+++ b/app/assets/javascripts/models/result.js.coffee
@@ -141,12 +141,13 @@ class Thorax.Models.Result extends Thorax.Model
     for precondition in preconditions
       if (precondition.conjunction_code == 'atLeastOneTrue' && !precondition.negation)
         trueCount = 0
-        for child in precondition.preconditions
-          if (child.preconditions)
-            key = "precondition_#{child.id}"
-          else
-            key = child.reference
-          trueCount += 1 if rationale[key]
+        if precondition.preconditions?.length > 0
+          for child in precondition.preconditions
+            if (child.preconditions)
+              key = "precondition_#{child.id}"
+            else
+              key = child.reference
+            trueCount += 1 if rationale[key]
         orCounts["precondition_#{precondition.id}"] = trueCount
       _.extend(orCounts, @calculateOrCountsRecursive(rationale, precondition.preconditions))
     return orCounts


### PR DESCRIPTION
**Story:** https://www.pivotaltracker.com/story/show/62175964

For measures, such as 0031, sometimes the logic highlighting throws a TypeError for undefined length.

I updated the highlighting logic in result.js.coffee to check if there are existing preconditions to recurse on.
### Error on patient-select

![original_typeerror](https://f.cloud.github.com/assets/456952/1744720/606af98e-6422-11e3-91d2-e0230bbf58f7.png)
### Post bugfix

![post_bugfix](https://f.cloud.github.com/assets/456952/1744721/6331ef7e-6422-11e3-9a20-6179c3bc64dd.png)

I am unsure if this affects the highlighting logic in a specific way, so that is the primary feedback I am looking for, etc.
