### PR TITLE
Allow measure populations to be collapsed

### DIFF
--- a/app/assets/javascripts/templates/logic/logic.hbs
+++ b/app/assets/javascripts/templates/logic/logic.hbs
@@ -1,4 +1,4 @@
-<div class="measure-viz rationale">
+<div class="measure-viz rationale panel-group">
   {{#each submeasurePopulations}}
     {{view "PopulationCriteriaLogic" population=this measure=../measure}}
   {{/each}}

--- a/app/assets/javascripts/templates/logic/population_criteria.hbs
+++ b/app/assets/javascripts/templates/logic/population_criteria.hbs
@@ -1,20 +1,28 @@
-
-<div class="{{population.type}}_children">
-  <div><span class="{{population.type}} rationale-target"><b>{{translate_population population.type}}: 
-</b>{{#unless rootPreconditon}}None{{/unless}}</span></div>
-  <div>
-    {{#if rootPreconditon}}
-      {{#if rootPreconditon.preconditions }}
-       {{#each rootPreconditon.preconditions}}
-        {{view "PreconditionLogic" precondition=this parentPrecondition=../rootPreconditon measure=../measure}}
-      {{/each}}
+<div class="panel panel-default {{population.type}}_children">
+  <div class="panel-heading">
+    <h4 class="panel-title panel-population">
+      <a data-toggle="collapse" href="#collapse{{cid}}">
+        <div><span class="{{population.type}} rationale-target"><b>{{translate_population population.type}}: </b></span></div>
+      </a>
+    </h4>
+  </div>
+  <div id="collapse{{cid}}" class="panel-collapse collapse">
+    <div class="panel-body">
+      {{#if rootPreconditon}}
+        {{#if rootPreconditon.preconditions }}
+         {{#each rootPreconditon.preconditions}}
+          {{view "PreconditionLogic" precondition=this parentPrecondition=../rootPreconditon measure=../measure}}
+        {{/each}}
+        {{else}}
+          <ul>
+            <li>
+              {{#if aggregator}}{{translate_aggregator aggregator}}: {{/if}} {{view "DataCriteriaLogic" reference=rootPreconditon.reference measure=../measure tag="span"}}
+            </li>
+          </ul>
+        {{/if}}
       {{else}}
-        <ul>
-          <li>
-            {{#if aggregator}}{{translate_aggregator aggregator}}: {{/if}} {{view "DataCriteriaLogic" reference=rootPreconditon.reference measure=../measure tag="span"}}
-          </li>
-        </ul>
+        None
       {{/if}}
-    {{/if}}
+    </div>
   </div>
 </div>

--- a/app/assets/javascripts/templates/logic/population_criteria.hbs
+++ b/app/assets/javascripts/templates/logic/population_criteria.hbs
@@ -2,7 +2,10 @@
   <div class="panel-heading">
     <h4 class="panel-title panel-population">
       <a data-toggle="collapse" href="#collapse{{cid}}">
-        <div><span class="{{population.type}} rationale-target"><b>{{translate_population population.type}}: </b></span></div>
+        <div>
+          <span class="{{population.type}} rationale-target"><b>{{translate_population population.type}}: </b></span>
+          <div class="pull-right"><i class="fa fa-lg fa-angle-right toggle-icon"></i></div>
+        </div> 
       </a>
     </h4>
   </div>

--- a/app/assets/javascripts/views/logic/population_criteria_logic_view.js.coffee
+++ b/app/assets/javascripts/views/logic/population_criteria_logic_view.js.coffee
@@ -1,5 +1,7 @@
 class Thorax.Views.PopulationCriteriaLogic extends Thorax.View
   template: JST['logic/population_criteria']
+  events:
+    'click .panel-population' : -> @$('.toggle-icon').toggleClass('fa-angle-right fa-angle-down')
   population_map:
     'IPP': 'Initial Patient Population'
     'DENOM': 'Denominator'
@@ -11,7 +13,6 @@ class Thorax.Views.PopulationCriteriaLogic extends Thorax.View
   aggregator_map:
     'MEAN':'Mean of'
     'MEDIAN':'Median of'
-
 
   initialize: ->
     @rootPreconditon = @population.preconditions[0] if @population.preconditions?.length > 0

--- a/app/assets/javascripts/views/logic/population_logic_view.js.coffee
+++ b/app/assets/javascripts/views/logic/population_logic_view.js.coffee
@@ -45,6 +45,7 @@ class Thorax.Views.PopulationLogic extends Thorax.View
             target = @$(".#{code}_children .#{key}")
             if (target.length > 0)
               target.addClass(if updatedRationale[code]?[key] is false then 'eval-bad-specifics' else "eval-#{!!value}")
+              target.closest('.panel-heading').addClass(if updatedRationale[code]?[key] is false then 'eval-panel-bad-specifics' else "eval-panel-#{!!value}")
 
   highlightPatientData: (dataCriteriaKey, populationCriteriaKey) ->
     if @latestResult?.get('finalSpecifics')?[populationCriteriaKey]
@@ -66,6 +67,7 @@ class Thorax.Views.PopulationLogic extends Thorax.View
 
   clearRationale: ->
     @$('.rationale .rationale-target').removeClass('eval-false eval-true eval-bad-specifics')
+    @$('.rationale .panel-heading').removeClass('eval-panel-false eval-panel-true eval-panel-bad-specifics')
 
   showCoverage: ->
     @clearRationale()

--- a/app/assets/stylesheets/builder.less
+++ b/app/assets/stylesheets/builder.less
@@ -132,6 +132,11 @@
       }
 
     }
+    .panel-population {
+      background-color: inherit;
+      color: inherit;
+      padding: 0;
+    }
   }
 
 

--- a/app/assets/stylesheets/rationale.less
+++ b/app/assets/stylesheets/rationale.less
@@ -33,4 +33,21 @@
     background-color: @blue-lightest;
     color: @brand-primary;
   }
+  .panel {
+    padding: 5px 0;
+    .panel-heading {
+      background-color: white;
+      border: 1px solid gray;
+      padding: 10px 15px;
+    }
+    .eval-panel-true {
+      background-color: @state-success-bg;
+    }
+    .eval-panel-false {
+      background-color: @state-danger-bg;
+    }
+    .eval-panel-bad-specifics {
+      background-color: @state-danger-bg;
+    }
+  }
 }


### PR DESCRIPTION
#### Story
- https://www.pivotaltracker.com/story/show/65923730
#### Notes
- switched <code>logicView</code> to panels with Bootstrap collapse support and integrated styling
- this does **not** use accordion-based collapsing, so individual panels can be opened/collapsed as desired
#### Screenshots
- default measure view, collapsed
  - ![screen shot 2014-02-19 at 12 51 28 pm](https://f.cloud.github.com/assets/456952/2209649/9b14a7e6-998e-11e3-845b-e30a47b0ccb4.png)
- measure view, expanded
  - ![screen shot 2014-02-19 at 12 51 36 pm](https://f.cloud.github.com/assets/456952/2209650/9b14ff66-998e-11e3-9bf3-3f5ab42d7fa9.png)
- measure view, expanded, rationale-highlighted
  - ![screen shot 2014-02-19 at 12 51 47 pm](https://f.cloud.github.com/assets/456952/2209648/9b1488d8-998e-11e3-8915-0e69002c44f6.png)
- patient builder view, expanded
  - ![screen shot 2014-02-19 at 12 52 05 pm](https://f.cloud.github.com/assets/456952/2209647/9b146cf4-998e-11e3-89c2-96707ad8f88e.png)
