### PR TITLE
Fix measure upload dialog when no measures are loaded

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -44,6 +44,8 @@
       });
       bonnie.isAdmin = <%= current_user.is_admin? %>;
       bonnie.isPortfolio = <%= current_user.is_portfolio? %>;
+      // prevent fetching directly from server after bootstrapping measures
+      bonnie.measures._fetched = true;
     </script>
   </body>
 </html>


### PR DESCRIPTION
#### Story
- https://www.pivotaltracker.com/story/show/63216448
#### Notes
- Marked <code>measures</code> collection's <code>_fetched</code> field with <code>true</code> value after bootstrapping measures in application.html.erb
  - This prevents the collection from fetching, so all server errors are prevented, as well.
- Alternative solutions require removing <code>url</code>, reworking collection implementation to prevent undesired loading/fetching, or reading <code>length</code> field off of the collection
