### PR TITLE
Two-step delete (part 1) for Measure view

### DIFF
--- a/app/assets/javascripts/templates/measure.hbs
+++ b/app/assets/javascripts/templates/measure.hbs
@@ -12,9 +12,9 @@
       <a href="/measures/{{_id}}/debug" class="btn btn-danger">Debug</a>
     {{/ifAdmin}}
     <script type="text/x-handlebars" class="popover-tmpl">
-      {{#button "updateMeasure" class="btn btn-primary"}}Update{{/button}}
-      {{#button "deleteMeasure" class="btn btn-danger delete-measure" style="display: none;"}}Delete{{/button}}
+      {{#button "deleteMeasure" class="btn btn-danger delete-measure" style="display: none;"}}<i class="fa fa-times "></i> Delete{{/button}}
       {{#button "showDelete" class="btn btn-danger-inverse show-delete"}}<i class="fa fa-minus-circle show-delete"></i>{{/button}}
+      {{#button "updateMeasure" class="btn btn-primary btn-update"}}<i class="fa fa-upload "></i> Update{{/button}}
     </script>
   </div>
 

--- a/app/assets/javascripts/templates/measure.hbs
+++ b/app/assets/javascripts/templates/measure.hbs
@@ -13,7 +13,8 @@
     {{/ifAdmin}}
     <script type="text/x-handlebars" class="popover-tmpl">
       {{#button "updateMeasure" class="btn btn-primary"}}Update{{/button}}
-      {{#link "" class="btn btn-danger delete-measure"}}Delete{{/link}}
+      {{#button "deleteMeasure" class="btn btn-danger delete-measure" style="display: none;"}}Delete{{/button}}
+      {{#button "showDelete" class="btn btn-danger-inverse show-delete"}}<i class="fa fa-minus-circle show-delete"></i>{{/button}}
     </script>
   </div>
 

--- a/app/assets/javascripts/views/measure_view.js.coffee
+++ b/app/assets/javascripts/views/measure_view.js.coffee
@@ -4,9 +4,8 @@ class Thorax.Views.Measure extends Thorax.View
     rendered: -> 
       @$("[rel='popover']").popover(content: @$('.popover-tmpl').text())
       $('html').click( (e) -> 
-        unless $(e.target).hasClass('popover-content')
+        unless $(e.target).hasClass('popover-content') or $(e.target).hasClass('show-delete')
           if $('#settings').has(e.target).length == 0 or $(e.target).is('.close') then $('#settings').popover('hide'))
-    'click .delete-measure': 'deleteMeasure'
 
   initialize: ->
     populations = @model.get 'populations'
@@ -32,6 +31,15 @@ class Thorax.Views.Measure extends Thorax.View
     importMeasureView.appendTo(@$el)
     importMeasureView.display()
 
+  showDelete: (e) ->
+    deleteButton = @$('.delete-measure')
+    deleteIcon = @$(e.target)
+    # if we clicked on the icon, grab the icon button instead
+    if deleteIcon[0].tagName is 'I' then deleteIcon = @$(deleteIcon[0].parentElement)
+    deleteIcon.toggle()
+    deleteButton.toggle()
+
   deleteMeasure: (e) ->
     @model = $(e.target).model()
     @model.destroy()
+    bonnie.renderMeasures()

--- a/app/assets/javascripts/views/measure_view.js.coffee
+++ b/app/assets/javascripts/views/measure_view.js.coffee
@@ -1,7 +1,11 @@
 class Thorax.Views.Measure extends Thorax.View
   template: JST['measure']
   events:
-    rendered: -> @$("[rel='popover']").popover(content: @$('.popover-tmpl').text())
+    rendered: -> 
+      @$("[rel='popover']").popover(content: @$('.popover-tmpl').text())
+      $('html').click( (e) -> 
+        unless $(e.target).hasClass('popover-content')
+          if $('#settings').has(e.target).length == 0 or $(e.target).is('.close') then $('#settings').popover('hide'))
     'click .delete-measure': 'deleteMeasure'
 
   initialize: ->

--- a/app/assets/javascripts/views/measure_view.js.coffee
+++ b/app/assets/javascripts/views/measure_view.js.coffee
@@ -6,7 +6,7 @@ class Thorax.Views.Measure extends Thorax.View
       # if we click anywhere but the gear icon or the delete icon, close the popover
       $('html').click( (e) => 
         unless @$(e.target).hasClass('popover-content') or @$(e.target).hasClass('show-delete')
-          if @$('#settings').has(e.target).length == 0 or @$(e.target).is('.close') then @$('#settings').popover('hide'))
+          if @$('#settings').has(e.target).length == 0 then @$('#settings').popover('hide'))
 
   initialize: ->
     populations = @model.get 'populations'

--- a/app/assets/javascripts/views/measure_view.js.coffee
+++ b/app/assets/javascripts/views/measure_view.js.coffee
@@ -6,7 +6,7 @@ class Thorax.Views.Measure extends Thorax.View
       # if we click anywhere but the gear icon or the delete icon, close the popover
       $('html').click( (e) => 
         unless @$(e.target).hasClass('popover-content') or @$(e.target).hasClass('show-delete')
-          if @$('#settings').has(e.target).length == 0 then @$('#settings').popover('hide'))
+          if @$('#settings').has(e.target).length == 0 and @$('.popover').is(':visible') then @$('#settings').popover('toggle'))
 
   initialize: ->
     populations = @model.get 'populations'

--- a/app/assets/javascripts/views/measure_view.js.coffee
+++ b/app/assets/javascripts/views/measure_view.js.coffee
@@ -3,9 +3,10 @@ class Thorax.Views.Measure extends Thorax.View
   events:
     rendered: -> 
       @$("[rel='popover']").popover(content: @$('.popover-tmpl').text())
-      $('html').click( (e) -> 
-        unless $(e.target).hasClass('popover-content') or $(e.target).hasClass('show-delete')
-          if $('#settings').has(e.target).length == 0 or $(e.target).is('.close') then $('#settings').popover('hide'))
+      # if we click anywhere but the gear icon or the delete icon, close the popover
+      $('html').click( (e) => 
+        unless @$(e.target).hasClass('popover-content') or @$(e.target).hasClass('show-delete')
+          if @$('#settings').has(e.target).length == 0 or @$(e.target).is('.close') then @$('#settings').popover('hide'))
 
   initialize: ->
     populations = @model.get 'populations'

--- a/app/assets/stylesheets/application.css.less
+++ b/app/assets/stylesheets/application.css.less
@@ -16,3 +16,6 @@
 @import "measure_calculation";
 @import "rationale";
 @import "builder";
+
+
+

--- a/app/assets/stylesheets/measure.less
+++ b/app/assets/stylesheets/measure.less
@@ -41,10 +41,23 @@
       font-weight: 700;
       font-size: 1.2em;
       .popover {
-        min-width: 187px;
+        min-width: 219px;
+        background-color: @gray-lighter;
+        margin-left: -87px;
         .popover-content {
           padding: 9px;
         }
+        .arrow {
+          margin-left: 76px;
+          &:after {
+            border-bottom-color: @gray-lighter;
+          }
+        }
+      }
+    }
+    .btn-danger {
+      .fa {
+        color: @btn-default-bg;
       }
     }
     .btn-danger-inverse {
@@ -54,6 +67,17 @@
       .fa {
         color: @btn-danger-bg;
       }
+    }
+    .btn-update {
+      color: @btn-default-color;
+      background-color: @btn-default-bg;
+      border-color: @btn-default-border;
+      .fa {
+        color: @btn-default-color;
+      }
+    }
+    p {
+      width: 70%;
     }
   }
 

--- a/app/assets/stylesheets/measure.less
+++ b/app/assets/stylesheets/measure.less
@@ -47,6 +47,14 @@
         }
       }
     }
+    .btn-danger-inverse {
+      color: @btn-danger-bg;
+      background-color: @btn-danger-color;
+      border-color: @btn-danger-border;
+      .fa {
+        color: @btn-danger-bg;
+      }
+    }
   }
 
   .measure-viz {


### PR DESCRIPTION
**Story: (ongoing)** https://www.pivotaltracker.com/story/show/62487888
- Added popover closing functionality on click anywhere but specific popover content or gear icon **(needs review)**
- Updated styling to match v5 mockup

If this is too early to review, please feel free to close this request until I can get to other two-step delete for the story (editable data criteria in the Patient Builder view).

![popover_closed](https://f.cloud.github.com/assets/456952/1872523/7d3b29c8-78a7-11e3-8810-fad57060e719.png)
![popover_opened](https://f.cloud.github.com/assets/456952/1872524/7f285332-78a7-11e3-8ab7-47c25e5f81a1.png)
![popover_delete](https://f.cloud.github.com/assets/456952/1872525/80883918-78a7-11e3-87be-7df9b95d739c.png)
