### PR TITLE
Data criteria

### DIFF
--- a/lib/measures/patient_builder.rb
+++ b/lib/measures/patient_builder.rb
@@ -61,7 +61,7 @@ module Measures
     # @return A coded entry with basic data defined by this data criteria.
     def self.derive_entry(data_criteria,value, value_sets)
  
-      return nil if data_criteria['type'] == 'characteristic' && data_criteria['patient_api_function'].nil? 
+      return nil if data_criteria.nil? || (data_criteria['type'] == 'characteristic' && data_criteria['patient_api_function'].nil?)
       time = derive_time_range(value)
       entry_type = HQMF::Generator.classify_entry(data_criteria['patient_api_function'].to_sym)
       entry = entry_type.classify.constantize.new

--- a/lib/tasks/bonnie.rake
+++ b/lib/tasks/bonnie.rake
@@ -125,6 +125,7 @@ namespace :bonnie do
           measures.each do |measure|
             measure_data_criteria = measure.source_data_criteria[patient_data_criteria['id']]
             if  measure_data_criteria && measure_data_criteria['code_list_id'] == patient_data_criteria['oid']
+              patient_data_criteria['code_list_id'] = patient_data_criteria['oid']
               patient_data_criteria['title'] = measure_data_criteria['title']
               patient_data_criteria['description'] = measure_data_criteria['description']
               patient_data_criteria['negation'] = patient_data_criteria['negation'] == "true"

--- a/test/functional/patients_controller_test.rb
+++ b/test/functional/patients_controller_test.rb
@@ -24,7 +24,7 @@ include Devise::TestHelpers
      'race'=> 'B',
      'start_date'=>'2012-01-01',
      'end_date'=>'2012-12-31',
-     'source_data_criteria' => [{"id"=>"EncounterPerformedPsychVisitDiagnosticEvaluation","start_date"=>1333206000000,"end_date"=>1333206000000,"value"=>[],"negation"=>"","negation_code_list_id"=>nil,"field_values"=>{},"oid"=>"2.16.840.1.113883.3.526.3.1492"}],
+     'source_data_criteria' => [{"id"=>"EncounterPerformedPsychVisitDiagnosticEvaluation", "status"=>"performed", "definition"=>"encounter", "start_date"=>1333206000000,"end_date"=>1333206000000,"value"=>[],"negation"=>"","negation_code_list_id"=>nil,"field_values"=>{},"code_list_id"=>"2.16.840.1.113883.3.526.3.1492"}],
      'measure_id' => @measure.hqmf_set_id}
 
     post :create, @patient
@@ -67,7 +67,7 @@ include Devise::TestHelpers
      'race'=> 'B',
      'start_date'=>'2012-01-01',
      'end_date'=>'2012-12-31',
-     'source_data_criteria' => [{"id"=>"EncounterPerformedPsychVisitDiagnosticEvaluation","start_date"=>1333206000000,"end_date"=>1333206000000,"value"=>[],"negation"=>"","negation_code_list_id"=>nil,"field_values"=>{},"oid"=>"2.16.840.1.113883.3.526.3.1492"}],
+     'source_data_criteria' => [{"id"=>"EncounterPerformedPsychVisitDiagnosticEvaluation","status"=>"performed", "definition"=>"encounter", "start_date"=>1333206000000,"end_date"=>1333206000000,"value"=>[],"negation"=>"","negation_code_list_id"=>nil,"field_values"=>{},"code_list_id"=>"2.16.840.1.113883.3.526.3.1492"}],
      'measure_id' => @measure.hqmf_set_id}
 
     post :update,@patient
@@ -102,7 +102,7 @@ include Devise::TestHelpers
      'race'=> 'B',
      'start_date'=>'2012-01-01',
      'end_date'=>'2012-12-31',
-     'source_data_criteria' => [{"id"=>"EncounterPerformedPsychVisitDiagnosticEvaluation","start_date"=>1333206000000,"end_date"=>1333206000000,"value"=>[],"negation"=>"","negation_code_list_id"=>nil,"field_values"=>{},"oid"=>"2.16.840.1.113883.3.526.3.1492"}],
+     'source_data_criteria' => [{"id"=>"EncounterPerformedPsychVisitDiagnosticEvaluation","status"=>"performed", "definition"=>"encounter", "start_date"=>1333206000000,"end_date"=>1333206000000,"value"=>[],"negation"=>"","negation_code_list_id"=>nil,"field_values"=>{},"code_list_id"=>"2.16.840.1.113883.3.526.3.1492"}],
      'measure_id' => @measure.hqmf_set_id}
 
     post :materialize, @patient

--- a/test/unit/patient_builder_test.rb
+++ b/test/unit/patient_builder_test.rb
@@ -7,28 +7,28 @@ class PatientBuilderTest < ActiveSupport::TestCase
     @user = User.by_email('bonnie@example.com').first
     associate_user_with_measures(@user,Measure.all)
     @measure_ids = ["E35791DF-5B25-41BB-B260-673337BC44A8"] # hqmf_set_id
-    @data_criteria = Measures::PatientBuilder.get_data_criteria(@measure_ids, @user)
-    @valuesets = {"2.16.840.1.113883.3.526.3.1492"=>{"oid" => "2.16.840.1.113883.3.526.3.1492", "concepts"=>[{"code_system_name" => "SNOMED", "code" =>"99201"},
+    @data_criteria = HQMF::DataCriteria.get_settings_for_definition('diagnosis','active')
+    @valuesets = {"2.16.840.1.113883.3.526.3.1492"=>HealthDataStandards::SVS::ValueSet.new({"oid" => "2.16.840.1.113883.3.526.3.1492", "concepts"=>[{"code_system_name" => "SNOMED", "code" =>"99201"},
                                                                             {"code_system_name" => "SNOMED", "code" =>"99202"},
                                                                             {"code_system_name" => "CPT", "code" =>"CPT1"},
-                                                                            {"code_system_name" => "CPT", "code" =>"CPT2"}]},
+                                                                            {"code_system_name" => "CPT", "code" =>"CPT2"}]}),
                   
-                  "2.16.840.1.113883.3.464.1003.102.12.1011"=>{"oid" => "2.16.840.1.113883.3.464.1003.102.12.1011" , "concepts"=>[{"code_system_name" => "LOINC", "code" =>"LOINC_1"},
+                  "2.16.840.1.113883.3.464.1003.102.12.1011"=>HealthDataStandards::SVS::ValueSet.new({"oid" => "2.16.840.1.113883.3.464.1003.102.12.1011" , "concepts"=>[{"code_system_name" => "LOINC", "code" =>"LOINC_1"},
                                                                                       {"code_system_name" => "LOINC", "code" =>"LOINC_2"},
                                                                                       {"code_system_name" => "AOCS", "code" =>"A_1"},
-                                                                                      {"code_system_name" => "AOCS", "code" =>"A_2"}]},
+                                                                                      {"code_system_name" => "AOCS", "code" =>"A_2"}]}),
                   
-                  "2.16.840.1.113883.3.464.1003.106.12.1005"=>{"oid" => "2.16.840.1.113883.3.464.1003.106.12.1005", "concepts"=>[{"code_system_name" => "SNOMED", "code" =>"999999"},
-                                                                                     {"code_system_name" => "SNOMED", "code" =>"222222"}]},
+                  "2.16.840.1.113883.3.464.1003.106.12.1005"=>HealthDataStandards::SVS::ValueSet.new({"oid" => "2.16.840.1.113883.3.464.1003.106.12.1005", "concepts"=>[{"code_system_name" => "SNOMED", "code" =>"999999"},
+                                                                                     {"code_system_name" => "SNOMED", "code" =>"222222"}]}),
                   
-                  "2.16.840.1.113883.3.526.3.1139"=>{"oid" => "2.16.840.1.113883.3.526.3.1139" , "concepts"=>[{"code_system_name" => "CPT", "code" =>"CHACHA1"},
+                  "2.16.840.1.113883.3.526.3.1139"=>HealthDataStandards::SVS::ValueSet.new({"oid" => "2.16.840.1.113883.3.526.3.1139" , "concepts"=>[{"code_system_name" => "CPT", "code" =>"CHACHA1"},
                                                                             {"code_system_name" => "CPT", "code" =>"CHACHA2"},
                                                                             {"code_system_name" => "SNOMED", "code" =>"SNO1"},
-                                                                            {"code_system_name" => "SNOMED", "code" =>"SNO2"}]},
-                   "2.16.840.1.113883.3.526.3.1259"=>{"oid" => "2.16.840.1.113883.3.526.3.1259" , "concepts"=>[{"code_system_name" => "CPT", "code" =>"CHACHA1"},
+                                                                            {"code_system_name" => "SNOMED", "code" =>"SNO2"}]}),
+                   "2.16.840.1.113883.3.526.3.1259"=>HealthDataStandards::SVS::ValueSet.new({"oid" => "2.16.840.1.113883.3.526.3.1259" , "concepts"=>[{"code_system_name" => "CPT", "code" =>"CHACHA1"},
                                                                             {"code_system_name" => "CPT", "code" =>"CHACHA2"},
                                                                             {"code_system_name" => "SNOMED", "code" =>"SNO1"},
-                                                                            {"code_system_name" => "SNOMED", "code" =>"SNO2"}]}                                                          
+                                                                            {"code_system_name" => "SNOMED", "code" =>"SNO2"}]})                                                      
                   } # todo need to fake some of these out
 
     @coded_source_data_critria = {
@@ -40,7 +40,7 @@ class PatientBuilderTest < ActiveSupport::TestCase
           "negation_code_list_id"=>"2.16.840.1.113883.3.464.1003.106.12.1005",
           "negation_code" => {"code_system" => "SNOMED", "code" =>"222222"},
           "field_values"=>{"ORDINAL"=>{"type"=>"CD","code_list_id"=>"2.16.840.1.113883.3.526.3.1139","title"=>"ACE inhibitor or ARB", "code" =>{"code_system"=>"CPT", "code"=>"CHACHA2", "title"=>nil}}},
-          "oid"=> "2.16.840.1.113883.3.526.3.1492",
+          "code_list_id"=> "2.16.840.1.113883.3.526.3.1492",
           "codes"=> [{"CPT" =>["CPT1"]}]
         }
 
@@ -52,26 +52,25 @@ class PatientBuilderTest < ActiveSupport::TestCase
           "negation"=>"true",
           "negation_code_list_id"=>"2.16.840.1.113883.3.464.1003.106.12.1005",
           "field_values"=>{"ORDINAL"=>{"type"=>"CD","code_list_id"=>"2.16.840.1.113883.3.526.3.1139","title"=>"ACE inhibitor or ARB"}},
-          "oid"=> "2.16.840.1.113883.3.526.3.1492"
+          "code_list_id"=> "2.16.840.1.113883.3.526.3.1492"
           }    
   end
 
 
   test "derive entry" do
-    data_criteria = HQMF::DataCriteria.from_json("DiagnosisActiveLimitedLifeExpectancy", @data_criteria["DiagnosisActiveLimitedLifeExpectancy"])
-    entry = Measures::PatientBuilder.derive_entry(data_criteria,@un_coded_source_data_critria, @valuesets)
+    entry = Measures::PatientBuilder.derive_entry(@data_criteria,@un_coded_source_data_critria, @valuesets)
     assert entry, "Should have created an entry with un coded data"
     assert_equal Condition, entry.class, "should have created and Encounter object"
     
-    entry = Measures::PatientBuilder.derive_entry(data_criteria,@coded_source_data_critria, @valuesets)
+    entry = Measures::PatientBuilder.derive_entry(@data_criteria,@coded_source_data_critria, @valuesets)
     assert entry, "Should have created an entry with  coded data"
     assert_equal Condition, entry.class, "should have created and Encounter object"
     assert_equal @coded_source_data_critria["codes"], entry.codes
   end
 
   test "derive negation" do
-    data_criteria = HQMF::DataCriteria.from_json("DiagnosisActiveLimitedLifeExpectancy", @data_criteria["DiagnosisActiveLimitedLifeExpectancy"])
-    entry = Measures::PatientBuilder.derive_entry(data_criteria,@un_coded_source_data_critria, @valuesets)
+    
+    entry = Measures::PatientBuilder.derive_entry(@data_criteria,@un_coded_source_data_critria, @valuesets)
     assert  !entry.negation_ind, "negation should be false"
     assert entry.negation_reason.nil?, "Negation should have no codes"
 
@@ -80,7 +79,7 @@ class PatientBuilderTest < ActiveSupport::TestCase
     code ={"code_system" => "SNOMED" , "code" =>"999999"}
     assert_equal code, entry.negation_reason, "Negation codes should have been auto selected"
 
-    entry = Measures::PatientBuilder.derive_entry(data_criteria,@coded_source_data_critria, @valuesets)
+    entry = Measures::PatientBuilder.derive_entry(@data_criteria,@coded_source_data_critria, @valuesets)
     
     Measures::PatientBuilder.derive_negation(entry,@coded_source_data_critria,@valuesets)
     assert entry.negation_ind, "negation should be true"
@@ -93,8 +92,7 @@ class PatientBuilderTest < ActiveSupport::TestCase
 
   test "derive values" do
 
-    data_criteria = HQMF::DataCriteria.from_json("DiagnosisActiveLimitedLifeExpectancy", @data_criteria["DiagnosisActiveLimitedLifeExpectancy"])
-    entry = Measures::PatientBuilder.derive_entry(data_criteria,@un_coded_source_data_critria,@valuesets)
+    entry = Measures::PatientBuilder.derive_entry(@data_criteria,@un_coded_source_data_critria,@valuesets)
     
     assert entry.values.nil? || entry.values.empty? , "There should be no values"
 
@@ -103,7 +101,7 @@ class PatientBuilderTest < ActiveSupport::TestCase
     assert_equal expected_length, entry.values.length, "Should have created #{expected_length} values"
     assert_equal({"LOINC"=>["LOINC_1"], "AOCS"=>["A_1"]}, entry.values[0].codes ) 
 
-    entry = Measures::PatientBuilder.derive_entry(data_criteria,@coded_source_data_critria, @valuesets)
+    entry = Measures::PatientBuilder.derive_entry(@data_criteria,@coded_source_data_critria, @valuesets)
     assert entry.values.nil? || entry.values.empty? , "There should be no values"
     Measures::PatientBuilder.derive_values(entry,@coded_source_data_critria["value"],@valuesets)
     expected_length = @un_coded_source_data_critria["value"].length
@@ -112,14 +110,13 @@ class PatientBuilderTest < ActiveSupport::TestCase
   end
 
   test "derive field"  do 
-    data_criteria = HQMF::DataCriteria.from_json("DiagnosisActiveLimitedLifeExpectancy", @data_criteria["DiagnosisActiveLimitedLifeExpectancy"])
-    entry = Measures::PatientBuilder.derive_entry(data_criteria,@un_coded_source_data_critria, @valuesets)
+    entry = Measures::PatientBuilder.derive_entry(@data_criteria,@un_coded_source_data_critria, @valuesets)
     assert entry.values.nil? || entry.values.empty? , "There should be no values"
     Measures::PatientBuilder.derive_field_values(entry,@un_coded_source_data_critria["field_values"],@valuesets)
 
     assert !entry.ordinality.nil?, "Should have created an ordinal filed value"
     
-    entry = Measures::PatientBuilder.derive_entry(data_criteria,@coded_source_data_critria, @valuesets)
+    entry = Measures::PatientBuilder.derive_entry(@data_criteria,@coded_source_data_critria, @valuesets)
     assert entry.values.nil? || entry.values.empty? , "There should be no values"
     Measures::PatientBuilder.derive_field_values(entry,@coded_source_data_critria["field_values"],@valuesets)
     assert_equal({"code_system"=>"CPT", "code"=>"CHACHA2", "title"=>nil}, entry.ordinality, "Should have created an ordinal filed value")

--- a/test/unit/patient_builder_test.rb
+++ b/test/unit/patient_builder_test.rb
@@ -88,6 +88,26 @@ class PatientBuilderTest < ActiveSupport::TestCase
 
   test "derive time range"  do 
     time_criteria = { "start_date" => 1333206000000, "end_date" => 1333206000000 }
+    range = Measures::PatientBuilder.derive_time_range(time_criteria)
+    assert range.low.nil? == false
+    assert range.high.nil? == false
+
+    time_criteria = { "start_date" => nil, "end_date" => 1333206000000 }
+    range = Measures::PatientBuilder.derive_time_range(time_criteria)
+    assert range.low.nil?
+    assert range.high.nil? == false
+
+
+    time_criteria = { "start_date" => 1333206000000, "end_date" => nil }
+    range = Measures::PatientBuilder.derive_time_range(time_criteria)
+    assert range.low.nil? == false
+    assert range.high.nil? 
+
+    time_criteria = { "start_date" => nil, "end_date" => nil }
+    range = Measures::PatientBuilder.derive_time_range(time_criteria)
+    assert range.low.nil?
+    assert range.high.nil?
+
   end
 
   test "derive values" do


### PR DESCRIPTION
Updating materialization to remove dependency on the Measure data_criteria.  This will need coordination with the client side code to return the valueset oid in the code_list_id field instead of the oid field.
