### PR TITLE
Fixed CV measures' expected values

### DIFF
--- a/app/assets/javascripts/models/measure.js.coffee
+++ b/app/assets/javascripts/models/measure.js.coffee
@@ -24,7 +24,7 @@ class Thorax.Models.Measure extends Thorax.Model
 
   # For speed on the dashboard, we only load partial measures, and rely on all the non-dashboard views to fetch the rest
   isPopulated: -> @has('data_criteria')
-    
+  populationCriteria: -> _.intersection(Thorax.Models.Measure.allPopulationCodes, _(@get('population_criteria')).keys())
 
 class Thorax.Collections.Measures extends Thorax.Collection
   url: '/measures'

--- a/app/assets/javascripts/templates/population_calculation.hbs
+++ b/app/assets/javascripts/templates/population_calculation.hbs
@@ -63,7 +63,11 @@
             <td>{{name}}</td>
             <td style="text-align: center;">
               {{#ifCond name "==" "OBSERV"}}
-                {{expected}}%
+                {{#ifCond expected "==" undefined}}
+                  <i class="fa fa-question-circle default"></i>
+                {{else}}
+                  {{expected}}%
+                {{/ifCond}}
               {{else}}
                 {{#if ../../episode_of_care}}
                   <span class="default">{{expected}}</span>
@@ -78,7 +82,11 @@
             </td>
             <td style="text-align: center;">
               {{#ifCond name "==" "OBSERV"}}
-                <span class="fail">{{actual}}%</span>
+                {{#ifCond actual "==" undefined}}
+                  <i class="fa fa-question-circle fail"></i>
+                {{else}}
+                  <span class="fail">{{actual}}%</span>
+                {{/ifCond}}
               {{else}}
                 {{#if ../../episode_of_care}}
                   <span class="fail">{{actual}}</span>

--- a/app/assets/javascripts/views/patient_builder.js.coffee
+++ b/app/assets/javascripts/views/patient_builder.js.coffee
@@ -335,7 +335,11 @@ class Thorax.Views.ExpectedValueView extends Thorax.View
     serialize: (attr) ->
       for pc in @model.populationCriteria()
         if @measure.get('episode_of_care') || (@measure.get('continuous_variable') && pc == 'OBSERV')
-          attr[pc] = parseFloat(attr[pc])
+          # Only parse a value for OBSERV if it exists
+          if attr[pc]
+            attr[pc] = parseFloat(attr[pc])
+            # otherwise line it up with the nonexistent value
+          else attr[pc] = undefined
         else
           attr[pc] = if attr[pc] then 1 else 0 # Convert from check-box true/false to 0/1
 
@@ -356,7 +360,8 @@ class Thorax.Views.ExpectedValueView extends Thorax.View
       MSRPOPL: 'MEASURE POP.'
       OBSERV: 'OBSERV'
     @currentCriteria = []
-    for pc in @model.populationCriteria()
+    # get population criteria from the measure to include OBSERV
+    for pc in @measure.populationCriteria()
       @currentCriteria.push
         key: pc
         displayName: criteriaMap[pc]


### PR DESCRIPTION
- Fixed population criteria selection in patient builder's expected value view to use measure instead of initialized expected value's attributes
- Updated population calculation template to show undefined icon if OBSERV values are undefined, otherwise the value as a percentage
