### PR TITLE
Save codes with the same format they are on the server

### DIFF
--- a/app/assets/javascripts/models/data_criteria.js.coffee
+++ b/app/assets/javascripts/models/data_criteria.js.coffee
@@ -20,7 +20,7 @@ class Thorax.Collections.MeasureDataCriteria extends Thorax.Collection
 class Thorax.Models.PatientDataCriteria extends Thorax.Model
   idAttribute: null
   initialize: ->
-    @set('codes', new Thorax.Collection) unless @has 'codes'
+    @set('codes', new Thorax.Collections.Codes) unless @has 'codes'
   parse: (attrs) ->
     attrs.value = new Thorax.Collection(attrs.value)
     # Transform fieldValues object to collection, one element per key/value, with key as additional attribute
@@ -29,7 +29,7 @@ class Thorax.Models.PatientDataCriteria extends Thorax.Model
       fieldValues.add _(value).extend(key: key)
     attrs.field_values = fieldValues
     if attrs.codes
-      attrs.codes = new Thorax.Collection attrs.codes
+      attrs.codes = new Thorax.Collections.Codes attrs.codes, parse: true
     attrs
   valueSet: -> _(bonnie.measures.valueSets()).detect (vs) => vs.get('oid') is @get('code_list_id')
   toJSON: ->
@@ -60,3 +60,15 @@ class Thorax.Collections.PatientDataCriteria extends Thorax.Collection
   model: Thorax.Models.PatientDataCriteria
   # FIXME sortable: commenting out due to odd bug in droppable
   # comparator: (m) -> [m.get('start_date'), m.get('end_date')]
+
+class Thorax.Collections.Codes extends Thorax.Collection
+  parse: (results, options) ->
+    codes = for codeset, codes of results
+      {codeset, code} for code in codes
+    _(codes).flatten()
+
+  toJSON: ->
+    json = {}
+    for codeset, codes of @groupBy 'codeset'
+      json[codeset] = _(codes).map (c) -> c.get('code')
+    json

--- a/app/assets/javascripts/models/patient.js.coffee
+++ b/app/assets/javascripts/models/patient.js.coffee
@@ -91,9 +91,7 @@ class Thorax.Models.Patient extends Thorax.Model
         criterium.set 'coded_entry_id', data['source_data_criteria'][i]['coded_entry_id'], silent: true
         # if we already have codes, then we know we're up to date; no change is necessary
         if criterium.get('codes').isEmpty()
-          codes = for codeset, codes of data['source_data_criteria'][i]['codes']
-            {codeset, code} for code in codes
-          criterium.get('codes').reset _(codes).flatten()
+          criterium.get('codes').reset data['source_data_criteria'][i]['codes'], parse: true
       @trigger 'materialize' # We use a new event rather than relying on 'change' because we don't want to automatically re-render everything
 
   getExpectedValue: (population) ->
@@ -114,15 +112,15 @@ class Thorax.Models.Patient extends Thorax.Model
     expectedValues
 
 class Thorax.Collections.Patients extends Thorax.Collection
-  model: Thorax.Models.Patient  
+  model: Thorax.Models.Patient
   dedupName: (patient) ->
     return patient.first if !(patient.first && patient.last)
-    #matcher to find all of the records that have the same last name and the first name starts with the first name of the 
-    #patient data being duplicated 
-    matcher =  (record) -> 
-      return false if !(record.get('first') && record.get('last')) || record.get('last') != patient.last 
+    #matcher to find all of the records that have the same last name and the first name starts with the first name of the
+    #patient data being duplicated
+    matcher =  (record) ->
+      return false if !(record.get('first') && record.get('last')) || record.get('last') != patient.last
       return record.get('first').substring( 0, patient.first.length ) == patient.first;
-  
+
     matches = @.filter(matcher)
     index = 1
     #increment the index for any copy index that may have been previously used


### PR DESCRIPTION
Prior to this, codes were initialized with a format optimized for client-side use, but then persisted with that same format. This PR isolates the client-side formatting of the codes to the Codes collection itself, and persists codes in the format the server should expect.
