### PR TITLE
Fixed expected value matching for CV measures

### DIFF
--- a/app/assets/javascripts/models/expected_value.js.coffee
+++ b/app/assets/javascripts/models/expected_value.js.coffee
@@ -5,7 +5,8 @@ class Thorax.Models.ExpectedValue extends Thorax.Model
 
   isMatch: (result) ->
     for popCrit in @populationCriteria()
-      return false unless @get(popCrit) == result.get(popCrit)
+      if popCrit is 'OBSERV' then return false unless @get(popCrit) == result.get('values')?[0]
+      else return false unless @get(popCrit) == result.get(popCrit)
     return true
 
   comparison: (result) ->


### PR DESCRIPTION
Simple check for OBSERV population, done correctly in EV.comparison() but needs to be done in EV.isMatch() as well.
