### PR TITLE
User first_name, last_name, and telephone display correctly in Account page

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,7 +18,7 @@ class User
   end
 
   # Setup accessible (or protected) attributes for your model
-  attr_accessible :email, :password, :password_confirmation, :remember_me
+  attr_accessible :email, :password, :password_confirmation, :remember_me, :first_name, :last_name, :telephone
 
   ## Database authenticatable
   field :email,              :type => String, :default => ""


### PR DESCRIPTION
#### Story
- https://www.pivotaltracker.com/story/show/65111524
#### Notes
- Updated User model to denote <code>first_name</code>, <code>last_name</code>, and <code>telephone</code> as accessible attributes, thereby allowing them to be saved to the database on registration and persisted to the Account page
#### Screenshot

![usernames](https://f.cloud.github.com/assets/456952/2112018/bcf1e0b0-9018-11e3-87f9-8f51608839a4.png)
