### PR TITLE
Show coverage for all patients in Measure view

### DIFF
--- a/app/assets/javascripts/templates/measure/coverage.hbs
+++ b/app/assets/javascripts/templates/measure/coverage.hbs
@@ -1,4 +1,14 @@
-<h5>{{#ifCond coverage '==' undefined}}Computing Total coverage...{{/ifCond}}
-{{#ifCond coverage '!=' undefined}}Total Coverage: {{coverage}}%{{/ifCond}}</h5>
-{{!-- Uncomment below for debugging --}}
-{{!-- {{#button "identifyCoverage" class="btn btn-primary"}}Debug{{/button}} --}}
+<div class="row coverage-summary">
+  {{#ifCond coverage '==' undefined}}<h5>Computing Total coverage...</h5>{{/ifCond}}
+  {{#ifCond coverage '!=' undefined}}
+    <div class="coverage">
+      <input type="text" value="{{coverage}}" class="dial" data-readOnly="true" data-width="60" data-height="60" data-thickness=".2" data-fgColor="#0075C4" data-inputColor="#444" data-font="Helvetica Neue, Roboto, Helvetica, Arial, sans-serif">
+    </div>
+    <div class="coverage-label">
+      <span class="status status-coverage">% COVERAGE</span>
+    </div>
+    <div class="coverage-data">
+      {{#button "identifyCoverage" class="btn btn-show-coverage"}}<i class="fa fa-bar-chart-o"></i> Show{{/button}}
+    </div>
+  {{/ifCond}}
+</div>

--- a/app/assets/javascripts/templates/population_calculation.hbs
+++ b/app/assets/javascripts/templates/population_calculation.hbs
@@ -14,7 +14,7 @@
       </a>
     </div>
   </div>  
-  {{view "MeasureCoverageView" model=totalCoverage}}
+  {{view coverageView}}
   <br>
   {{#collection differences tag="div" class="panel panel-default" item-context=differenceContext}}
     <div class="panel-heading">

--- a/app/assets/javascripts/views/logic/population_logic_view.js.coffee
+++ b/app/assets/javascripts/views/logic/population_logic_view.js.coffee
@@ -6,12 +6,17 @@ class Thorax.Views.PopulationsLogic extends Thorax.LayoutView
     @trigger 'population:update', population
   showRationale: (result) -> @getView().showRationale(result)
   clearRationale: -> @getView().clearRationale()
+  showCoverage: -> @getView().showCoverage()
+  clearCoverage: -> @getView().clearCoverage()
   populationContext: (population) ->
     _(population.toJSON()).extend isActive: population is @collection.first()
 
 class Thorax.Views.PopulationLogic extends Thorax.View
 
   template: JST['logic/logic']
+
+  events:
+    rendered: -> @showCoverage()
 
   initialize: ->
     @submeasurePopulations = []
@@ -29,6 +34,7 @@ class Thorax.Views.PopulationLogic extends Thorax.View
     result.calculation.done =>
       @latestResult = result
       rationale = result.get('rationale')
+      @clearCoverage()
       @clearRationale()
       # rationale only handles the logical true/false values
       # we need to go in and modify the highlighting based on the final specific contexts for each population
@@ -60,3 +66,10 @@ class Thorax.Views.PopulationLogic extends Thorax.View
 
   clearRationale: ->
     @$('.rationale .rationale-target').removeClass('eval-false eval-true eval-bad-specifics')
+
+  showCoverage: ->
+    @clearRationale()
+    @$(".#{criteria}").addClass('eval-coverage') for criteria in @model.coverage().rationaleCriteria
+
+  clearCoverage: ->
+    @$('.rationale .rationale-target').removeClass('eval-coverage')

--- a/app/assets/javascripts/views/measure_view.js.coffee
+++ b/app/assets/javascripts/views/measure_view.js.coffee
@@ -14,6 +14,8 @@ class Thorax.Views.Measure extends Thorax.View
       @logicView = populationLogicView
 
     @populationCalculation = new Thorax.Views.PopulationCalculation(model: population)
+    @logicView.listenTo @populationCalculation, 'logicView:showCoverage', -> @showCoverage()
+    @logicView.listenTo @populationCalculation, 'logicView:clearCoverage', -> @clearCoverage()
 
     @populationCalculation.listenTo @logicView, 'population:update', (population) -> @updatePopulation(population)
     # FIXME: change the name of these events to reflect what the measure calculation view is actually saying

--- a/app/assets/javascripts/views/measures_view.js.coffee
+++ b/app/assets/javascripts/views/measures_view.js.coffee
@@ -52,9 +52,20 @@ class Thorax.Views.MeasureFractionView extends Thorax.View
 
 class Thorax.Views.MeasureCoverageView extends Thorax.View
   template: JST['measure/coverage']
+  events:
+    rendered: -> 
+      @$('.dial').knob()
+      @showCoverage()
 
-  # Uncommet below for debugging
-  # identifyCoverage: (e) ->
-  #   for criteria in @model.rationaleCriteria
-  #     logicLine = $(".#{criteria}")
-  #     if logicLine.hasClass('text-primary') then logicLine.removeClass('text-primary') else logicLine.addClass('text-primary')
+  showCoverage: ->
+    @trigger 'logicView:showCoverage'
+    @$('.btn-show-coverage').removeClass('btn-default').addClass('btn-primary').prop('disabled',true)
+
+  hideCoverage: ->
+    @trigger 'logicView:clearCoverage'
+    @$('.btn-show-coverage').removeClass('btn-primary').addClass('btn-default').prop('disabled',false)
+
+  identifyCoverage: (e) ->
+    $('.toggle-result').hide()
+    @showCoverage()
+

--- a/app/assets/stylesheets/application.css.less
+++ b/app/assets/stylesheets/application.css.less
@@ -19,6 +19,3 @@
 @import "measure_calculation";
 @import "rationale";
 @import "builder";
-
-
-

--- a/app/assets/stylesheets/measure_calculation.less
+++ b/app/assets/stylesheets/measure_calculation.less
@@ -28,6 +28,28 @@
     }
   }
 
+  .coverage-summary {
+    > * {
+      line-height: 65px;
+    }
+
+    .coverage {
+      .make-sm-column(4);
+      text-align: center;
+    }
+
+    .coverage-label {
+      .make-sm-column(4);
+      padding: 0;
+    }
+
+    .coverage-data {
+      .make-sm-column(4);
+      .pull-right;
+      padding: 0;
+    }
+  }
+
   .patient {
     .patient-status-icon-col {
       .make-sm-column(1);

--- a/app/assets/stylesheets/mixins.less
+++ b/app/assets/stylesheets/mixins.less
@@ -28,6 +28,10 @@
   &.status-pending {
     .text-info;
   }
+  &.status-coverage {
+    font-size: 1em;
+    .text-primary;
+  }
 }
 
 .btn-danger-inverse {

--- a/app/assets/stylesheets/rationale.less
+++ b/app/assets/stylesheets/rationale.less
@@ -1,7 +1,7 @@
 // Displays colors according to patient results on the measure logic
 
 .rationale {
-  .eval-true, .eval-false, .eval-bad-specifics {
+  .eval-true, .eval-false, .eval-bad-specifics, .eval-coverage {
     font-weight: 500;
     padding: 2px;
   }
@@ -28,5 +28,9 @@
       content: @fa-var-asterisk;
       font-family: FontAwesome;
     }
+  }
+  .eval-coverage{
+    background-color: @blue-lightest;
+    color: @brand-primary;
   }
 }


### PR DESCRIPTION
#### Story
- https://www.pivotaltracker.com/story/show/65372354
#### Notes
- show coverage for all patients in default rendering on Measure view; this gets overidden when a test patient result is expanded
- when a test patient result is expanded, the coverage section shows a button to return to the coverage for all patients; when test patients are collapsed, a disabled button is rendered
- replace total coverage percentage with a jquery spinner with brand-primary color
- highlight logic view with brand-primary and lighter blue
#### Screenshots
- ![overallcoveragedefault](https://f.cloud.github.com/assets/456952/2162520/2ec2f242-94d3-11e3-97e4-4298b2c6ae88.png)
- ![overallcoverageexpanded](https://f.cloud.github.com/assets/456952/2162519/2ec012f2-94d3-11e3-8617-be2c5735d883.png)
