### PR TITLE
Loaded patients correctly display icons and field values in patient builder

### DIFF
--- a/lib/tasks/bonnie.rake
+++ b/lib/tasks/bonnie.rake
@@ -156,6 +156,7 @@ namespace :bonnie do
               patient_data_criteria['title'] = measure_data_criteria['title']
               patient_data_criteria['description'] = measure_data_criteria['description']
               patient_data_criteria['negation'] = patient_data_criteria['negation'] == "true"
+              patient_data_criteria['type'] = measure_data_criteria['type']
 
               # FIXME Not sure why field_values has no keys now, did the Cypress patient set change?
               unless patient_data_criteria['field_values'].blank?


### PR DESCRIPTION
_Note: requires resetting database via <code>rake bonnie:db:reset</code> for verification and/or testing_
#### Story
- https://www.pivotaltracker.com/story/show/64922470
#### Notes
- Updated <code>bonnie:patients:update_source_data_criteria</code> rake task to include <code>type</code>, since the patient builder's data criteria view(s) and logic rely on it for icons and field values
#### Screenshot
- ![ecounterfieldvalues](https://f.cloud.github.com/assets/456952/2079109/c9004946-8dc5-11e3-800e-d266b8a5e231.png)
