### PR TITLE
Update coverage to compute for passing patients only

### DIFF
--- a/app/assets/javascripts/models/coverage.js.coffee
+++ b/app/assets/javascripts/models/coverage.js.coffee
@@ -1,16 +1,17 @@
 class Thorax.Model.Coverage extends Thorax.Model
   initialize: (attrs, options) ->
     @population = options.population
-    @results = @population.calculationResults()
+    @differences = @population.differencesFromExpected()
     @measureCriteria = @population.dataCriteriaKeys()
 
-    @listenTo @results, 'change add reset destroy remove', @update
+    @listenTo @differences, 'change add reset destroy remove', @update
     @update()
   update: ->
 
     # Find all unique criteria that evaluated true in the rationale that are also in the measure
     @rationaleCriteria = []
-    for result in (@results.select (d) -> d.isPopulated())
+    @differences.each (difference) => if difference.get('done') and difference.get('match')
+      result = difference.result
       rationale = result.updatedRationale()
       @rationaleCriteria.push(criteria) for criteria, result of rationale when result
     @rationaleCriteria = _(@rationaleCriteria).intersection(@measureCriteria)


### PR DESCRIPTION
#### Story
- https://www.pivotaltracker.com/story/show/65923094
#### Notes
- update coverage model to utilize <code>difference</code> models instead of <code>result</code> models to allow for status-based rationale coverage computation
