### PR TITLE
Change PatientDataCriteria to remove definition from description

### DIFF
--- a/app/assets/javascripts/templates/patient_builder/edit_criteria.hbs
+++ b/app/assets/javascripts/templates/patient_builder/edit_criteria.hbs
@@ -7,7 +7,7 @@
       <div class="row">
         <div class="col-md-6">
           <label>{{definition}}</label>
-          <div>{{description}}</div>
+          <div>{{specificDescription}}</div>
         </div>
 
         <div class="col-md-6">
@@ -20,7 +20,7 @@
     <form class="hide" role="form">
       {{#button "toggleDetails" class="close"}}<i class="fa fa-lg fa-angle-down"></i>{{/button}}
 
-      <p><strong>{{definition}}:</strong> {{description}}</p>
+      <p><strong>{{definition}}:</strong> {{specificDescription}}</p>
 
       <div class="row">
         <div class="form-group col-md-6">

--- a/app/assets/javascripts/templates/patient_builder/edit_criteria.hbs
+++ b/app/assets/javascripts/templates/patient_builder/edit_criteria.hbs
@@ -20,7 +20,7 @@
     <form class="hide" role="form">
       {{#button "toggleDetails" class="close"}}<i class="fa fa-lg fa-angle-down"></i>{{/button}}
 
-      <p><strong>{{definition}}:</strong> {{specificDescription}}</p>
+      <p><label>{{definition}}:</label> {{specificDescription}}</p>
 
       <div class="row">
         <div class="form-group col-md-6">

--- a/app/assets/javascripts/views/patient_builder/data_criteria.js.coffee
+++ b/app/assets/javascripts/views/patient_builder/data_criteria.js.coffee
@@ -61,6 +61,7 @@ class Thorax.Views.EditCriteriaView extends Thorax.Views.BuilderChildView
       end_date_is_undefined: !@model.has('end_date')
       codes: @measure.get('value_sets').map (vs) -> vs.toJSON()
       faIcon: @model.faIcon()
+      specificDescription: (@model.get('description').split("#{@model.get('definition')[0].toUpperCase() + @model.get('definition')[1..-1]}, "))[1]
 
   # When we serialize the form, we want to convert formatted dates back to times
   events:

--- a/app/assets/javascripts/views/patient_builder/data_criteria.js.coffee
+++ b/app/assets/javascripts/views/patient_builder/data_criteria.js.coffee
@@ -53,6 +53,8 @@ class Thorax.Views.EditCriteriaView extends Thorax.Views.BuilderChildView
 
   # When we create the form and populate it, we want to convert times to moment-formatted dates
   context: ->
+    description = (@model.get('description').split("#{@model.get('definition')?[0].toUpperCase() + @model.get('definition')?[1..-1]}, "))?[1]
+    description ?= @model.get('description')
     _(super).extend
       start_date: moment(@model.get('start_date')).format('L') if @model.get('start_date')
       start_time: moment(@model.get('start_date')).format('LT') if @model.get('start_date')
@@ -61,7 +63,7 @@ class Thorax.Views.EditCriteriaView extends Thorax.Views.BuilderChildView
       end_date_is_undefined: !@model.has('end_date')
       codes: @measure.get('value_sets').map (vs) -> vs.toJSON()
       faIcon: @model.faIcon()
-      specificDescription: (@model.get('description').split("#{@model.get('definition')[0].toUpperCase() + @model.get('definition')[1..-1]}, "))[1]
+      specificDescription: description
 
   # When we serialize the form, we want to convert formatted dates back to times
   events:

--- a/app/assets/stylesheets/application.css.less
+++ b/app/assets/stylesheets/application.css.less
@@ -19,3 +19,4 @@
 @import "measure_calculation";
 @import "rationale";
 @import "builder";
+


### PR DESCRIPTION
#### Story
- https://www.pivotaltracker.com/story/show/62487958
#### Notes
- Added <code>specificDescription</code> to PatientDataCriteria context where the original <code>description</code> is split using a capitalized <code>definition</code>
- Also updated toggled PatientDataCriteria to use a label for the definition
#### Screenshot

![pdcdesc](https://f.cloud.github.com/assets/456952/2079732/03b0a3f8-8dce-11e3-80eb-71a4ab9fac6f.png)
