### PR TITLE
Sort data criteria by start date/end date, re-sort on close

### DIFF
--- a/app/assets/javascripts/models/data_criteria.js.coffee
+++ b/app/assets/javascripts/models/data_criteria.js.coffee
@@ -51,3 +51,4 @@ class Thorax.Models.PatientDataCriteria extends Thorax.Model
 
 class Thorax.Collections.PatientDataCriteria extends Thorax.Collection
   model: Thorax.Models.PatientDataCriteria
+  comparator: (m) -> [m.get('start_date'), m.get('end_date')]

--- a/app/assets/javascripts/views/patient_builder.js.coffee
+++ b/app/assets/javascripts/views/patient_builder.js.coffee
@@ -14,6 +14,9 @@ class Thorax.Views.PatientBuilder extends Thorax.View
     @editCriteriaCollectionView = new Thorax.CollectionView
       collection: @model.get('source_data_criteria')
       itemView: (item) => new Thorax.Views.EditCriteriaView(model: item.model, measure: @measure)
+      events:
+        collection:
+          close: -> @collection.sort()
     @expectedValuesView = new Thorax.Views.ExpectedValuesView
       collection: @model.getExpectedValues(@measure)
       measure: @measure
@@ -187,7 +190,8 @@ class Thorax.Views.EditCriteriaView extends Thorax.View
 
   closeDetails: ->
     @serialize(children: false)
-    @render()
+    @model.trigger 'close', @model
+    # @render() # re-sorting the collection will re-render this view
 
   removeCriteria: (e) ->
     e.preventDefault()


### PR DESCRIPTION
Adds a comparator to the Patient Data Criteria. When closing a data criteria, the model triggers a "close" event, which the parent view listens to and re-sorts the collection, triggering a re-render of the criteria in order.

Re-rendering the criteria means that all criteria get rendered in their closed state; if we want more than one to be able to be open at a time, we'd have to maintain state in the view and render accordingly. Not too hard to do, but it would add complexity. We've also talked about displaying the criteria accordion style, where opening one closes any others that were open.

The code so far is relatively simple, so I thought I'd get it up here and we can discuss how we want it to work.
