### PR TITLE
Expand bonnie:load:mitre_bundle to allow EP/EH selection

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,7 +44,7 @@ GIT
 
 GIT
   remote: https://github.com/projecttacoma/bonnie_bundler.git
-  revision: de123b1e01aa25cc9433c4c6d37fc7db9c5ca0ed
+  revision: c19bb6e88f2ee6c0fd78e01ae94fd11a1e69f9e8
   branch: develop
   specs:
     bonnie_bundler (1.0.0)

--- a/lib/tasks/loading/bundle.rake
+++ b/lib/tasks/loading/bundle.rake
@@ -4,13 +4,21 @@ namespace :bonnie do
   namespace :load do
   
     desc 'Load Exported MITRE measure bundle'
-    task :mitre_bundle, [:file, :email, :reparse_hqmf?, :measures_yml, :drop_db?] do |t, args|
+    task :mitre_bundle, [:file, :email, :measure_type, :reparse_hqmf?, :measures_yml, :drop_db?] do |t, args|
       raise "The file to measure definition must be specified" unless args.file
       raise "The user email to load the measures for must be specified" unless args.email
 
       email = args.email || 'bonnie@example.com'
       load_from_hqmf = args.reparse_hqmf? == 'true'
       measures_yml = args.measures_yml unless measures_yml.nil? || measures_yml.empty?
+      measure_type = args.measure_type
+      unless measure_type.nil?
+        measure_type.downcase!
+        # If we're not given eh or ep, set to nil for bundle:import
+        if measure_type != 'ep' && measure_type != 'eh'
+          measure_type = nil
+        end
+      end
 
       if args.drop_db? != 'false'
         Rake::Task["db:drop"].invoke()
@@ -21,7 +29,7 @@ namespace :bonnie do
       User.create!({agree_license: true, approved: true, password: password, password_confirmation: password, email: email, first_name: username, last_name: username})
       puts "created user #{email}/#{password}"
 
-      Rake::Task["bundle:import"].invoke(args.file,'true','true',nil,'false')
+      Rake::Task["bundle:import"].invoke(args.file,'true','true',measure_type,'false')
 
       puts "dropping unneeded collections: measures, bundles, patient_cache, query_cache..."
       MONGO_DB['bundles'].drop()
@@ -33,7 +41,7 @@ namespace :bonnie do
       MONGO_DB['system.js'].find({}).remove_all
 
       user = User.by_email(email).first
-      Measures::BundleLoader.load(args.file, user, measures_yml, load_from_hqmf)
+      Measures::BundleLoader.load(args.file, user, measures_yml, load_from_hqmf, measure_type)
 
       Rake::Task['bonnie:patients:update_measure_ids'].invoke
       Rake::Task['bonnie:users:associate_user_with_measures'].invoke(EMAIL: email)


### PR DESCRIPTION
_This pull request must be merged with the bonnie_bundler pull request projecttacoma/bonnie_bundler#5 for correct application functionality._
#### Story
- https://www.pivotaltracker.com/story/show/63975288
#### Notes
- Updated <code>rake bonnie:load:mitre_bundle</code> to take an additional, optional, input specifying whether **<code>ep</code>** or **<code>eh</code>** or both types of measures should be loaded from the specified bundle
- Also correctly imports the bundle such that only the corresponding <code>measures</code>, <code>patients</code>, and <code>value sets</code> are loaded via <code>bundle:import</code>
- E.g., the following commands produce the following results
  - <code>rake bonnie:load:mitre_bundle['/path/to/your/bundle-2.4.0.zip',bonnie@example.com]</code>
    - Imports and loads all <code>measures</code>, <code>patients</code>, <code>value sets</code>, and <code>results</code>
  - <code>rake bonnie:load:mitre_bundle['/path/to/your/bundle-2.4.0.zip',bonnie@example.com,eh]</code>
    - Imports and loads all **EH** <code>measures</code>, <code>patients</code>, <code>value sets</code>, and <code>results</code>
  - <code>rake bonnie:load:mitre_bundle['/path/to/your/bundle-2.4.0.zip',bonnie@example.com,ep]</code>
    - Imports and loads all **EP** <code>measures</code>, <code>patients</code>, <code>value sets</code>, and <code>results</code>
  - <code>rake bonnie:load:mitre_bundle['/path/to/your/bundle-2.4.0.zip',bonnie@example.com,banana]</code>
    - Imports and loads all <code>measures</code>, <code>patients</code>, <code>value sets</code>, and <code>results</code>
