### PR TITLE
finalize should clear the cache since we are setting the episode ids

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,7 +44,7 @@ GIT
 
 GIT
   remote: https://github.com/projecttacoma/bonnie_bundler.git
-  revision: ab8de30f67e6658199a9379b5ab12bab65b245ae
+  revision: dd727c238f31c67fe722390ac2ec6ac81c1d78f1
   branch: develop
   specs:
     bonnie_bundler (1.0.0)

--- a/app/controllers/measures_controller.rb
+++ b/app/controllers/measures_controller.rb
@@ -90,7 +90,7 @@ class MeasuresController < ApplicationController
       measure.populations.each_with_index do |population, population_index|
         population['title'] = data['titles']["#{population_index}"] if (data['titles'])
       end
-      measure.generate_js
+      measure.generate_js(clear_db_cache: true)
       measure.save!
     end
     redirect_to root_path


### PR DESCRIPTION
episode ids are needed to generate the javascript

the finalize method sets the episode ids for the measure if it is episode of care.  We have already generated the javascript once on load, but we did not have the episode ids at that point.  We need to re-generate with the episode id specified by the user
