### PR TITLE
replace oid with code_list_id

### DIFF
--- a/app/assets/javascripts/models/data_criteria.js.coffee
+++ b/app/assets/javascripts/models/data_criteria.js.coffee
@@ -1,9 +1,8 @@
 class Thorax.Models.MeasureDataCriteria extends Thorax.Model
   toPatientDataCriteria: ->
     # FIXME: Temporary approach
-    attr = _(@pick('negation', 'definition', 'status', 'title', 'description', 'type')).extend
+    attr = _(@pick('negation', 'definition', 'status', 'title', 'description', 'code_list_id', 'type')).extend
              id: @get('source_data_criteria')
-             oid: @get('code_list_id')
              start_date: new Date().getTime()
              end_date: new Date().getTime()
              value: new Thorax.Collection()


### PR DESCRIPTION
This updates the patient data criteria to reference the `code_list_id` instead of `oid`.
