### PR TITLE
Add null end dates

### DIFF
--- a/app/assets/javascripts/templates/patient_builder/edit_criteria.hbs
+++ b/app/assets/javascripts/templates/patient_builder/edit_criteria.hbs
@@ -25,17 +25,17 @@
       <div class="element-edit">
         <div class="form-date">
           <div class="section-heading time-heading"><i class="fa fa-clock-o"></i>START</div>
-          <input type="text" name="start_date" class="form-control form-control-date" placeholder="mm/dd/yyyy" data-date-format="mm/dd/yyyy" data-date-autoclose="true" data-provide="datepicker">
+          <input type="text" name="start_date" class="form-control form-control-date" placeholder="mm/dd/yyyy" data-date-format="mm/dd/yyyy" data-date-autoclose="true">
           <input type="text" name="start_time" class="form-control form-control-time" placeholder="h:mm PM" data-show-inputs="false" data-default-time="false">
         </div>
 
         <div class="form-date">
           <div class="section-heading time-heading"><i class="fa fa-clock-o"></i>STOP</div>
-          <input type="text" name="end_date" class="form-control form-control-date" placeholder="mm/dd/yyyy" data-date-format="mm/dd/yyyy" data-date-autoclose="true" data-provide="datepicker">
-          <input type="text" name="end_time" class="form-control form-control-time" placeholder="h:mm PM" data-show-inputs="false" data-default-time="false">
+          <input type="text" name="end_date" class="form-control form-control-date" placeholder="mm/dd/yyyy" data-date-format="mm/dd/yyyy" data-date-autoclose="true"{{#if end_date_is_undefined}} disabled{{/if}}>
+          <input type="text" name="end_time" class="form-control form-control-time" placeholder="h:mm PM" data-show-inputs="false" data-default-time="false"{{#if end_date_is_undefined}} disabled{{/if}}>
           <div class="checkbox">
             <label class="checkbox-label">
-              <input type="checkbox" value="end_date_undefined"> <span>undefined</span>
+              <input type="checkbox" class="undefined-end-date" name="end_date_is_undefined"> <span>undefined</span>
             </label>
           </div>
         </div>

--- a/app/assets/javascripts/templates/patient_builder/edit_criteria.hbs
+++ b/app/assets/javascripts/templates/patient_builder/edit_criteria.hbs
@@ -33,6 +33,11 @@
           <div class="section-heading time-heading"><i class="fa fa-clock-o"></i>STOP</div>
           <input type="text" name="end_date" class="form-control form-control-date" placeholder="mm/dd/yyyy" data-date-format="mm/dd/yyyy" data-date-autoclose="true" data-provide="datepicker">
           <input type="text" name="end_time" class="form-control form-control-time" placeholder="h:mm PM" data-show-inputs="false" data-default-time="false">
+          <div class="checkbox">
+            <label class="checkbox-label">
+              <input type="checkbox" value="end_date_undefined"> <span>undefined</span>
+            </label>
+          </div>
         </div>
 
         <div class="section-heading">

--- a/app/assets/javascripts/templates/patient_builder/patient_builder.hbs
+++ b/app/assets/javascripts/templates/patient_builder/patient_builder.hbs
@@ -40,7 +40,7 @@
         <div class="form-group">
           <label for="birthdate">DOB</label>
           <div class="clearfix">{{! FIXME this is because these inputs are floated left, because they're made into columns- they should be within columns (that are within a row), but not columns themselves. This needs to be cleaned up. }}
-            <input type="text" name="birthdate" class="form-control form-control-date" placeholder="mm/dd/yyyy" data-date-format="mm/dd/yyyy" data-date-autoclose="true" data-provide="datepicker">
+            <input type="text" name="birthdate" class="form-control form-control-date" placeholder="mm/dd/yyyy" data-date-format="mm/dd/yyyy" data-date-autoclose="true">
             <input type="text" name="birthtime" class="form-control form-control-time" placeholder="h:mm PM" data-show-inputs="false" data-default-time="false">
           </div>
         </div>


### PR DESCRIPTION
Setting an end date as undefined has the following effects:
- it disables the end date/time boxes
- it unsets the end_date field on the model (within the serialize event)
- it triggers a call to materialize

Materialize is now evented. Child views of the parent builder register with the parent builder, so it can listen to them. When they trigger a bonnie:materialize event, the patient builder kicks off a call to materialize.
