### PR TITLE
Coverage calc excluding specific occurences

### DIFF
--- a/app/assets/javascripts/models/coverage.js.coffee
+++ b/app/assets/javascripts/models/coverage.js.coffee
@@ -9,11 +9,11 @@ class Thorax.Model.Coverage extends Thorax.Model
   update: ->
 
     # Find all unique criteria that evaluated true in the rationale that are also in the measure
-    rationaleCriteria = []
+    @rationaleCriteria = []
     for result in (@results.select (d) -> d.isPopulated())
-      rationale = result.get 'rationale'
-      rationaleCriteria.push(criteria) for criteria, result of rationale when result
-    rationaleCriteria = _(rationaleCriteria).intersection(@measureCriteria)
+      rationale = result.updatedRationale()
+      @rationaleCriteria.push(criteria) for criteria, result of rationale when result
+    @rationaleCriteria = _(@rationaleCriteria).intersection(@measureCriteria)
 
     # Set coverage to the fraction of measure criteria that were true in the rationale
-    @set coverage: ( rationaleCriteria.length * 100 / @measureCriteria.length ).toFixed()
+    @set coverage: ( @rationaleCriteria.length * 100 / @measureCriteria.length ).toFixed()

--- a/app/assets/javascripts/models/result.js.coffee
+++ b/app/assets/javascripts/models/result.js.coffee
@@ -45,6 +45,15 @@ class Thorax.Models.Result extends Thorax.Model
           @updatedNegatedGood(updatedRationale[code], rationale, goodOccurrence, parentMap)
     return updatedRationale
 
+  updatedRationale: ->
+    updatedRationale = @specificsRationale()
+    currentRationale = @get 'rationale'
+    cleanup = []
+    for code in @population.populationCriteria() when currentRationale[code]?
+      for key, value of currentRationale
+        if _(updatedRationale).has(code) and updatedRationale[code][key] is false then cleanup.push(key)
+    _(currentRationale).omit(cleanup)
+
   updatedNegatedGood: (updatedRationale, rationale, goodOccurrence, parentMap) ->
     parent = parentMap[goodOccurrence]
     while parent

--- a/app/assets/javascripts/templates/measure/coverage.hbs
+++ b/app/assets/javascripts/templates/measure/coverage.hbs
@@ -1,2 +1,4 @@
 <h5>{{#ifCond coverage '==' undefined}}Computing Total coverage...{{/ifCond}}
 {{#ifCond coverage '!=' undefined}}Total Coverage: {{coverage}}%{{/ifCond}}</h5>
+{{!-- Uncomment below for debugging --}}
+{{!-- {{#button "identifyCoverage" class="btn btn-primary"}}Debug{{/button}} --}}

--- a/app/assets/javascripts/views/measures_view.js.coffee
+++ b/app/assets/javascripts/views/measures_view.js.coffee
@@ -52,3 +52,9 @@ class Thorax.Views.MeasureFractionView extends Thorax.View
 
 class Thorax.Views.MeasureCoverageView extends Thorax.View
   template: JST['measure/coverage']
+
+  # Uncommet below for debugging
+  # identifyCoverage: (e) ->
+  #   for criteria in @model.rationaleCriteria
+  #     logicLine = $(".#{criteria}")
+  #     if logicLine.hasClass('text-primary') then logicLine.removeClass('text-primary') else logicLine.addClass('text-primary')


### PR DESCRIPTION
**Story:** https://www.pivotaltracker.com/story/show/63217518
- Added <code>updatedRationale()</code> method to <code>result</code> model for retrieving the <code>rationale</code> hash excluding specific occurrence criteria that were marked as <code>false</code>
- Included commented-out code for a simple logic view highlighting-debug, which can be used to verify correct coverage computation, if necessary
