### PR TITLE
Import patient results when importing a bundle

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,8 +15,8 @@ gem 'rubyzip', '< 1.0.0'
 gem 'quality-measure-engine', :git => 'https://github.com/pophealth/quality-measure-engine.git', :branch => 'mongoid_refactor'
 #gem 'quality-measure-engine', :path => '../quality-measure-engine'
 
-gem 'bonnie_bundler', :git => 'https://github.com/projecttacoma/bonnie_bundler.git', :branch => 'develop'
-# gem 'bonnie_bundler', :path => '../bonnie_bundler'
+# gem 'bonnie_bundler', :git => 'https://github.com/projecttacoma/bonnie_bundler.git', :branch => 'develop'
+gem 'bonnie_bundler', :path => '../bonnie_bundler'
 
 gem 'mongoid', '~> 3.1.0'
 

--- a/Gemfile
+++ b/Gemfile
@@ -15,8 +15,8 @@ gem 'rubyzip', '< 1.0.0'
 gem 'quality-measure-engine', :git => 'https://github.com/pophealth/quality-measure-engine.git', :branch => 'mongoid_refactor'
 #gem 'quality-measure-engine', :path => '../quality-measure-engine'
 
-# gem 'bonnie_bundler', :git => 'https://github.com/projecttacoma/bonnie_bundler.git', :branch => 'develop'
-gem 'bonnie_bundler', :path => '../bonnie_bundler'
+gem 'bonnie_bundler', :git => 'https://github.com/projecttacoma/bonnie_bundler.git', :branch => 'develop'
+# gem 'bonnie_bundler', :path => '../bonnie_bundler'
 
 gem 'mongoid', '~> 3.1.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,10 +42,8 @@ GIT
       rubyzip (= 0.9.9)
       uuid (~> 2.3.7)
 
-GIT
-  remote: https://github.com/projecttacoma/bonnie_bundler.git
-  revision: 551120895a058d01b4fa0cfdd53012c0f8980cd9
-  branch: develop
+PATH
+  remote: ../bonnie_bundler
   specs:
     bonnie_bundler (1.0.0)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,8 +42,10 @@ GIT
       rubyzip (= 0.9.9)
       uuid (~> 2.3.7)
 
-PATH
-  remote: ../bonnie_bundler
+GIT
+  remote: https://github.com/projecttacoma/bonnie_bundler.git
+  revision: e3c894ea9541914c57a671caa7ad5cfa5205e837
+  branch: develop
   specs:
     bonnie_bundler (1.0.0)
 

--- a/app/assets/javascripts/models/patient.js.coffee
+++ b/app/assets/javascripts/models/patient.js.coffee
@@ -92,7 +92,7 @@ class Thorax.Models.Patient extends Thorax.Model
     unless expectedValue
       expectedValue = new Thorax.Models.ExpectedValue measure_id: measure.get('hqmf_set_id'), population_index: population.index()
       @get('expected_values').add expectedValue
-    for populationCriteria in Thorax.Models.Measure.allPopulationCodes when population.has populationCriteria
+    for populationCriteria in Thorax.Models.Measure.allPopulationCodes when population.has populationCriteria and populationCriteria is not 'OBSERV'
       expectedValue.set populationCriteria, 0 unless expectedValue.has populationCriteria
     expectedValue
 

--- a/app/assets/javascripts/models/patient.js.coffee
+++ b/app/assets/javascripts/models/patient.js.coffee
@@ -92,7 +92,8 @@ class Thorax.Models.Patient extends Thorax.Model
     unless expectedValue
       expectedValue = new Thorax.Models.ExpectedValue measure_id: measure.get('hqmf_set_id'), population_index: population.index()
       @get('expected_values').add expectedValue
-    for populationCriteria in Thorax.Models.Measure.allPopulationCodes when population.has populationCriteria and populationCriteria is not 'OBSERV'
+    # We don't want to set a value for OBSERV, it should already exist or be created in the builder
+    for populationCriteria in Thorax.Models.Measure.allPopulationCodes when population.has(populationCriteria) and populationCriteria != 'OBSERV'
       expectedValue.set populationCriteria, 0 unless expectedValue.has populationCriteria
     expectedValue
 

--- a/app/assets/javascripts/models/population.js.coffee
+++ b/app/assets/javascripts/models/population.js.coffee
@@ -12,10 +12,14 @@ class Thorax.Models.Population extends Thorax.Model
       correct = 0
       result = population.calculate(patient)
       for criteria in validPopulations
-        if patient.has('expected_values') and result.has criteria
-          # FIXME: The ? below is a temporary work around; we want to refactor the models for results and expectations
-          if patient.getExpectedValue(population).get(criteria) is result.get(criteria)
+        if criteria is 'OBSERV' and patient.has('expected_values') and result.has('values')
+          if patient.getExpectedValue(population).get(criteria) is result.get('values')?[0]
             correct++
+        else 
+          if patient.has('expected_values') and result.has criteria
+          # FIXME: The ? below is a temporary work around; we want to refactor the models for results and expectations
+            if patient.getExpectedValue(population).get(criteria) is result.get(criteria)
+              correct++
       # only count it as a match if all the expectations are met
       if correct is validPopulations.length then matches++
     return matches
@@ -29,10 +33,14 @@ class Thorax.Models.Population extends Thorax.Model
     correct = 0
     result = population.calculate(patient)
     for criteria in validPopulations
-      if patient.has('expected_values') and result.has criteria
-        # FIXME: The ? below is a temporary work around; we want to refactor the models for results and expectations
-        if patient.getExpectedValue(population).get(criteria) is result.get(criteria)
+      if criteria is 'OBSERV' and patient.has('expected_values') and result.has('values')
+        if patient.getExpectedValue(population).get(criteria) is result.get('values')?[0]
           correct++
+      else 
+        if patient.has('expected_values') and result.has criteria
+        # FIXME: The ? below is a temporary work around; we want to refactor the models for results and expectations
+          if patient.getExpectedValue(population).get(criteria) is result.get(criteria)
+            correct++
     # only count it as a match if all the expectations are met
     return correct is validPopulations.length
 

--- a/app/assets/javascripts/views/measure_calculation_view.js.coffee
+++ b/app/assets/javascripts/views/measure_calculation_view.js.coffee
@@ -39,8 +39,6 @@ class Thorax.Views.MeasureCalculation extends Thorax.View
       resultValue = if p is 'OBSERV' then result.get('values')?[0] else result.get(p)
       ev = expectedValues?.get(p)
       combinedResults[p] = { name: p, expected: ev, result: resultValue }
-    console.log result
-    console.log combinedResults
     _(result.toJSON()).extend
       measure_id: @model.get('hqmf_set_id')
       populationTitle: popTitle ?= @population.get('sub_id')

--- a/app/assets/javascripts/views/measure_calculation_view.js.coffee
+++ b/app/assets/javascripts/views/measure_calculation_view.js.coffee
@@ -39,8 +39,8 @@ class Thorax.Views.MeasureCalculation extends Thorax.View
       resultValue = if p is 'OBSERV' then result.get('values')?[0] else result.get(p)
       ev = expectedValues?.get(p)
       combinedResults[p] = { name: p, expected: ev, result: resultValue }
-    # console.log result
-    # console.log combinedResults
+    console.log result
+    console.log combinedResults
     _(result.toJSON()).extend
       measure_id: @model.get('hqmf_set_id')
       populationTitle: popTitle ?= @population.get('sub_id')

--- a/lib/tasks/bonnie.rake
+++ b/lib/tasks/bonnie.rake
@@ -94,7 +94,7 @@ namespace :bonnie do
   end
 
   namespace :test do
-    desc 'Prune some measures, initiailize the patients, and expected values!'
+    desc 'Deletes all measures except for failing Cypress measures and CV measures; Use after running a bonnie:load:mitre_bundle rake task.'
     task :prune_db => :environment do
       puts "Reducing imported measures"
       some_measure_ids = Measure.in(measure_id: ['0710', '0389', 'ADE_TTR', '0497', '0495', '0496']).pluck('hqmf_set_id')

--- a/lib/tasks/bonnie.rake
+++ b/lib/tasks/bonnie.rake
@@ -93,6 +93,15 @@ namespace :bonnie do
     end
   end
 
+  namespace :test do
+    desc 'Prune some measures, initiailize the patients, and expected values!'
+    task :prune_db => :environment do
+      puts "Reducing imported measures"
+      some_measure_ids = Measure.in(measure_id: ['0710', '0389', 'ADE_TTR', '0497', '0495', '0496']).pluck('hqmf_set_id')
+      Measure.nin(hqmf_set_id: some_measure_ids).delete
+    end
+  end
+
   namespace :measures do
     desc 'Pre-generate measure JavaScript and cache in the DB'
     task :pregenerate_js => :environment do

--- a/lib/tasks/loading/bundle.rake
+++ b/lib/tasks/loading/bundle.rake
@@ -35,6 +35,12 @@ namespace :bonnie do
       user = User.by_email(email).first
       Measures::BundleLoader.load(args.file, user, measures_yml, load_from_hqmf)
 
+      Rake::Task['bonnie:patients:update_measure_ids'].invoke
+      Rake::Task['bonnie:users:associate_user_with_measures'].invoke(EMAIL: email)
+      Rake::Task['bonnie:users:associate_user_with_patients'].invoke(EMAIL: email)
+      Rake::Task["bonnie:patients:update_source_data_criteria"].invoke
+      Rake::Task['bonnie:measures:pregenerate_js'].invoke
+
     end
   end
 end


### PR DESCRIPTION
**Story:** https://www.pivotaltracker.com/story/show/62046488

Updated rake tasks and population criteria to support loaded results from a bundle import.

The values are set during the import within bonnie_bundler: https://github.com/projecttacoma/bonnie_bundler/commit/e3c894ea9541914c57a671caa7ad5cfa5205e837

Expected results when loading all EH and EP measures is every patient passing except the following:
- 0710: D,BH_Adult (NUMER) => expected: 1.0, actual: 0.0
- 0389: B,Cancer_Adult_Male (DENOM) => expected: 1.0, actual: 0.0
- 0389: B,Cancer_Adult_Male (NUMER) => expected: 1.0, actual: 0.0
- 0389: A,Cancer_Adult_Male (DENOM) => expected: 1.0, actual: 0.0
##### Actions
- <code>bundle install</code>
- <code>rake bonnie:load:mitre_bundle['/path/to/your/bundle-2.4.0.zip',bonnie@example.com]</code>
##### Screenshots
- Dashboard of all results from 2.4.0 bundle 
  - (https://f.cloud.github.com/assets/456952/1768433/6a276e38-6762-11e3-9ef3-962a5fa96c2a.png)
- CV measure with parsed value 
  - (https://f.cloud.github.com/assets/456952/1768456/e87bbe1a-6762-11e3-8c22-fa1a4344c779.png)
- CV measure with no value defined 
  - (https://f.cloud.github.com/assets/456952/1768458/eb419f48-6762-11e3-9f2e-f3af08f22983.png)
- Measure 0710 failure 
  - (https://f.cloud.github.com/assets/456952/1768463/ee3a2198-6762-11e3-8716-2750f95e5ebf.png)
- Measure 0389 failure A 
  - (https://f.cloud.github.com/assets/456952/1768465/ef98a942-6762-11e3-80d5-408ba7e997d3.png)
- Measure 0389 failure B 
  - (https://f.cloud.github.com/assets/456952/1768480/2adca1e8-6763-11e3-994f-0143a3bc5698.png)
