### PR TITLE
Fix specific occurrences rationale highlighting

### DIFF
--- a/app/assets/javascripts/models/measure.js.coffee
+++ b/app/assets/javascripts/models/measure.js.coffee
@@ -11,7 +11,8 @@ class Thorax.Models.Measure extends Thorax.Model
       # copy population criteria data to population
       for code in @constructor.allPopulationCodes
         if populationCriteriaKey = population[code]
-          population[code] = attrs.population_criteria[populationCriteriaKey]
+          # preserve the original population code for specifics rationale
+          population[code] = _(code: population[code]).extend(attrs.population_criteria[populationCriteriaKey])
       populations.add new Thorax.Models.Population(population)
     attrs.populations = populations
 

--- a/app/assets/javascripts/models/result.js.coffee
+++ b/app/assets/javascripts/models/result.js.coffee
@@ -27,7 +27,7 @@ class Thorax.Models.Result extends Thorax.Model
       if specifics = @get('finalSpecifics')?[code]
         updatedRationale[code] ||= {} # FIXME why '||=' instead of '=' ?
         # get the referenced occurrences in the logic tree using original population code
-        occurrences = @population.getDataCriteriaKeys(@measure.get('population_criteria')[@population.get(code).code])
+        occurrences = @population.getDataCriteriaKeys(@measure.get('population_criteria')[@population.get(code)?.code])
         # get the good and bad specifics
         occurrenceResults = @checkSpecificsForRationale(specifics, occurrences, @measure.get('data_criteria'))
         parentMap = @buildParentMap(@measure.get('population_criteria')[code])

--- a/app/assets/javascripts/models/result.js.coffee
+++ b/app/assets/javascripts/models/result.js.coffee
@@ -26,8 +26,8 @@ class Thorax.Models.Result extends Thorax.Model
     for code in Thorax.Models.Measure.allPopulationCodes
       if specifics = @get('finalSpecifics')?[code]
         updatedRationale[code] ||= {} # FIXME why '||=' instead of '=' ?
-        # get the referenced occurrences in the logic tree
-        occurrences = @population.getDataCriteriaKeys(@measure.get('population_criteria')[code])
+        # get the referenced occurrences in the logic tree using original population code
+        occurrences = @population.getDataCriteriaKeys(@measure.get('population_criteria')[@population.get(code).code])
         # get the good and bad specifics
         occurrenceResults = @checkSpecificsForRationale(specifics, occurrences, @measure.get('data_criteria'))
         parentMap = @buildParentMap(@measure.get('population_criteria')[code])

--- a/app/assets/javascripts/views/population_calculation_view.js.coffee
+++ b/app/assets/javascripts/views/population_calculation_view.js.coffee
@@ -28,7 +28,7 @@ class Thorax.Views.PopulationCalculation extends Thorax.View
     @initialize()
     @render() # FIXME: we'd prefer not to explicitly render(), prefer to use a layout view or similar
     @trigger 'rationale:clear'
-    if selectedResult? && selectedResult.get('done')? == true
+    if selectedResult? && selectedResult.isPopulated()
       @$(".toggle-result-#{selectedResult.patient.id}").show()
       @trigger 'rationale:show', selectedResult
     else @coverageView.showCoverage()

--- a/app/assets/javascripts/views/population_calculation_view.js.coffee
+++ b/app/assets/javascripts/views/population_calculation_view.js.coffee
@@ -30,7 +30,8 @@ class Thorax.Views.PopulationCalculation extends Thorax.View
     @trigger 'rationale:clear'
     if selectedResult? && selectedResult.isPopulated()
       @$(".toggle-result-#{selectedResult.patient.id}").show()
-      @trigger 'rationale:show', selectedResult
+      @trigger 'rationale:show', @$(".toggle-result-#{selectedResult.patient.id}").model().result
+      @$(".expand-result-icon-#{selectedResult.patient.id}").removeClass('fa-angle-right').addClass('fa-angle-down')
     else @coverageView.showCoverage()
 
   showDelete: (e) ->


### PR DESCRIPTION
#### Stories
- https://www.pivotaltracker.com/story/show/65112412
- https://www.pivotaltracker.com/story/show/65988280
#### Notes
- issues included misbehaving highlighting when switching between populations, and incorrect specific occurrence evaluations when applying rationale highlighting
- resolved misbehavior by passing updated result model to <code>logicView</code>
- resolved incorrect specific occurrence evaluations by preserving original population code (e.g., <code>IPP_1</code>, <code>NUMER_1</code>, etc.) in population model when parsing measure attrs
- resolved population switching incorrectly rendering toggle-icon on result in <code>populationCalculation</code> view
#### Screenshots
- **before** branch fixes
  - expand result
    - ![screen shot 2014-02-20 at 12 12 44 pm](https://f.cloud.github.com/assets/456952/2220845/52952f6c-9a52-11e3-87be-386e1fccab39.png)
  - switch population
    - ![screen shot 2014-02-20 at 12 12 58 pm](https://f.cloud.github.com/assets/456952/2220847/52993ee0-9a52-11e3-87b1-df28a55cf332.png)
  - trigger highlighting 
    - ![screen shot 2014-02-20 at 12 13 15 pm](https://f.cloud.github.com/assets/456952/2220846/529939c2-9a52-11e3-8e8e-01f0b5c01353.png)
- **after** branch fixes
  - 1st pop
    - ![screen shot 2014-02-20 at 12 10 45 pm](https://f.cloud.github.com/assets/456952/2220820/0191f80c-9a52-11e3-8116-28de6bde75b3.png)
  - 2nd pop
    - ![screen shot 2014-02-20 at 12 10 53 pm](https://f.cloud.github.com/assets/456952/2220819/01919678-9a52-11e3-9464-cc0c53f5ffa2.png)
