### PR TITLE
Total Coverage on Measure View

### DIFF
--- a/app/assets/javascripts/models/coverage.js.coffee
+++ b/app/assets/javascripts/models/coverage.js.coffee
@@ -1,0 +1,28 @@
+class Thorax.Model.Coverage extends Thorax.Model
+  initialize: (attrs, options) ->
+    @results = options.results
+    @measure = options.measure
+    @listenTo @results, 'change add reset destroy remove', @update
+    @update()
+  update: ->
+    completedResults = @results.select (d) -> d.isPopulated()
+    dataCriteria = @measure.get 'data_criteria'
+    rationaleCoverage = {}
+    for result in completedResults
+      rationale = result.get 'rationale'
+      for key, value of dataCriteria
+        criteriaId = value['key']
+        if !!rationale[criteriaId]
+          rationaleCoverage[criteriaId] = true
+        else
+          unless !!rationaleCoverage[criteriaId]
+            rationaleCoverage[criteriaId] = false
+
+    matches = 0
+    mismatches = 0
+    for criteriaId, match of rationaleCoverage
+      if match then matches++ else mismatches++
+    unless matches == mismatches == 0
+      @set coverage: ( matches * 100 / ( matches + mismatches )).toFixed()
+    else
+      @set coverage: 0

--- a/app/assets/javascripts/models/difference.js.coffee
+++ b/app/assets/javascripts/models/difference.js.coffee
@@ -32,3 +32,4 @@ class Thorax.Collections.Differences extends Thorax.Collection
              else
                'fail'
     @summary.set total: @length, matching: successful.length, percent: percent, done: done, status: status
+    if done then @trigger 'differences:done', this

--- a/app/assets/javascripts/models/difference.js.coffee
+++ b/app/assets/javascripts/models/difference.js.coffee
@@ -32,4 +32,3 @@ class Thorax.Collections.Differences extends Thorax.Collection
              else
                'fail'
     @summary.set total: @length, matching: successful.length, percent: percent, done: done, status: status
-    if done then @trigger 'differences:done', this

--- a/app/assets/javascripts/models/population.js.coffee
+++ b/app/assets/javascripts/models/population.js.coffee
@@ -23,6 +23,9 @@ class Thorax.Models.Population extends Thorax.Model
     differences.reset @measure().get('patients').map (patient) => @differenceFromExpected(patient)
     differences
 
+  coverage: ->
+    new Thorax.Model.Coverage({}, results: @calculationResults(), measure: @measure())
+
 class Thorax.Collections.Population extends Thorax.Collection
   model: Thorax.Models.Population
   initialize: (models, options) -> @parent = options?.parent

--- a/app/assets/javascripts/templates/measure/coverage.hbs
+++ b/app/assets/javascripts/templates/measure/coverage.hbs
@@ -1,0 +1,2 @@
+<h5>{{#ifCond coverage '==' undefined}}Computing Total coverage...{{/ifCond}}
+{{#ifCond coverage '!=' undefined}}Total Coverage: {{coverage}}%{{/ifCond}}</h5>

--- a/app/assets/javascripts/templates/population_calculation.hbs
+++ b/app/assets/javascripts/templates/population_calculation.hbs
@@ -13,7 +13,8 @@
         <i class="fa fa-plus"></i>
       </a>
     </div>
-  </div>
+  </div>  
+  {{view "MeasureCoverageView" model=totalCoverage}}
   <br>
   {{#collection differences tag="div" class="panel panel-default" item-context=differenceContext}}
     <div class="panel-heading">

--- a/app/assets/javascripts/views/measures_view.js.coffee
+++ b/app/assets/javascripts/views/measures_view.js.coffee
@@ -49,3 +49,6 @@ class Thorax.Views.MeasureStatusView extends Thorax.View
 
 class Thorax.Views.MeasureFractionView extends Thorax.View
   template: JST['measure/fraction']
+
+class Thorax.Views.MeasureCoverageView extends Thorax.View
+  template: JST['measure/coverage']

--- a/app/assets/javascripts/views/population_calculation_view.js.coffee
+++ b/app/assets/javascripts/views/population_calculation_view.js.coffee
@@ -9,9 +9,7 @@ class Thorax.Views.PopulationCalculation extends Thorax.View
     @differences.sort()
     # Make sure the sort order updates as results come in
     @differences.on 'change', @differences.sort, @differences
-    @totalCoverage = new Thorax.Model
-    @listenTo @differences, 'differences:done', (differences) -> @computeTotalCoverage(differences.map (d) -> d.result)
-    if @differences.summary.get('done') then @computeTotalCoverage(@differences.map (d) -> d.result)
+    @totalCoverage = @model.coverage()
 
   context: ->
     _(super).extend measure_id: @measure.get('hqmf_set_id')
@@ -67,25 +65,4 @@ class Thorax.Views.PopulationCalculation extends Thorax.View
       @$('.toggle-result').hide()
       @$(".toggle-result-#{result.patient.id}").show()
       @trigger 'rationale:show', result
-
-  computeTotalCoverage: (results) ->
-    dataCriteria = @measure.get 'data_criteria'
-    rationaleCoverage = {}
-    for result in results
-      rationale = result.get 'rationale'
-      for key, value of dataCriteria
-        criteriaId = value['key']
-        if !!rationale[criteriaId]
-          rationaleCoverage[criteriaId] = true
-        else
-          unless !!rationaleCoverage[criteriaId]
-            rationaleCoverage[criteriaId] = false
-
-    matches = 0
-    mismatches = 0
-    for criteriaId, match of rationaleCoverage
-      if match then matches++ else mismatches++
-    unless matches == mismatches == 0
-      @totalCoverage.set coverage: ( matches * 100 / ( matches + mismatches )).toFixed()
-    else
-      @totalCoverage.set coverage: 0
+      

--- a/app/assets/javascripts/views/population_calculation_view.js.coffee
+++ b/app/assets/javascripts/views/population_calculation_view.js.coffee
@@ -9,6 +9,9 @@ class Thorax.Views.PopulationCalculation extends Thorax.View
     @differences.sort()
     # Make sure the sort order updates as results come in
     @differences.on 'change', @differences.sort, @differences
+    @totalCoverage = new Thorax.Model
+    @listenTo @differences, 'differences:done', (differences) -> @computeTotalCoverage(differences.map (d) -> d.result)
+    if @differences.summary.get('done') then @computeTotalCoverage(@differences.map (d) -> d.result)
 
   context: ->
     _(super).extend measure_id: @measure.get('hqmf_set_id')
@@ -64,3 +67,25 @@ class Thorax.Views.PopulationCalculation extends Thorax.View
       @$('.toggle-result').hide()
       @$(".toggle-result-#{result.patient.id}").show()
       @trigger 'rationale:show', result
+
+  computeTotalCoverage: (results) ->
+    dataCriteria = @measure.get 'data_criteria'
+    rationaleCoverage = {}
+    for result in results
+      rationale = result.get 'rationale'
+      for key, value of dataCriteria
+        criteriaId = value['key']
+        if !!rationale[criteriaId]
+          rationaleCoverage[criteriaId] = true
+        else
+          unless !!rationaleCoverage[criteriaId]
+            rationaleCoverage[criteriaId] = false
+
+    matches = 0
+    mismatches = 0
+    for criteriaId, match of rationaleCoverage
+      if match then matches++ else mismatches++
+    unless matches == mismatches == 0
+      @totalCoverage.set coverage: ( matches * 100 / ( matches + mismatches )).toFixed()
+    else
+      @totalCoverage.set coverage: 0

--- a/lib/tasks/bonnie.rake
+++ b/lib/tasks/bonnie.rake
@@ -129,10 +129,13 @@ namespace :bonnie do
               patient_data_criteria['title'] = measure_data_criteria['title']
               patient_data_criteria['description'] = measure_data_criteria['description']
               patient_data_criteria['negation'] = patient_data_criteria['negation'] == "true"
-              patient_data_criteria['field_values'].keys.each do |key|
-                field_value = patient_data_criteria['field_values'][key]
-                if (field_value['type'] == 'TS')
-                  field_value['value'] = Time.strptime(field_value['value'],"%m/%d/%Y %H:%M").to_i*1000 rescue field_value['value']
+              # FIXME Not sure why field_values has no keys now, did the Cypress patient set change?
+              unless patient_data_criteria['field_values'].blank?
+                patient_data_criteria['field_values'].keys.each do |key|
+                  field_value = patient_data_criteria['field_values'][key]
+                  if (field_value['type'] == 'TS')
+                    field_value['value'] = Time.strptime(field_value['value'],"%m/%d/%Y %H:%M").to_i*1000 rescue field_value['value']
+                  end
                 end
               end if patient_data_criteria['field_values']
             end


### PR DESCRIPTION
Story: https://www.pivotaltracker.com/story/show/61762256

Added simple total coverage percentage in aggregate results section of the individual measure view.

Current styling is a simple header-5 with a percent, dropped below the aggregate results views.

Current computation:
- iterate over the data criteria associated with the given measure
- store all of its keys in the <code>rationaleCoverage</code> hash
- iterate over each results' <code>rationale</code> hash
  - for each entry in the <code>rationale</code> hash, if it is truthy, then record a true value in the <code>rationaleCoverage</code> hash, otherwise if it is falsey and has not been marked true yet, then mark it as false
- the percentage is a simple computation of # of true values in the <code>rationaleCoverage</code> hash over the total number of values, rounded to a whole percentage
