### PR TITLE
Measure two-step delete, with fade-in buttons

### DIFF
--- a/app/assets/javascripts/templates/measure.hbs
+++ b/app/assets/javascripts/templates/measure.hbs
@@ -2,19 +2,23 @@
   <div class="measure-title">
     <span class="short-title pull-left"><i class="fa fa-tasks"></i> {{measure_id}}:</span>
     <span class="full-title">{{title}}</span>
+    <span class="settings-container">
+      <div class="measure-settings">
+        {{#button "updateMeasure" class="btn btn-default update-measure"}}<i class="fa fa-upload"></i> Update{{/button}}
+        {{#button "deleteMeasure" class="btn btn-danger delete-measure hide"}}<i class="fa fa-times"></i> Delete{{/button}}
+        {{#button "showDelete" class="btn btn-danger-inverse delete-icon"}}<i class="fa fa-minus-circle"></i>{{/button}}
+      </div>
+      {{#button "toggleSettings" tag="a" class="btn-settings" href=""}}<i class="fa fa-cog"></i>{{/button}}
+    </span>
   </div>
   <div class="measure-dsp">
     <div class="measure-dsp-title">
-      Description: <a class="pull-right" data-toggle="popover" id="settings" rel="popover" data-placement="bottom" data-html="true"><i class="fa fa-cog"></i></a>
+      Description: 
     </div>
     <p>{{description}}</p>
     {{#ifAdmin}}
       <a href="/measures/{{_id}}/debug" class="btn btn-danger">Debug</a>
     {{/ifAdmin}}
-    <script type="text/x-handlebars" class="popover-tmpl">
-      {{#button "updateMeasure" class="btn btn-primary"}}Update{{/button}}
-      {{#link "" class="btn btn-danger delete-measure"}}Delete{{/link}}
-    </script>
   </div>
 
   {{view logicView}}

--- a/app/assets/javascripts/views/measure_view.js.coffee
+++ b/app/assets/javascripts/views/measure_view.js.coffee
@@ -1,8 +1,5 @@
 class Thorax.Views.Measure extends Thorax.View
   template: JST['measure']
-  events:
-    rendered: -> @$("[rel='popover']").popover(content: @$('.popover-tmpl').text())
-    'click .delete-measure': 'deleteMeasure'
 
   initialize: ->
     populations = @model.get 'populations'
@@ -31,3 +28,14 @@ class Thorax.Views.Measure extends Thorax.View
   deleteMeasure: (e) ->
     @model = $(e.target).model()
     @model.destroy()
+    bonnie.renderMeasures()
+
+  toggleSettings: (e) ->
+    e.preventDefault()
+    @$('.delete-icon').click() if @$('.delete-measure').is(':visible')
+    @$('.measure-settings').toggleClass('measure-settings-expanded')
+
+  showDelete: (e) ->
+    e.preventDefault()
+    $btn = $(e.currentTarget)
+    $btn.toggleClass('btn-danger btn-danger-inverse').prev().toggleClass('hide')

--- a/app/assets/stylesheets/application.css.less
+++ b/app/assets/stylesheets/application.css.less
@@ -20,3 +20,5 @@
 @import "rationale";
 @import "builder";
 
+
+

--- a/app/assets/stylesheets/measure.less
+++ b/app/assets/stylesheets/measure.less
@@ -25,11 +25,50 @@
     .title-bar;
     .short-title {
       font-size: 1.8em;
-      padding-right: 15px;
       line-height: 1.75;
+      padding-right: 15px;
     }
     .full-title {
       line-height: 1.6;
+      padding-right: 10px;
+    }
+    .settings-container {
+      position: absolute;
+      top: 0;
+      right: 15px;
+    }
+    .btn-settings {
+      font-size: 1.8em;
+      line-height: 1.75;
+    }
+    .measure-settings {
+      visibility: hidden;
+      opacity: 0;
+      background-color: @gray-lighter;
+      position: absolute;
+      top: 4px;
+      .transition(opacity 0.5s linear);
+      .btn-danger {
+        .fa {
+          color: @btn-danger-color;
+        }
+      }
+      .btn-danger-inverse {
+        .fa {
+          color: @btn-danger-bg;
+        }
+      }
+      .update-measure {
+        .fa {
+          color: @brand-primary;
+        }
+      }
+    }
+    .measure-settings-expanded {
+      visibility: visible;
+      opacity: 1;
+      right: 1.8em;
+      white-space: nowrap;
     }
   }
 


### PR DESCRIPTION
#### Story
- https://www.pivotaltracker.com/story/show/62487888
#### Notes
- Replaced measure's delete button with consistent two-step delete button used within patient results and patient data criteria, moved measure settings gear icon into title bar
- Updated styling to match v5 mockups
- Added simple CSS3 fading transition for buttons
#### Images

![screen shot 2014-02-07 at 8 45 58 am](https://f.cloud.github.com/assets/456952/2110170/4a6cffee-8ffe-11e3-8ced-79e672c618fd.png)
![screen shot 2014-02-07 at 8 46 06 am](https://f.cloud.github.com/assets/456952/2110171/4a6de102-8ffe-11e3-91a5-817a1d765a93.png)
![screen shot 2014-02-07 at 8 46 12 am](https://f.cloud.github.com/assets/456952/2110172/4a6e237e-8ffe-11e3-9532-81ab6ce4bc31.png)
