### PR TITLE
Rename rationale css

### DIFF
--- a/app/assets/javascripts/templates/logic/data_criteria.hbs
+++ b/app/assets/javascripts/templates/logic/data_criteria.hbs
@@ -1,4 +1,4 @@
-<span class="{{dataCriteria.key}} rationale_target">
+<span class="{{dataCriteria.key}} rationale-target">
 {{#each dataCriteria.subset_operators}}
   {{view "SubsetOperatorLogic" subsetOperator=this tag="span"}}
 {{/each}}
@@ -7,7 +7,7 @@
     <ul>
       {{#each dataCriteria.children_criteria}}
         <li>
-          <span class="{{../dataCriteria.key}} rationale_target">{{translate_operator ../dataCriteria.derivation_operator}} : </span>
+          <span class="{{../dataCriteria.key}} rationale-target">{{translate_operator ../dataCriteria.derivation_operator}} : </span>
           {{view "DataCriteriaLogic" reference=this measure=../measure tag="span"}}
         </li>
       {{/each}}

--- a/app/assets/javascripts/templates/logic/population_criteria.hbs
+++ b/app/assets/javascripts/templates/logic/population_criteria.hbs
@@ -1,6 +1,6 @@
 
 <div class="{{population.type}}_children">
-  <div><span class="{{population.type}} rationale_target"><b>{{translate_population population.type}}: 
+  <div><span class="{{population.type}} rationale-target"><b>{{translate_population population.type}}: 
 </b>{{#unless rootPreconditon}}None{{/unless}}</span></div>
   <div>
     {{#if rootPreconditon}}

--- a/app/assets/javascripts/templates/logic/precondition.hbs
+++ b/app/assets/javascripts/templates/logic/precondition.hbs
@@ -1,6 +1,6 @@
 <ul id="precondition_{{precondition.id}}">
   <li>
-    <span class="{{parentPreconditionKey}} rationale_target">
+    <span class="{{parentPreconditionKey}} rationale-target">
       {{translate_conjunction parentPrecondition.conjunction_code}}
       {{#if parentPrecondition.negation}} NOT{{/if}}: 
     </span>

--- a/app/assets/javascripts/views/logic/population_logic_view.js.coffee
+++ b/app/assets/javascripts/views/logic/population_logic_view.js.coffee
@@ -37,7 +37,7 @@ class Thorax.Views.PopulationLogic extends Thorax.View
           for key, value of rationale
             target = @$(".#{code}_children .#{key}")
             if (target.length > 0)
-              target.addClass(if updatedRationale[code]?[key] is false then 'bad_specifics' else "#{!!value}_eval")
+              target.addClass(if updatedRationale[code]?[key] is false then 'bad-specifics' else "#{!!value}-eval")
 
   clearRationale: ->
-    @$('.rationale .rationale_target').removeClass('false_eval true_eval bad_specifics')
+    @$('.rationale .rationale-target').removeClass('false-eval true-eval bad-specifics')

--- a/app/assets/stylesheets/rationale.less
+++ b/app/assets/stylesheets/rationale.less
@@ -1,11 +1,11 @@
 // Displays colors according to patient results on the measure logic
 
 .rationale {
-  .true_eval, .false_eval, .bad_specifics {
+  .true-eval, .false-eval, .bad-specifics {
     font-weight: 500;
     padding: 2px;
   }
-  .true_eval {
+  .true-eval {
     background-color: @state-success-bg;
     color: @state-success-text;
     &:before {
@@ -13,7 +13,7 @@
       font-family: FontAwesome;
     }
   }
-  .false_eval {
+  .false-eval {
     background-color: @state-danger-bg;
     color: @state-danger-text;
     &:before {
@@ -21,15 +21,12 @@
       font-family: FontAwesome;
     }
   }
-  .bad_specifics {
+  .bad-specifics {
     background-color: @state-danger-bg;
     color: @state-danger-text;
     &:before {
       content: @fa-var-asterisk;
       font-family: FontAwesome;
     }
-  }
-  .no_eval {
-    background-color: @body-bg;
   }
 }


### PR DESCRIPTION
fixes rationale classes to align with CSS guidance.  The css classes were changed to use - rather than _.  However, the actual names of the classes were left the same since a better alternative was not obvious to align with bootstrap class names
