### PR TITLE
Field Values: Filtering and sorting

### DIFF
--- a/app/assets/javascripts/models/measure.js.coffee
+++ b/app/assets/javascripts/models/measure.js.coffee
@@ -26,6 +26,57 @@ class Thorax.Models.Measure extends Thorax.Model
   isPopulated: -> @has('data_criteria')
   populationCriteria: -> _.intersection(Thorax.Models.Measure.allPopulationCodes, _(@get('population_criteria')).keys())
 
+  @logicFieldsFor: (criteriaType) ->
+
+    # Define field values for all criteria types
+    globalInclusions = ['anatomical_structure', 'cumulative_medication_duration', 'dose', 
+    'frequency', 'incision_time', 'length_of_stay', 'ordinality', 'reason', 'removal_time', 
+    'route', 'severity', 'source', 'start_date', 'end_date']
+
+    # Define criteria type-specific field values
+    typeInclusions = 
+      care_goals: []
+      characteristics: []
+      communications: []
+      conditions: []
+      devices: []
+      diagnostic_studies: []
+      encounters: ['admit_time', 'discharge_time', 'discharge_disposition', 'facility', 
+        'facility_arrival', 'facility_departure', 'transfer_to', 'transfer_from']
+      functional_statuses: []
+      interventions: []
+      laboratory_tests: []
+      medications: []
+      patient_care_experiences: []
+      physical_exams: []
+      preferences: []
+      procedures: []
+      provider_care_experiences: []
+      provider_characteristics: []
+      risk_category_assessments: []
+      substances: []
+      symptoms: []
+      system_characteristics: []
+      transfers: []
+
+    # start with all field values
+    fields = Thorax.Models.Measure.logicFields
+
+    # grab all defined field values, merging global and type-specific specs
+    allInclusions = _(globalInclusions).union(typeInclusions[criteriaType])
+    allInclusions ?= []
+
+    # check any defined inclusions against the coded_entry_value of each field value
+    matchedInclusions = []
+    for field, attrs of fields
+      for inclusion in allInclusions when attrs['coded_entry_method'] is inclusion
+        matchedInclusions.push field
+    fields = _(fields).pick(matchedInclusions) if matchedInclusions.length > 0
+
+    # sort field values by title
+    fields = _.sortBy(fields, (f) -> f.title)
+    fields
+
 class Thorax.Collections.Measures extends Thorax.Collection
   url: '/measures'
   model: Thorax.Models.Measure

--- a/app/assets/javascripts/views/patient_builder.js.coffee
+++ b/app/assets/javascripts/views/patient_builder.js.coffee
@@ -161,7 +161,12 @@ class Thorax.Views.EditCriteriaView extends Thorax.Views.Materializer
 
   initialize: ->
     @editValueView = new Thorax.Views.EditCriteriaValueView(model: new Thorax.Model, measure: @measure, fieldValue: false, values: @model.get('value'))
-    @editFieldValueView = new Thorax.Views.EditCriteriaValueView(model: new Thorax.Model, measure: @measure, fieldValue: true, values: @model.get('field_values'))
+    @editFieldValueView = new Thorax.Views.EditCriteriaValueView
+      model: new Thorax.Model
+      measure: @measure
+      fieldValue: true
+      values: @model.get('field_values')
+      criteriaType: @model.get('type')
 
   valueWithDateContext: (model) ->
     _(model.toJSON()).extend
@@ -250,7 +255,7 @@ class Thorax.Views.EditCriteriaValueView extends Thorax.Views.Materializer
       typeCD: @model.get('type') is 'CD'
       typeTS: @model.get('type') is 'TS'
       codes: @measure.get('value_sets').map (vs) -> vs.toJSON()
-      fields: Thorax.Models.Measure.logicFields
+      fields: Thorax.Models.Measure.logicFieldsFor(@criteriaType)
 
   # When we serialize the form, we want to put the description for any CD codes into the submission
   events:
@@ -286,7 +291,6 @@ class Thorax.Views.EditCriteriaValueView extends Thorax.Views.Materializer
     @model.set('type', 'PQ') # TODO unify this line with setting the type in `initialize`
     @$('select').val ''
     @triggerMaterialize()
-
 
 class Thorax.Views.ExpectedValuesView extends Thorax.View
 


### PR DESCRIPTION
**Stories**
- https://www.pivotaltracker.com/story/show/62925160
- https://www.pivotaltracker.com/story/show/63158864

Current filtering strategy involves a hash keyed off of PatientDataCriteria <code>type</code>, added to the EditCriteriaValueView.
For now, all PatientDataCriteria will have field value options defined in the <code>globalInclusions</code> attribute, and all ecounter-based PatientDataCriteria will have ecounter-specific field value options also available.

Going forward, we will determine which field values should be long in the global list, and which ones belong in the specific PatientDataCriteria <code>type</code> list.

Additionally, if we can introduce <code>patient_api_function</code> values into the PatientDataCriteria model, we can key the inclusion hash off of those instead of <code>type</code>.
