### PR TITLE
Fix null end_date toggling on patient builder's data criteria

### DIFF
--- a/app/assets/javascripts/views/patient_builder/data_criteria.js.coffee
+++ b/app/assets/javascripts/views/patient_builder/data_criteria.js.coffee
@@ -118,6 +118,10 @@ class Thorax.Views.EditCriteriaView extends Thorax.Views.BuilderChildView
     $cb = $(e.target)
     $endDateTime = @$('input[name=end_date], input[name=end_time]')
     $endDateTime.val('') if $cb.is(':checked')
+    unless $cb.is(':checked') # set default date to 8:00am, current day
+      @$('input[name=end_date]').datepicker('setDate', new Date())
+      @$('input[name=end_date]').datepicker('update')
+      @$('input[name=end_time]').timepicker('setTime','8:00 AM')
     $endDateTime.prop 'disabled', $cb.is(':checked')
     @triggerMaterialize()
 


### PR DESCRIPTION
#### Story
- https://www.pivotaltracker.com/story/show/64921386
#### Notes
- on toggling <code>end_date</code> via undefined checkbox, if unchecked then set the datepicker's date to the current day (requires <code>$().datepicker('update')</code>) and the timepicker's time to 8:00AM
#### Screenshots
- set date and time to arbitrary values
  - ![screen shot 2014-02-20 at 1 28 33 pm](https://f.cloud.github.com/assets/456952/2221786/3ca43c60-9a5d-11e3-8e22-77a4938830ff.png)
- apply UNDEFINED to end date
  - ![screen shot 2014-02-20 at 1 28 39 pm](https://f.cloud.github.com/assets/456952/2221784/3ca1d4a2-9a5d-11e3-9236-3dda4aa67137.png)
- unapply UNDEFINED on end date
  - ![screen shot 2014-02-20 at 1 28 43 pm](https://f.cloud.github.com/assets/456952/2221785/3ca20c2e-9a5d-11e3-990e-f3b0cfdcddf3.png)
