### PR TITLE
Update episode(s) of care during measure update

### DIFF
--- a/app/assets/javascripts/templates/import/import_measure.hbs
+++ b/app/assets/javascripts/templates/import/import_measure.hbs
@@ -66,6 +66,25 @@
               </div>
             {{/if}}
           </div>
+          {{#if isUpdate}}
+            {{#if episode_of_care}}
+              <input type="hidden" name="{{@cid}}[hqmf_id]" value="{{hqmf_id}}">
+              <div class="form-group">
+                <label for="episodeSelect_{{@cid}}" class="col-lg-3 control-label">Episode(s) of Care:</label>
+                <div class="col-lg-9">
+                  <select multiple="true" class="form-control" id="episodeSelect_{{@cid}}" name="eoc_{{hqmfSetId}}[episode_ids][]">
+                    {{#each source_data_criteria.models}}
+                      {{#with attributes}}
+                        {{#if specific_occurrence}}
+                          <option value="{{source_data_criteria}}" id="{{@cid}}">{{description}}</option>
+                        {{/if}}
+                      {{/with}}
+                    {{/each}}
+                  </select>
+                </div>
+              </div>
+            {{/if}}
+          {{/if}}
         </form>
       </div>
       <div class="modal-footer">

--- a/app/assets/javascripts/views/import_measure_view.js.coffee
+++ b/app/assets/javascripts/views/import_measure_view.js.coffee
@@ -10,17 +10,19 @@ class Thorax.Views.ImportMeasure extends Thorax.View
       else if @model.get('episode_of_care') is true then 'Episode of Care'
       else if @model.get('continuous_variable') is true then 'Continuous Variable'
     currentRoute = Backbone.history.fragment
-    titleSize: 3
-    dataSize: 9
-    token: $("meta[name='csrf-token']").attr('content')
-    dialogTitle: if @model? then @model.get('title') else "New Measure"
-    isUpdate: @model?
-    measureTypeLabel: measureTypeLabel
-    calculationTypeLabel: calculationTypeLabel
-    hqmfSetId: hqmfSetId
-    redirectRoute: currentRoute
+    _(super).extend
+      titleSize: 3
+      dataSize: 9
+      token: $("meta[name='csrf-token']").attr('content')
+      dialogTitle: if @model? then @model.get('title') else "New Measure"
+      isUpdate: @model?
+      measureTypeLabel: measureTypeLabel
+      calculationTypeLabel: calculationTypeLabel
+      hqmfSetId: hqmfSetId
+      redirectRoute: currentRoute
 
   events:
+    rendered: -> @$("option[value=\"#{eoc}\"]").attr('selected','selected') for eoc in @model.get('episode_ids') if @model? && @model.get('episode_of_care')
     'ready': 'setup'
     'change input:file':  'enableLoad'
 

--- a/app/controllers/measures_controller.rb
+++ b/app/controllers/measures_controller.rb
@@ -54,7 +54,11 @@ class MeasuresController < ApplicationController
       existing = Measure.by_user(current_user).where(hqmf_set_id: params[:hqmf_set_id]).first
       measure_details['type'] = existing.type
       measure_details['episode_of_care'] = existing.episode_of_care
-      measure_details['episode_ids'] = existing.episode_ids
+      if params["eoc_#{existing.hqmf_set_id}"]['episode_ids'] && !params["eoc_#{existing.hqmf_set_id}"]['episode_ids'].empty?
+        measure_details['episode_ids'] = params["eoc_#{existing.hqmf_set_id}"]['episode_ids']
+      else
+        measure_details['episode_ids'] = existing.episode_ids
+      end
       measure_details['population_titles'] = existing.populations.map {|p| p['title']} if existing.populations.length > 1
       existing.delete
     end


### PR DESCRIPTION
#### Story
- https://www.pivotaltracker.com/story/show/61762456
#### Notes
- Used functionality from measure loading finalization to render and allow selection to update episode(s) of care in measure update dialog
- Current episode(s) of care are selected by default when update dialog is shown
#### Screenshots
- default update for eoc measure
  - ![screen shot 2014-02-18 at 9 14 55 am](https://f.cloud.github.com/assets/456952/2195927/893122f8-98a7-11e3-9a41-0ad3c7fd6b0f.png)
- updating with new zip and different episodes of care
  - ![screen shot 2014-02-18 at 9 15 07 am](https://f.cloud.github.com/assets/456952/2195926/8930dcda-98a7-11e3-8cdc-fe3facb3f2af.png)
- default update after update
  - ![screen shot 2014-02-18 at 9 15 33 am](https://f.cloud.github.com/assets/456952/2195925/8930b7d2-98a7-11e3-9e1c-8d2529a9b16d.png)
