### PR TITLE
disable the end date/time when clicking 'undefined' end date

### DIFF
--- a/app/assets/javascripts/views/patient_builder/data_criteria.js.coffee
+++ b/app/assets/javascripts/views/patient_builder/data_criteria.js.coffee
@@ -75,10 +75,10 @@ class Thorax.Views.EditCriteriaView extends Thorax.Views.BuilderChildView
       @$('.criteria-data.droppable').droppable greedy: true, accept: '.ui-draggable', hoverClass: 'drop-target-highlight', drop: _.bind(@dropCriteria, this)
       @$('.date-picker').datepicker().on 'changeDate', _.bind(@triggerMaterialize, this)
       @$('.time-picker').timepicker().on 'changeTime.timepicker', _.bind(@triggerMaterialize, this)
-    'change .negation-select':    'toggleNegationSelect'
-    'change .undefined-end-date': 'toggleEndDateDefinition'
-    'blur :text':                 'triggerMaterialize'
-    'change select':              'triggerMaterialize'
+    'change .negation-select':                    'toggleNegationSelect'
+    'change :input[name=end_date_is_undefined]':  'toggleEndDateDefinition'
+    'blur :text':                                 'triggerMaterialize'
+    'change select':                              'triggerMaterialize'
 
   dropCriteria: (e, ui) ->
     # When we drop a new criteria on an existing criteria

--- a/spec/javascripts/views/patient_builder_spec.js.coffee
+++ b/spec/javascripts/views/patient_builder_spec.js.coffee
@@ -92,9 +92,13 @@ describe 'PatientBuilderView', ->
   describe "editing basic attributes of a criteria", ->
     beforeEach ->
       @patientBuilder.appendTo 'body'
+      @patientBuilder.$('button[data-call-method=toggleDetails]:first').click()
       @patientBuilder.$(':input[name=start_date]:first').val('08/10/2012')
       @patientBuilder.$(':input[name=start_time]:first').val('3:33')
       @patientBuilder.$(':input[name=end_date_is_undefined]:first').click()
+      # verify DOM as well
+      expect(@patientBuilder.$(':input[name=end_date]:first')).toBeDisabled()
+      expect(@patientBuilder.$(':input[name=end_time]:first')).toBeDisabled()
       @patientBuilder.$("button[data-call-method=save]").click()
 
     it "serializes the attributes correctly", ->


### PR DESCRIPTION
This fixes a regression introduced when I updated the patient builder markup. I've also added DOM testing in addition to the view testing that was already in place.
