### PR TITLE
Remove definition from patient data criteria descriptions

### DIFF
--- a/app/assets/javascripts/views/patient_builder/data_criteria.js.coffee
+++ b/app/assets/javascripts/views/patient_builder/data_criteria.js.coffee
@@ -54,12 +54,14 @@ class Thorax.Views.EditCriteriaView extends Thorax.Views.BuilderChildView
   # When we create the form and populate it, we want to convert times to moment-formatted dates
   context: ->
     cmsIdParts = @model.get("cms_id")?.match(/CMS(\d+)(V\d+)/i) or []
+    desc = @model.get('description').split(", ")?[1] or @model.get('description')
     _(super).extend
       start_date: moment(@model.get('start_date')).format('L') if @model.get('start_date')
       start_time: moment(@model.get('start_date')).format('LT') if @model.get('start_date')
       end_date: moment(@model.get('end_date')).format('L') if @model.get('end_date')
       end_time: moment(@model.get('end_date')).format('LT') if @model.get('end_date')
       end_date_is_undefined: !@model.has('end_date')
+      description: desc
       value_sets: @measure.get('value_sets').map (vs) -> vs.toJSON()
       cms_id_number: cmsIdParts[1]
       cms_id_version: cmsIdParts[2]

--- a/spec/javascripts/views/patient_builder_spec.js.coffee
+++ b/spec/javascripts/views/patient_builder_spec.js.coffee
@@ -60,7 +60,7 @@ describe 'PatientBuilderView', ->
         criteria = @$el.find(".draggable:eq(#{position})").draggable()
         criteriaOffset = criteria.offset()
         droppableOffset = @$el.find(targetSelector).offset()
-        criteria.simulate 'drag', dx: droppableOffset.left - criteriaOffset.left, dy: droppableOffset.top - criteriaOffset.top
+        criteria.simulate 'drag', dx: droppableOffset.left - criteriaOffset.left - (criteria.width()/2), dy: droppableOffset.top - criteriaOffset.top - (criteria.height()/2)
 
     it "adds data criteria to model when dragged", ->
       expect(@patientBuilder.model.get('source_data_criteria').length).toEqual 3 # Patient starts with existing criteria


### PR DESCRIPTION
~~_Note: This branch fails on Travis, but passes locally; the specific issue is dropping data criteria on existing data criteria does not set the correct start and end dates, again only for the Travis jasmine specs_~~
https://travis-ci.org/projecttacoma/bonnie/builds/19053804
#### Story
- https://www.pivotaltracker.com/story/show/62487958
#### Notes
- Update description to <code>edit_criteria</code> context, which simply splits the existing description on ', '
#### Screenshot

![screen shot 2014-02-07 at 2 33 29 pm](https://f.cloud.github.com/assets/456952/2113541/c287b0a2-902e-11e3-90ca-bfbb55752753.png)
