### PR TITLE
fix value and negation titles

### DIFF
--- a/app/assets/javascripts/templates/logic/data_criteria.hbs
+++ b/app/assets/javascripts/templates/logic/data_criteria.hbs
@@ -1,6 +1,6 @@
 <span class="{{dataCriteria.key}} rationale_target">
 {{#each dataCriteria.subset_operators}}
-  {{view "SubsetOperatorLogic" subsetOperator=this tag="span" sourceDataCriteria=../sourceDataCriteria}}
+  {{view "SubsetOperatorLogic" subsetOperator=this tag="span"}}
 {{/each}}
 {{#ifCond dataCriteria.type '==' 'derived'}}
   {{#if dataCriteria.children_criteria}}
@@ -8,7 +8,7 @@
       {{#each dataCriteria.children_criteria}}
         <li>
           <span class="{{../dataCriteria.key}} rationale_target">{{translate_operator ../dataCriteria.derivation_operator}} : </span>
-          {{view "DataCriteriaLogic" reference=this dataCriteriaMap=../dataCriteriaMap sourceDataCriteria=../sourceDataCriteria tag="span"}}
+          {{view "DataCriteriaLogic" reference=this measure=../measure tag="span"}}
         </li>
       {{/each}}
     </ul>
@@ -17,20 +17,20 @@
   {{#if dataCriteria.specific_occurrence}}Occurrence {{dataCriteria.specific_occurrence}}: {{/if}}{{dataCriteria.description}}
   {{#if dataCriteria.value}}
     {{#ifCond dataCriteria.type '!=' 'characteristic' }}
-      (result{{view "ValueLogic" value=dataCriteria.value tag="span"}})
+      (result{{view "ValueLogic" value=dataCriteria.value measure=../measure tag="span"}})
     {{/ifCond}}
   {{/if}}
   {{#if dataCriteria.field_values}}
     ({{#each dataCriteria.field_values}}
-      {{key_title}}{{#ifCond type '!=' 'ANYNonNull'}}{{view "ValueLogic" value=this tag="span"}} {{/ifCond}}
+      {{key_title}}{{#ifCond type '!=' 'ANYNonNull'}}{{view "ValueLogic" value=this measure=../../measure tag="span"}} {{/ifCond}}
     {{/each}})
   {{/if}}
   {{#if dataCriteria.negation}}
-    {{translate_source_data dataCriteria.negation_code_list_id}}
+    (Not Done: {{translate_oid dataCriteria.negation_code_list_id}})
   {{/if}}
   {{#if dataCriteria.temporal_references}}
     {{#each dataCriteria.temporal_references}}
-      {{view "TemporalReferenceLogic" temporalReference=this dataCriteriaMap=../dataCriteriaMap tag="span"}}
+      {{view "TemporalReferenceLogic" temporalReference=this measure=../measure tag="span"}}
     {{/each}}
   {{/if}}
 {{/ifCond}}

--- a/app/assets/javascripts/templates/logic/logic.hbs
+++ b/app/assets/javascripts/templates/logic/logic.hbs
@@ -1,5 +1,5 @@
 <div class="measure-viz rationale">
   {{#each submeasurePopulations}}
-    {{view "PopulationCriteriaLogic" population=this dataCriteriaMap=../dataCriteriaMap sourceDataCriteria=../sourceDataCriteria}}
+    {{view "PopulationCriteriaLogic" population=this measure=../measure}}
   {{/each}}
 </div>

--- a/app/assets/javascripts/templates/logic/population_criteria.hbs
+++ b/app/assets/javascripts/templates/logic/population_criteria.hbs
@@ -6,12 +6,12 @@
     {{#if rootPreconditon}}
       {{#if rootPreconditon.preconditions }}
        {{#each rootPreconditon.preconditions}}
-        {{view "PreconditionLogic" precondition=this parentPrecondition=../rootPreconditon dataCriteriaMap=../dataCriteriaMap sourceDataCriteria=../sourceDataCriteria}}
+        {{view "PreconditionLogic" precondition=this parentPrecondition=../rootPreconditon measure=../measure}}
       {{/each}}
       {{else}}
         <ul>
           <li>
-            {{#if aggregator}}{{translate_aggregator aggregator}}: {{/if}} {{view "DataCriteriaLogic" reference=rootPreconditon.reference dataCriteriaMap=../dataCriteriaMap sourceDataCriteria=../sourceDataCriteria tag="span"}}
+            {{#if aggregator}}{{translate_aggregator aggregator}}: {{/if}} {{view "DataCriteriaLogic" reference=rootPreconditon.reference measure=../measure tag="span"}}
           </li>
         </ul>
       {{/if}}

--- a/app/assets/javascripts/templates/logic/precondition.hbs
+++ b/app/assets/javascripts/templates/logic/precondition.hbs
@@ -6,10 +6,10 @@
     </span>
     {{#if precondition.preconditions }}
         {{#each precondition.preconditions}}
-          {{view "PreconditionLogic" precondition=this parentPrecondition=../precondition dataCriteriaMap=../dataCriteriaMap sourceDataCriteria=../sourceDataCriteria}}
+          {{view "PreconditionLogic" precondition=this parentPrecondition=../precondition measure=../measure}}
         {{/each}}
     {{else}}
-      {{view "DataCriteriaLogic" reference=precondition.reference dataCriteriaMap=../dataCriteriaMap sourceDataCriteria=../sourceDataCriteria negatedParent=../parentPrecondition.negation tag="span"}}
+      {{view "DataCriteriaLogic" reference=precondition.reference measure=../measure negatedParent=../parentPrecondition.negation tag="span"}}
     {{/if}}
   </li>
 </ul>

--- a/app/assets/javascripts/templates/logic/temporal_reference.hbs
+++ b/app/assets/javascripts/templates/logic/temporal_reference.hbs
@@ -5,6 +5,6 @@
 {{#ifCond temporalReference.reference '==' 'MeasurePeriod'}}
   "Measurement Period"
 {{else}}
-  {{view "DataCriteriaLogic" reference=temporalReference.reference dataCriteriaMap=../dataCriteriaMap tag="span"}}
+  {{view "DataCriteriaLogic" reference=temporalReference.reference measure=../measure tag="span"}}
 {{/ifCond}}
  

--- a/app/assets/javascripts/templates/logic/value.hbs
+++ b/app/assets/javascripts/templates/logic/value.hbs
@@ -20,7 +20,7 @@
       {{/ifCond}}
     {{else}}
       {{#ifCond value.type '==' 'CD'}}
-        : {{value.title}}
+        : {{translate_oid value.code_list_id}}
       {{/ifCond}}
     {{/if}}
   {{/if}}

--- a/app/assets/javascripts/views/logic/data_criteria_logic_view.js.coffee
+++ b/app/assets/javascripts/views/logic/data_criteria_logic_view.js.coffee
@@ -6,7 +6,7 @@ class Thorax.Views.DataCriteriaLogic extends Thorax.View
     'UNION':'OR'
 
   initialize: ->
-    @dataCriteria = @dataCriteriaMap[@reference]
+    @dataCriteria = @measure.get('data_criteria')[@reference]
     # we need to do this because the view helper doesn't seem to be available in an #each.
     if @dataCriteria.field_values
       for key, field of @dataCriteria.field_values
@@ -23,5 +23,5 @@ class Thorax.Views.DataCriteriaLogic extends Thorax.View
   translate_field: (field_key) =>
     Thorax.Models.Measure.logicFields[field_key]?['title']
 
-  translate_source_data: (oid) =>
-    @sourceDataCriteria.findWhere(code_list_id: oid)?.get('description')
+  translate_oid: (oid) =>
+    @measure.get('value_sets').findWhere({oid: oid})?.get('display_name')

--- a/app/assets/javascripts/views/logic/population_logic_view.js.coffee
+++ b/app/assets/javascripts/views/logic/population_logic_view.js.coffee
@@ -22,8 +22,7 @@ class Thorax.Views.PopulationLogic extends Thorax.View
   context: ->
     measure = @model.collection.parent
     _(super).extend
-      dataCriteriaMap: measure.get 'data_criteria'
-      sourceDataCriteria: measure.get 'source_data_criteria'
+      measure: measure
 
   showRationale: (result) ->
     # Only show the rationale once the result is populated

--- a/app/assets/javascripts/views/logic/value_logic_view.js.coffee
+++ b/app/assets/javascripts/views/logic/value_logic_view.js.coffee
@@ -20,3 +20,6 @@ class Thorax.Views.ValueLogic extends Thorax.View
       @unit_map[unit] + (if value > 1 then 's' else '')
     else
       unit
+
+  translate_oid: (oid) =>
+    @measure.get('value_sets').findWhere({oid: oid})?.get('display_name')


### PR DESCRIPTION
the latest MAT HQMF exports no longer give us reasonable titles for coded values on data criteria, field values, or negations.  You end up with fields like (ordinal: ordinal).  This gets the titles off of the value set via the oid rather than from the measure structure
