### PR TITLE
Fixed issue with showing upload dialog when user has no measures

### DIFF
--- a/app/assets/javascripts/views/measures_view.js.coffee
+++ b/app/assets/javascripts/views/measures_view.js.coffee
@@ -13,7 +13,7 @@ class Thorax.Views.Measures extends Thorax.View
 
   events:
     rendered: ->
-      if @collection.isEmpty() then @importMeasure()
+      if @collection.length is 0 then @importMeasure()
 
 
 class Thorax.Views.MeasureRowView extends Thorax.View


### PR DESCRIPTION
- Since the <code>measure_controller</code> has been updated to no longer support an <code>index</code> method, a user with no measures doesn't load any measures after hitting the <code>root_path</code> and subsequently tries to load measures via the <code>measure_controller</code>'s index path.
  - This still is an **issue** and causes the server to return a 500 error. Adding an empty index.json.erb file in the measures directory resolves this error, but I'm not sure if there's an underlying issue with <code>application.html.erb</code> when attempting to load non-existing measures, so I left the file out for this pull request.
- The reason why the dialog won't show is because the <code>@collection.isEmpty()</code> method returns <code>false</code> because it's internal <code>isPopulated()</code> method returns false since there are no measures being loaded. Checking the length instead of calling <code>isEmpty()</code> resolves this, but it may be sidestepping a model-loading issue...
