### PR TITLE
Still need value sets in test measure JSON for calculation code

### DIFF
--- a/spec/javascripts/fixtures/json/README
+++ b/spec/javascripts/fixtures/json/README
@@ -1,7 +1,11 @@
 Contents of measures.json were created using:
 
-  json = Measure.in(measure_id: ['0002', '0022']).to_json(except: [:map_fns, :record_ids])
+  json = Measure.in(measure_id: ['0002', '0022']).to_json(except: [:map_fns, :record_ids], methods: [:value_sets])
   File.write('measures.json', JSON.pretty_generate(JSON.parse(json)))
+
+(Note that we're including value sets in the measure JSON even though
+our client side code doesn't use it; that's because this JSON is also
+needed to generate the calculation code for the tests)
 
 Contents of patients.json were generated using:
 

--- a/spec/javascripts/fixtures/json/measures.json
+++ b/spec/javascripts/fixtures/json/measures.json
@@ -1336,7 +1336,7 @@
     },
     "title": "Appropriate Testing for Children with Pharyngitis",
     "type": "ep",
-    "updated_at": "2014-02-19T15:28:11Z",
+    "updated_at": "2014-02-26T01:47:09Z",
     "user_id": "501fdba3044a111b98000001",
     "value_set_oids": [
       "2.16.840.1.113883.3.464.1003.102.12.1011",
@@ -1350,7 +1350,6879 @@
       "2.16.840.1.113883.3.464.1003.198.12.1012",
       "2.16.840.1.113883.3.560.100.4"
     ],
-    "version": null
+    "version": null,
+    "value_sets": [
+      {
+        "_id": "521f533a0017f7454b000062",
+        "concepts": [
+          {
+            "_id": "521f533a0017f7454b000063",
+            "black_list": false,
+            "code": "2135-2",
+            "code_system": "2.16.840.1.113883.6.238",
+            "code_system_name": "CDC Race",
+            "code_system_version": null,
+            "display_name": "Hispanic or Latino",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000064",
+            "black_list": false,
+            "code": "2186-5",
+            "code_system": "2.16.840.1.113883.6.238",
+            "code_system_name": "CDC Race",
+            "code_system_version": null,
+            "display_name": "Not Hispanic or Latino",
+            "white_list": false
+          }
+        ],
+        "display_name": "Ethnicity",
+        "oid": "2.16.840.1.114222.4.11.837",
+        "version": "20121025"
+      },
+      {
+        "_id": "521f533a0017f7454b00005b",
+        "concepts": [
+          {
+            "_id": "521f533a0017f7454b00005c",
+            "black_list": false,
+            "code": "1002-5",
+            "code_system": "2.16.840.1.113883.6.238",
+            "code_system_name": "CDC Race",
+            "code_system_version": null,
+            "display_name": "American Indian or Alaska Native",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00005d",
+            "black_list": false,
+            "code": "2028-9",
+            "code_system": "2.16.840.1.113883.6.238",
+            "code_system_name": "CDC Race",
+            "code_system_version": null,
+            "display_name": "Asian",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00005e",
+            "black_list": false,
+            "code": "2054-5",
+            "code_system": "2.16.840.1.113883.6.238",
+            "code_system_name": "CDC Race",
+            "code_system_version": null,
+            "display_name": "Black or African American",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00005f",
+            "black_list": false,
+            "code": "2076-8",
+            "code_system": "2.16.840.1.113883.6.238",
+            "code_system_name": "CDC Race",
+            "code_system_version": null,
+            "display_name": "Native Hawaiian or Other Pacific Islander",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000060",
+            "black_list": false,
+            "code": "2106-3",
+            "code_system": "2.16.840.1.113883.6.238",
+            "code_system_name": "CDC Race",
+            "code_system_version": null,
+            "display_name": "White",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000061",
+            "black_list": false,
+            "code": "2131-1",
+            "code_system": "2.16.840.1.113883.6.238",
+            "code_system_name": "CDC Race",
+            "code_system_version": null,
+            "display_name": "Other Race",
+            "white_list": false
+          }
+        ],
+        "display_name": "Race",
+        "oid": "2.16.840.1.114222.4.11.836",
+        "version": "20121025"
+      },
+      {
+        "_id": "521f533a0017f7454b000065",
+        "concepts": [
+          {
+            "_id": "521f533a0017f7454b000066",
+            "black_list": false,
+            "code": "1",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "MEDICARE",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000067",
+            "black_list": false,
+            "code": "11",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Medicare (Managed Care)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000068",
+            "black_list": false,
+            "code": "111",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Medicare HMO",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000069",
+            "black_list": false,
+            "code": "112",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Medicare PPO",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00006a",
+            "black_list": false,
+            "code": "113",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Medicare POS",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00006b",
+            "black_list": false,
+            "code": "119",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Medicare Managed Care Other",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00006c",
+            "black_list": false,
+            "code": "12",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Medicare (Non-managed Care)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00006d",
+            "black_list": false,
+            "code": "121",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Medicare FFS",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00006e",
+            "black_list": false,
+            "code": "122",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Medicare Drug Benefit",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00006f",
+            "black_list": false,
+            "code": "123",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Medicare Medical Savings Account (MSA)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000070",
+            "black_list": false,
+            "code": "129",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Medicare Non-managed Care Other",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000071",
+            "black_list": false,
+            "code": "19",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Medicare Other",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000072",
+            "black_list": false,
+            "code": "2",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "MEDICAID",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000073",
+            "black_list": false,
+            "code": "21",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Medicaid (Managed Care)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000074",
+            "black_list": false,
+            "code": "211",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Medicaid HMO",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000075",
+            "black_list": false,
+            "code": "212",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Medicaid PPO",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000076",
+            "black_list": false,
+            "code": "213",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Medicaid PCCM (Primary Care Case Management)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000077",
+            "black_list": false,
+            "code": "219",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Medicaid Managed Care Other",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000078",
+            "black_list": false,
+            "code": "22",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Medicaid (Non-managed Care Plan)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000079",
+            "black_list": false,
+            "code": "23",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Medicaid/SCHIP",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00007a",
+            "black_list": false,
+            "code": "24",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Medicaid Applicant",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00007b",
+            "black_list": false,
+            "code": "25",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Medicaid - Out of State",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00007c",
+            "black_list": false,
+            "code": "29",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Medicaid Other",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00007d",
+            "black_list": false,
+            "code": "3",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "OTHER GOVERNMENT (Federal/State/Local) (excluding Department of Corrections)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00007e",
+            "black_list": false,
+            "code": "31",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Department of Defense",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00007f",
+            "black_list": false,
+            "code": "311",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "TRICARE (CHAMPUS)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000080",
+            "black_list": false,
+            "code": "3111",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "TRICARE Prime-HMO",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000081",
+            "black_list": false,
+            "code": "3112",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "TRICARE Extra-PPO",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000082",
+            "black_list": false,
+            "code": "3113",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "TRICARE Standard - Fee For Service",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000083",
+            "black_list": false,
+            "code": "3114",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "TRICARE For Life--Medicare Supplement",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000084",
+            "black_list": false,
+            "code": "3115",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "TRICARE Reserve Select",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000085",
+            "black_list": false,
+            "code": "3116",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Uniformed Services Family Health Plan (USFHP) -- HMO",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000086",
+            "black_list": false,
+            "code": "3119",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Department of Defense - (other)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000087",
+            "black_list": false,
+            "code": "312",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Military Treatment Facility",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000088",
+            "black_list": false,
+            "code": "3121",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Enrolled Prime-HMO",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000089",
+            "black_list": false,
+            "code": "3122",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Non-enrolled Space Available",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00008a",
+            "black_list": false,
+            "code": "3123",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "TRICARE For Life (TFL)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00008b",
+            "black_list": false,
+            "code": "313",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Dental --Stand Alone",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00008c",
+            "black_list": false,
+            "code": "32",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Department of Veterans Affairs",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00008d",
+            "black_list": false,
+            "code": "321",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Veteran care--Care provided to Veterans",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00008e",
+            "black_list": false,
+            "code": "3211",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Direct Care--Care provided in VA facilities",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00008f",
+            "black_list": false,
+            "code": "3212",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Indirect Care--Care provided outside VA facilities",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000090",
+            "black_list": false,
+            "code": "32121",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Fee Basis",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000091",
+            "black_list": false,
+            "code": "32122",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Foreign Fee/Foreign Medical Program(FMP)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000092",
+            "black_list": false,
+            "code": "32123",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Contract Nursing Home/Community Nursing Home",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000093",
+            "black_list": false,
+            "code": "32124",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "State Veterans Home",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000094",
+            "black_list": false,
+            "code": "32125",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Sharing Agreements",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000095",
+            "black_list": false,
+            "code": "32126",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Other Federal Agency",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000096",
+            "black_list": false,
+            "code": "322",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Non-veteran care",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000097",
+            "black_list": false,
+            "code": "3221",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Civilian Health and Medical Program for the VA (CHAMPVA)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000098",
+            "black_list": false,
+            "code": "3222",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Spina Bifida Health Care Program (SB)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000099",
+            "black_list": false,
+            "code": "3223",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Children of Women Vietnam Veterans (CWVV)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00009a",
+            "black_list": false,
+            "code": "3229",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Other non-veteran care",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00009b",
+            "black_list": false,
+            "code": "33",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Indian Health Service or Tribe",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00009c",
+            "black_list": false,
+            "code": "331",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Indian Health Service - Regular",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00009d",
+            "black_list": false,
+            "code": "332",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Indian Health Service - Contract",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00009e",
+            "black_list": false,
+            "code": "333",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Indian Health Service - Managed Care",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00009f",
+            "black_list": false,
+            "code": "334",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Indian Tribe - Sponsored Coverage",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000a0",
+            "black_list": false,
+            "code": "34",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "HRSA Program",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000a1",
+            "black_list": false,
+            "code": "341",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Title V (MCH Block Grant)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000a2",
+            "black_list": false,
+            "code": "342",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Migrant Health Program",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000a3",
+            "black_list": false,
+            "code": "343",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Ryan White Act",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000a4",
+            "black_list": false,
+            "code": "349",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Other",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000a5",
+            "black_list": false,
+            "code": "35",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Black Lung",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000a6",
+            "black_list": false,
+            "code": "36",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "State Government",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000a7",
+            "black_list": false,
+            "code": "361",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "State SCHIP program (codes for individual states)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000a8",
+            "black_list": false,
+            "code": "362",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Specific state programs (list/ local code)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000a9",
+            "black_list": false,
+            "code": "369",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "State, not otherwise specified (other state)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000aa",
+            "black_list": false,
+            "code": "37",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Local Government",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000ab",
+            "black_list": false,
+            "code": "371",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Local - Managed care",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000ac",
+            "black_list": false,
+            "code": "3711",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "HMO",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000ad",
+            "black_list": false,
+            "code": "3712",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "PPO",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000ae",
+            "black_list": false,
+            "code": "3713",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "POS",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000af",
+            "black_list": false,
+            "code": "372",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "FFS/Indemnity",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000b0",
+            "black_list": false,
+            "code": "379",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Local, not otherwise specified (other local, county)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000b1",
+            "black_list": false,
+            "code": "38",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Other Government (Federal, State, Local not specified)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000b2",
+            "black_list": false,
+            "code": "381",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Federal, State, Local not specified managed care",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000b3",
+            "black_list": false,
+            "code": "3811",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Federal, State, Local not specified - HMO",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000b4",
+            "black_list": false,
+            "code": "3812",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Federal, State, Local not specified - PPO",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000b5",
+            "black_list": false,
+            "code": "3813",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Federal, State, Local not specified - POS",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000b6",
+            "black_list": false,
+            "code": "3819",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Federal, State, Local not specified - not specified managed care",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000b7",
+            "black_list": false,
+            "code": "382",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Federal, State, Local not specified - FFS",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000b8",
+            "black_list": false,
+            "code": "389",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Federal, State, Local not specified - Other",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000b9",
+            "black_list": false,
+            "code": "39",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Other Federal",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000ba",
+            "black_list": false,
+            "code": "4",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "DEPARTMENTS OF CORRECTIONS",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000bb",
+            "black_list": false,
+            "code": "41",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Corrections Federal",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000bc",
+            "black_list": false,
+            "code": "42",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Corrections State",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000bd",
+            "black_list": false,
+            "code": "43",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Corrections Local",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000be",
+            "black_list": false,
+            "code": "44",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Corrections Unknown Level",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000bf",
+            "black_list": false,
+            "code": "5",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "PRIVATE HEALTH INSURANCE",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000c0",
+            "black_list": false,
+            "code": "51",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Managed Care (Private)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000c1",
+            "black_list": false,
+            "code": "511",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Commercial Managed Care - HMO",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000c2",
+            "black_list": false,
+            "code": "512",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Commercial Managed Care - PPO",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000c3",
+            "black_list": false,
+            "code": "513",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Commercial Managed Care - POS",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000c4",
+            "black_list": false,
+            "code": "514",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Exclusive Provider Organization",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000c5",
+            "black_list": false,
+            "code": "515",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Gatekeeper PPO (GPPO)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000c6",
+            "black_list": false,
+            "code": "519",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Managed Care, Other (non HMO)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000c7",
+            "black_list": false,
+            "code": "52",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Private Health Insurance - Indemnity",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000c8",
+            "black_list": false,
+            "code": "521",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Commercial Indemnity",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000c9",
+            "black_list": false,
+            "code": "522",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Self-insured (ERISA) Administrative Services Only (ASO) plan",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000ca",
+            "black_list": false,
+            "code": "523",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Medicare supplemental policy (as second payer)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000cb",
+            "black_list": false,
+            "code": "529",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Private health insurance-other commercial Indemnity",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000cc",
+            "black_list": false,
+            "code": "53",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Managed Care (private) or private health insurance (indemnity), not otherwise specified",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000cd",
+            "black_list": false,
+            "code": "54",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Organized Delivery System",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000ce",
+            "black_list": false,
+            "code": "55",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Small Employer Purchasing Group",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000cf",
+            "black_list": false,
+            "code": "59",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Other Private Insurance",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000d0",
+            "black_list": false,
+            "code": "6",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "BLUE CROSS/BLUE SHIELD",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000d1",
+            "black_list": false,
+            "code": "61",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "BC Managed Care",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000d2",
+            "black_list": false,
+            "code": "611",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "BC Managed Care - HMO",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000d3",
+            "black_list": false,
+            "code": "612",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "BC Managed Care - PPO",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000d4",
+            "black_list": false,
+            "code": "613",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "BC Managed Care - POS",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000d5",
+            "black_list": false,
+            "code": "619",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "BC Managed Care - Other",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000d6",
+            "black_list": false,
+            "code": "62",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "BC Indemnity",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000d7",
+            "black_list": false,
+            "code": "63",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "BC (Indemnity or Managed Care) - Out of State",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000d8",
+            "black_list": false,
+            "code": "64",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "BC (Indemnity or Managed Care) - Unspecified",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000d9",
+            "black_list": false,
+            "code": "69",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "BC (Indemnity or Managed Care) - Other",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000da",
+            "black_list": false,
+            "code": "7",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "MANAGED CARE, UNSPECIFIED (to be used only if one can't distinguish public from private)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000db",
+            "black_list": false,
+            "code": "71",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "HMO",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000dc",
+            "black_list": false,
+            "code": "72",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "PPO",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000dd",
+            "black_list": false,
+            "code": "73",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "POS",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000de",
+            "black_list": false,
+            "code": "79",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Other Managed Care, Unknown if public or private",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000df",
+            "black_list": false,
+            "code": "8",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "NO PAYMENT from an Organization/Agency/Program/Private Payer Listed",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000e0",
+            "black_list": false,
+            "code": "81",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Self-pay",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000e1",
+            "black_list": false,
+            "code": "82",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "No Charge",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000e2",
+            "black_list": false,
+            "code": "821",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Charity",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000e3",
+            "black_list": false,
+            "code": "822",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Professional Courtesy",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000e4",
+            "black_list": false,
+            "code": "823",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Research/Clinical Trial",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000e5",
+            "black_list": false,
+            "code": "83",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Refusal to Pay/Bad Debt",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000e6",
+            "black_list": false,
+            "code": "84",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Hill Burton Free Care",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000e7",
+            "black_list": false,
+            "code": "85",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Research/Donor",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000e8",
+            "black_list": false,
+            "code": "89",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "No Payment, Other",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000e9",
+            "black_list": false,
+            "code": "9",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "MISCELLANEOUS/OTHER",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000ea",
+            "black_list": false,
+            "code": "91",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Foreign National",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000eb",
+            "black_list": false,
+            "code": "92",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Other (Non-government)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000ec",
+            "black_list": false,
+            "code": "93",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Disability Insurance",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000ed",
+            "black_list": false,
+            "code": "94",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Long-term Care Insurance",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000ee",
+            "black_list": false,
+            "code": "95",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Worker's Compensation",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000ef",
+            "black_list": false,
+            "code": "951",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Worker's Comp HMO",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000f0",
+            "black_list": false,
+            "code": "953",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Worker's Comp Fee-for-Service",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000f1",
+            "black_list": false,
+            "code": "954",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Worker's Comp Other Managed Care",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000f2",
+            "black_list": false,
+            "code": "959",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Worker's Comp, Other unspecified",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000f3",
+            "black_list": false,
+            "code": "96",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Auto Insurance (no fault)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000f4",
+            "black_list": false,
+            "code": "98",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Other specified (includes Hospice - Unspecified plan)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000f5",
+            "black_list": false,
+            "code": "99",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "No Typology Code available for payment source",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000f6",
+            "black_list": false,
+            "code": "9999",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Unavailable / Unknown",
+            "white_list": false
+          }
+        ],
+        "display_name": "Payer",
+        "oid": "2.16.840.1.114222.4.11.3591",
+        "version": "20121025"
+      },
+      {
+        "_id": "521f533b0017f7454b0002b0",
+        "concepts": [
+          {
+            "_id": "521f533b0017f7454b0002b1",
+            "black_list": false,
+            "code": "21112-8",
+            "code_system": "2.16.840.1.113883.6.1",
+            "code_system_name": "LOINC",
+            "code_system_version": null,
+            "display_name": "Birth date",
+            "white_list": false
+          }
+        ],
+        "display_name": "birth date",
+        "oid": "2.16.840.1.113883.3.560.100.4",
+        "version": "20130401"
+      },
+      {
+        "_id": "521f533b0017f7454b0002a2",
+        "concepts": [
+          {
+            "_id": "521f533b0017f7454b0002a3",
+            "black_list": false,
+            "code": "11268-0",
+            "code_system": "2.16.840.1.113883.6.1",
+            "code_system_name": "LOINC",
+            "code_system_version": null,
+            "display_name": "Streptococcus pyogenes [Presence] in Throat by Organism specific culture",
+            "white_list": false
+          },
+          {
+            "_id": "521f533b0017f7454b0002a4",
+            "black_list": false,
+            "code": "17656-0",
+            "code_system": "2.16.840.1.113883.6.1",
+            "code_system_name": "LOINC",
+            "code_system_version": null,
+            "display_name": "Streptococcus pyogenes [Presence] in Unspecified specimen by Organism specific culture",
+            "white_list": false
+          },
+          {
+            "_id": "521f533b0017f7454b0002a5",
+            "black_list": false,
+            "code": "18481-2",
+            "code_system": "2.16.840.1.113883.6.1",
+            "code_system_name": "LOINC",
+            "code_system_version": null,
+            "display_name": "Streptococcus pyogenes Ag [Presence] in Throat",
+            "white_list": false
+          },
+          {
+            "_id": "521f533b0017f7454b0002a6",
+            "black_list": false,
+            "code": "31971-5",
+            "code_system": "2.16.840.1.113883.6.1",
+            "code_system_name": "LOINC",
+            "code_system_version": null,
+            "display_name": "Streptococcus pyogenes Ag [Presence] in Unspecified specimen",
+            "white_list": false
+          },
+          {
+            "_id": "521f533b0017f7454b0002a7",
+            "black_list": false,
+            "code": "49610-9",
+            "code_system": "2.16.840.1.113883.6.1",
+            "code_system_name": "LOINC",
+            "code_system_version": null,
+            "display_name": "Streptococcus pyogenes DNA [Identifier] in Unspecified specimen by Probe and target amplification method",
+            "white_list": false
+          },
+          {
+            "_id": "521f533b0017f7454b0002a8",
+            "black_list": false,
+            "code": "5036-9",
+            "code_system": "2.16.840.1.113883.6.1",
+            "code_system_name": "LOINC",
+            "code_system_version": null,
+            "display_name": "Streptococcus pyogenes rRNA [Presence] in Unspecified specimen by DNA probe",
+            "white_list": false
+          },
+          {
+            "_id": "521f533b0017f7454b0002a9",
+            "black_list": false,
+            "code": "60489-2",
+            "code_system": "2.16.840.1.113883.6.1",
+            "code_system_name": "LOINC",
+            "code_system_version": null,
+            "display_name": "Streptococcus pyogenes DNA [Presence] in Throat by Probe and target amplification method",
+            "white_list": false
+          },
+          {
+            "_id": "521f533b0017f7454b0002aa",
+            "black_list": false,
+            "code": "626-2",
+            "code_system": "2.16.840.1.113883.6.1",
+            "code_system_name": "LOINC",
+            "code_system_version": null,
+            "display_name": "Bacteria identified in Throat by Culture",
+            "white_list": false
+          },
+          {
+            "_id": "521f533b0017f7454b0002ab",
+            "black_list": false,
+            "code": "6556-5",
+            "code_system": "2.16.840.1.113883.6.1",
+            "code_system_name": "LOINC",
+            "code_system_version": null,
+            "display_name": "Streptococcus pyogenes Ag [Presence] in Throat by Immunoassay",
+            "white_list": false
+          },
+          {
+            "_id": "521f533b0017f7454b0002ac",
+            "black_list": false,
+            "code": "6557-3",
+            "code_system": "2.16.840.1.113883.6.1",
+            "code_system_name": "LOINC",
+            "code_system_version": null,
+            "display_name": "Streptococcus pyogenes Ag [Presence] in Throat by Immunofluorescence",
+            "white_list": false
+          },
+          {
+            "_id": "521f533b0017f7454b0002ad",
+            "black_list": false,
+            "code": "6558-1",
+            "code_system": "2.16.840.1.113883.6.1",
+            "code_system_name": "LOINC",
+            "code_system_version": null,
+            "display_name": "Streptococcus pyogenes Ag [Presence] in Unspecified specimen by Immunoassay",
+            "white_list": false
+          },
+          {
+            "_id": "521f533b0017f7454b0002ae",
+            "black_list": false,
+            "code": "6559-9",
+            "code_system": "2.16.840.1.113883.6.1",
+            "code_system_name": "LOINC",
+            "code_system_version": null,
+            "display_name": "Streptococcus pyogenes Ag [Presence] in Unspecified specimen by Immunofluorescence",
+            "white_list": false
+          },
+          {
+            "_id": "521f533b0017f7454b0002af",
+            "black_list": false,
+            "code": "68954-7",
+            "code_system": "2.16.840.1.113883.6.1",
+            "code_system_name": "LOINC",
+            "code_system_version": null,
+            "display_name": "Streptococcus pyogenes rRNA [Presence] in Throat by DNA probe",
+            "white_list": false
+          }
+        ],
+        "display_name": "Group A Streptococcus Test",
+        "oid": "2.16.840.1.113883.3.464.1003.198.12.1012",
+        "version": "20130614"
+      },
+      {
+        "_id": "521f533a0017f7454b0000f7",
+        "concepts": [
+          {
+            "_id": "521f533a0017f7454b0000f8",
+            "black_list": false,
+            "code": "1013659",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "24 HR Minocycline 105 MG Extended Release Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000f9",
+            "black_list": false,
+            "code": "1013662",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "24 HR Minocycline 55 MG Extended Release Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000fa",
+            "black_list": false,
+            "code": "1013665",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "24 HR Minocycline 80 MG Extended Release Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000fb",
+            "black_list": false,
+            "code": "1043022",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Cefixime 100 MG Chewable Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000fc",
+            "black_list": false,
+            "code": "1043027",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Cefixime 150 MG Chewable Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000fd",
+            "black_list": false,
+            "code": "1043030",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Cefixime 200 MG Chewable Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000fe",
+            "black_list": false,
+            "code": "1043464",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Piperacillin 80 MG/ML / tazobactam 10 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000ff",
+            "black_list": false,
+            "code": "105152",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Amoxicillin 60 MG/ML Oral Suspension",
+            "white_list": true
+          },
+          {
+            "_id": "521f533a0017f7454b000100",
+            "black_list": false,
+            "code": "105170",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Cefadroxil 25 MG/ML Oral Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000101",
+            "black_list": false,
+            "code": "105171",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Cefadroxil 100 MG/ML Oral Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000102",
+            "black_list": false,
+            "code": "108449",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Trimethoprim 10 MG/ML Oral Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000103",
+            "black_list": false,
+            "code": "1113012",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "{100 (24 HR Clarithromycin 500 MG Extended Release Tablet) } Pack",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000104",
+            "black_list": false,
+            "code": "1114491",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Ceftazidime 180 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000105",
+            "black_list": false,
+            "code": "1148107",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "{6 (Azithromycin 500 MG Oral Tablet) } Pack",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000106",
+            "black_list": false,
+            "code": "1302650",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "24 HR Minocycline 45 MG Extended Release Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000107",
+            "black_list": false,
+            "code": "1302664",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "24 HR Minocycline 90 MG Extended Release Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000108",
+            "black_list": false,
+            "code": "1302674",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "24 HR Minocycline 135 MG Extended Release Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000109",
+            "black_list": false,
+            "code": "141962",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Azithromycin 250 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00010a",
+            "black_list": false,
+            "code": "141963",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Azithromycin 40 MG/ML Oral Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00010b",
+            "black_list": false,
+            "code": "142118",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Sulfamethoxazole 100 MG / Trimethoprim 20 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00010c",
+            "black_list": false,
+            "code": "197449",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Cefaclor 500 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00010d",
+            "black_list": false,
+            "code": "197450",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Cefixime 200 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00010e",
+            "black_list": false,
+            "code": "197451",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Cefixime 400 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00010f",
+            "black_list": false,
+            "code": "197452",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "cefprozil 250 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000110",
+            "black_list": false,
+            "code": "197453",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "cefprozil 500 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000111",
+            "black_list": false,
+            "code": "197454",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Cephalexin 500 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000112",
+            "black_list": false,
+            "code": "197511",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Ciprofloxacin 250 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000113",
+            "black_list": false,
+            "code": "197512",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Ciprofloxacin 750 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000114",
+            "black_list": false,
+            "code": "197516",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Clarithromycin 250 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000115",
+            "black_list": false,
+            "code": "197517",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Clarithromycin 500 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000116",
+            "black_list": false,
+            "code": "197518",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Clindamycin 150 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000117",
+            "black_list": false,
+            "code": "197595",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Dicloxacillin 250 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000118",
+            "black_list": false,
+            "code": "197596",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Dicloxacillin 500 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000119",
+            "black_list": false,
+            "code": "197633",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Doxycycline 100 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00011a",
+            "black_list": false,
+            "code": "197650",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Erythromycin 500 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00011b",
+            "black_list": false,
+            "code": "197736",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Gentamicin Sulfate (USP) 2 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00011c",
+            "black_list": false,
+            "code": "197898",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "loracarbef 200 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00011d",
+            "black_list": false,
+            "code": "197899",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "loracarbef 400 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00011e",
+            "black_list": false,
+            "code": "197984",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Minocycline 100 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00011f",
+            "black_list": false,
+            "code": "197985",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Minocycline 50 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000120",
+            "black_list": false,
+            "code": "198044",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Norfloxacin 400 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000121",
+            "black_list": false,
+            "code": "198048",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Ofloxacin 200 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000122",
+            "black_list": false,
+            "code": "198049",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Ofloxacin 300 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000123",
+            "black_list": false,
+            "code": "198050",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Ofloxacin 400 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000124",
+            "black_list": false,
+            "code": "198201",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Rifampin 150 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000125",
+            "black_list": false,
+            "code": "198202",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Rifampin 300 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000126",
+            "black_list": false,
+            "code": "198228",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Sulfadiazine 500 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000127",
+            "black_list": false,
+            "code": "198250",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Tetracycline 250 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000128",
+            "black_list": false,
+            "code": "198252",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Tetracycline 500 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000129",
+            "black_list": false,
+            "code": "198332",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Trimethoprim 100 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00012a",
+            "black_list": false,
+            "code": "198334",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Sulfamethoxazole 400 MG / Trimethoprim 80 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00012b",
+            "black_list": false,
+            "code": "198335",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Sulfamethoxazole 800 MG / Trimethoprim 160 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00012c",
+            "black_list": false,
+            "code": "198395",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Cefotaxime 40 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00012d",
+            "black_list": false,
+            "code": "198396",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Cefotaxime 20 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00012e",
+            "black_list": false,
+            "code": "199026",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Doxycycline 100 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00012f",
+            "black_list": false,
+            "code": "199027",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Doxycycline 50 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000130",
+            "black_list": false,
+            "code": "199055",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Metronidazole 375 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000131",
+            "black_list": false,
+            "code": "199326",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Metronidazole 200 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000132",
+            "black_list": false,
+            "code": "199327",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Metronidazole 400 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000133",
+            "black_list": false,
+            "code": "199332",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Trimethoprim 300 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000134",
+            "black_list": false,
+            "code": "199370",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Ciprofloxacin 100 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000135",
+            "black_list": false,
+            "code": "199620",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Rifampin 600 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000136",
+            "black_list": false,
+            "code": "199802",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Rifampin 450 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000137",
+            "black_list": false,
+            "code": "199884",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Levofloxacin 250 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000138",
+            "black_list": false,
+            "code": "199885",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Levofloxacin 500 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000139",
+            "black_list": false,
+            "code": "199886",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Levofloxacin 5 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00013a",
+            "black_list": false,
+            "code": "199997",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "sparfloxacin 200 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00013b",
+            "black_list": false,
+            "code": "200346",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "cefdinir 300 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00013c",
+            "black_list": false,
+            "code": "204466",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Penicillin G Potassium 40000 UNT/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00013d",
+            "black_list": false,
+            "code": "204844",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Azithromycin 600 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00013e",
+            "black_list": false,
+            "code": "204871",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Ceftriaxone 350 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00013f",
+            "black_list": false,
+            "code": "204929",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Cefuroxime 15 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000140",
+            "black_list": false,
+            "code": "204931",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Cefotetan 10 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000141",
+            "black_list": false,
+            "code": "205964",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Clindamycin 150 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000142",
+            "black_list": false,
+            "code": "207362",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Minocycline 50 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000143",
+            "black_list": false,
+            "code": "207364",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Minocycline 100 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000144",
+            "black_list": false,
+            "code": "207390",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Penicillin G Potassium 20000 UNT/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000145",
+            "black_list": false,
+            "code": "207391",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Penicillin G Potassium 60000 UNT/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000146",
+            "black_list": false,
+            "code": "226633",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Ampicillin 125 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000147",
+            "black_list": false,
+            "code": "239186",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Piperacillin 200 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000148",
+            "black_list": false,
+            "code": "239189",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Nafcillin 100 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000149",
+            "black_list": false,
+            "code": "239190",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Nafcillin 250 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00014a",
+            "black_list": false,
+            "code": "239191",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Amoxicillin 50 MG/ML Oral Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00014b",
+            "black_list": false,
+            "code": "239200",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Chloramphenicol 100 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00014c",
+            "black_list": false,
+            "code": "239204",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Gentamicin Sulfate (USP) 10 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00014d",
+            "black_list": false,
+            "code": "239209",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Vancomycin 100 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00014e",
+            "black_list": false,
+            "code": "239210",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Vancomycin 50 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00014f",
+            "black_list": false,
+            "code": "239211",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Vancomycin 83.3 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000150",
+            "black_list": false,
+            "code": "239212",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Lincomycin 300 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000151",
+            "black_list": false,
+            "code": "240447",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Ceftazidime 250 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000152",
+            "black_list": false,
+            "code": "240637",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Oxacillin 40 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000153",
+            "black_list": false,
+            "code": "240639",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Ofloxacin 20 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000154",
+            "black_list": false,
+            "code": "240741",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Clarithromycin 25 MG/ML Oral Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000155",
+            "black_list": false,
+            "code": "240984",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Ampicillin 100 MG/ML / Sulbactam 50 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000156",
+            "black_list": false,
+            "code": "242800",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Ceftazidime 200 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000157",
+            "black_list": false,
+            "code": "242807",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Minocycline 10 MG/ML Oral Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000158",
+            "black_list": false,
+            "code": "242816",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Gentamicin Sulfate (USP) 1 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000159",
+            "black_list": false,
+            "code": "242825",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Tobramycin 1.2 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00015a",
+            "black_list": false,
+            "code": "245242",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Erythromycin 20 MG/ML Oral Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00015b",
+            "black_list": false,
+            "code": "246282",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Amoxicillin 100 MG/ML Oral Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00015c",
+            "black_list": false,
+            "code": "247673",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Metronidazole 500 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00015d",
+            "black_list": false,
+            "code": "248656",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Azithromycin 500 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00015e",
+            "black_list": false,
+            "code": "250347",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Chloramphenicol 500 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00015f",
+            "black_list": false,
+            "code": "250582",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Cephalexin 100 MG/ML Oral Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000160",
+            "black_list": false,
+            "code": "259290",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "dalfopristin 70 MG/ML / quinupristin 30 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000161",
+            "black_list": false,
+            "code": "259311",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "gatifloxacin 2 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000162",
+            "black_list": false,
+            "code": "283535",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Doxycycline 20 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000163",
+            "black_list": false,
+            "code": "284215",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Clindamycin 300 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000164",
+            "black_list": false,
+            "code": "308177",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Amoxicillin 125 MG Chewable Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000165",
+            "black_list": false,
+            "code": "308181",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Amoxicillin 200 MG Chewable Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000166",
+            "black_list": false,
+            "code": "308182",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Amoxicillin 250 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000167",
+            "black_list": false,
+            "code": "308188",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Amoxicillin 400 MG Chewable Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000168",
+            "black_list": false,
+            "code": "308189",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Amoxicillin 80 MG/ML Oral Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000169",
+            "black_list": false,
+            "code": "308191",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Amoxicillin 500 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00016a",
+            "black_list": false,
+            "code": "308192",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Amoxicillin 500 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00016b",
+            "black_list": false,
+            "code": "308194",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Amoxicillin 875 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00016c",
+            "black_list": false,
+            "code": "308207",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Ampicillin 125 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00016d",
+            "black_list": false,
+            "code": "308208",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Ampicillin 250 MG/ML / Sulbactam 125 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00016e",
+            "black_list": false,
+            "code": "308210",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Ampicillin 50 MG/ML Oral Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00016f",
+            "black_list": false,
+            "code": "308212",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Ampicillin 500 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000170",
+            "black_list": false,
+            "code": "308459",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Azithromycin 20 MG/ML Oral Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000171",
+            "black_list": false,
+            "code": "308460",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Azithromycin 250 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000172",
+            "black_list": false,
+            "code": "308461",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Azithromycin 100 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000173",
+            "black_list": false,
+            "code": "308466",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Aztreonam 20 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000174",
+            "black_list": false,
+            "code": "308467",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Aztreonam 333 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000175",
+            "black_list": false,
+            "code": "308468",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Aztreonam 40 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000176",
+            "black_list": false,
+            "code": "309040",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Cefaclor 37.4 MG/ML Oral Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000177",
+            "black_list": false,
+            "code": "309042",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Cefaclor 75 MG/ML Oral Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000178",
+            "black_list": false,
+            "code": "309043",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "12 HR Cefaclor 500 MG Extended Release Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000179",
+            "black_list": false,
+            "code": "309044",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Cefaclor 25 MG/ML Oral Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00017a",
+            "black_list": false,
+            "code": "309045",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Cefaclor 250 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00017b",
+            "black_list": false,
+            "code": "309047",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Cefadroxil 1000 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00017c",
+            "black_list": false,
+            "code": "309048",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Cefadroxil 50 MG/ML Oral Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00017d",
+            "black_list": false,
+            "code": "309049",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Cefadroxil 500 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00017e",
+            "black_list": false,
+            "code": "309051",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Cefazolin 10 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00017f",
+            "black_list": false,
+            "code": "309052",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Cefazolin 20 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000180",
+            "black_list": false,
+            "code": "309053",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Cefazolin 225 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000181",
+            "black_list": false,
+            "code": "309054",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "cefdinir 25 MG/ML Oral Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000182",
+            "black_list": false,
+            "code": "309055",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "cefepime 20 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000183",
+            "black_list": false,
+            "code": "309056",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "cefepime 40 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000184",
+            "black_list": false,
+            "code": "309057",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "cefepime 280 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000185",
+            "black_list": false,
+            "code": "309058",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Cefixime 20 MG/ML Oral Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000186",
+            "black_list": false,
+            "code": "309065",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Cefotaxime 200 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000187",
+            "black_list": false,
+            "code": "309066",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Cefotaxime 300 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000188",
+            "black_list": false,
+            "code": "309067",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Cefotaxime 330 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000189",
+            "black_list": false,
+            "code": "309068",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Cefotaxime 230 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00018a",
+            "black_list": false,
+            "code": "309069",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Cefotetan 100 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00018b",
+            "black_list": false,
+            "code": "309070",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Cefotetan 40 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00018c",
+            "black_list": false,
+            "code": "309071",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Cefotetan 500 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00018d",
+            "black_list": false,
+            "code": "309072",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Cefoxitin 200 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00018e",
+            "black_list": false,
+            "code": "309074",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Cefoxitin 20 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00018f",
+            "black_list": false,
+            "code": "309075",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Cefoxitin 180 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000190",
+            "black_list": false,
+            "code": "309076",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "cefpodoxime 100 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000191",
+            "black_list": false,
+            "code": "309078",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "cefpodoxime 200 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000192",
+            "black_list": false,
+            "code": "309079",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "cefpodoxime 10 MG/ML Oral Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000193",
+            "black_list": false,
+            "code": "309080",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "cefprozil 25 MG/ML Oral Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000194",
+            "black_list": false,
+            "code": "309081",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "cefprozil 50 MG/ML Oral Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000195",
+            "black_list": false,
+            "code": "309082",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Ceftazidime 20 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000196",
+            "black_list": false,
+            "code": "309083",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Ceftazidime 170 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000197",
+            "black_list": false,
+            "code": "309084",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Ceftazidime 40 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000198",
+            "black_list": false,
+            "code": "309085",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "ceftibuten 36 MG/ML Oral Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000199",
+            "black_list": false,
+            "code": "309086",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "ceftibuten 400 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00019a",
+            "black_list": false,
+            "code": "309087",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "ceftibuten 18 MG/ML Oral Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00019b",
+            "black_list": false,
+            "code": "309090",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Ceftriaxone 100 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00019c",
+            "black_list": false,
+            "code": "309091",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Ceftriaxone 20 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00019d",
+            "black_list": false,
+            "code": "309092",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Ceftriaxone 250 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00019e",
+            "black_list": false,
+            "code": "309093",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Ceftriaxone 40 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00019f",
+            "black_list": false,
+            "code": "309095",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Cefuroxime 125 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0001a0",
+            "black_list": false,
+            "code": "309096",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Cefuroxime 25 MG/ML Oral Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0001a1",
+            "black_list": false,
+            "code": "309097",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Cefuroxime 250 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0001a2",
+            "black_list": false,
+            "code": "309098",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Cefuroxime 500 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0001a3",
+            "black_list": false,
+            "code": "309099",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Cefuroxime 90 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0001a4",
+            "black_list": false,
+            "code": "309100",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Cefuroxime 30 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0001a5",
+            "black_list": false,
+            "code": "309101",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Cefuroxime 95 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0001a6",
+            "black_list": false,
+            "code": "309110",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Cephalexin 25 MG/ML Oral Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0001a7",
+            "black_list": false,
+            "code": "309111",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Cephalexin 1000 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0001a8",
+            "black_list": false,
+            "code": "309112",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Cephalexin 250 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0001a9",
+            "black_list": false,
+            "code": "309113",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Cephalexin 50 MG/ML Oral Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0001aa",
+            "black_list": false,
+            "code": "309114",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Cephalexin 500 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0001ab",
+            "black_list": false,
+            "code": "309115",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Cephalexin 250 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0001ac",
+            "black_list": false,
+            "code": "309175",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Chloramphenicol 30 MG/ML Oral Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0001ad",
+            "black_list": false,
+            "code": "309304",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Ciprofloxacin 2 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0001ae",
+            "black_list": false,
+            "code": "309308",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Ciprofloxacin 50 MG/ML Oral Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0001af",
+            "black_list": false,
+            "code": "309309",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Ciprofloxacin 500 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0001b0",
+            "black_list": false,
+            "code": "309310",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Ciprofloxacin 100 MG/ML Oral Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0001b1",
+            "black_list": false,
+            "code": "309322",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Clarithromycin 50 MG/ML Oral Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0001b2",
+            "black_list": false,
+            "code": "309329",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Clindamycin 75 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0001b3",
+            "black_list": false,
+            "code": "309335",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Clindamycin 12 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0001b4",
+            "black_list": false,
+            "code": "309336",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Clindamycin 18 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0001b5",
+            "black_list": false,
+            "code": "309339",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Clindamycin 6 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0001b6",
+            "black_list": false,
+            "code": "309860",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Dicloxacillin 125 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0001b7",
+            "black_list": false,
+            "code": "310026",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Doxycycline 10 MG/ML Oral Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0001b8",
+            "black_list": false,
+            "code": "310027",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Doxycycline 10 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0001b9",
+            "black_list": false,
+            "code": "310028",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Doxycycline 20 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0001ba",
+            "black_list": false,
+            "code": "310029",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Doxycycline 50 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0001bb",
+            "black_list": false,
+            "code": "310030",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Doxycycline 5 MG/ML Oral Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0001bc",
+            "black_list": false,
+            "code": "310151",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Erythromycin 125 MG Enteric Coated Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0001bd",
+            "black_list": false,
+            "code": "310154",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Erythromycin 250 MG Enteric Coated Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0001be",
+            "black_list": false,
+            "code": "310155",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Erythromycin 250 MG Enteric Coated Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0001bf",
+            "black_list": false,
+            "code": "310156",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Erythromycin 333 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0001c0",
+            "black_list": false,
+            "code": "310157",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Erythromycin 500 MG Enteric Coated Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0001c1",
+            "black_list": false,
+            "code": "310160",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Erythromycin Estolate 125 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0001c2",
+            "black_list": false,
+            "code": "310163",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Erythromycin 50 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0001c3",
+            "black_list": false,
+            "code": "310165",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Erythromycin Estolate 250 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0001c4",
+            "black_list": false,
+            "code": "310472",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Gentamicin Sulfate (USP) 0.6 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0001c5",
+            "black_list": false,
+            "code": "310473",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Gentamicin Sulfate (USP) 0.8 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0001c6",
+            "black_list": false,
+            "code": "310474",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Gentamicin Sulfate (USP) 0.9 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0001c7",
+            "black_list": false,
+            "code": "310475",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Gentamicin Sulfate (USP) 1.2 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0001c8",
+            "black_list": false,
+            "code": "310476",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Gentamicin Sulfate (USP) 1.4 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0001c9",
+            "black_list": false,
+            "code": "310477",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Gentamicin Sulfate (USP) 1.6 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0001ca",
+            "black_list": false,
+            "code": "311214",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Kanamycin 333 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0001cb",
+            "black_list": false,
+            "code": "311215",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Kanamycin 500 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0001cc",
+            "black_list": false,
+            "code": "311296",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Levofloxacin 750 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0001cd",
+            "black_list": false,
+            "code": "311341",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Lincomycin 250 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0001ce",
+            "black_list": false,
+            "code": "311342",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Lincomycin 500 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0001cf",
+            "black_list": false,
+            "code": "311345",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "linezolid 20 MG/ML Oral Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0001d0",
+            "black_list": false,
+            "code": "311346",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "linezolid 2 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0001d1",
+            "black_list": false,
+            "code": "311347",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "linezolid 600 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0001d2",
+            "black_list": false,
+            "code": "311364",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "lomefloxacin 400 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0001d3",
+            "black_list": false,
+            "code": "311370",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "loracarbef 20 MG/ML Oral Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0001d4",
+            "black_list": false,
+            "code": "311371",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "loracarbef 40 MG/ML Oral Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0001d5",
+            "black_list": false,
+            "code": "311681",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Metronidazole 500 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0001d6",
+            "black_list": false,
+            "code": "311683",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Metronidazole 5 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0001d7",
+            "black_list": false,
+            "code": "311787",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "moxifloxacin 400 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0001d8",
+            "black_list": false,
+            "code": "311895",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Nafcillin 20 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0001d9",
+            "black_list": false,
+            "code": "311896",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Nafcillin 40 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0001da",
+            "black_list": false,
+            "code": "311897",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Nafcillin 250 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0001db",
+            "black_list": false,
+            "code": "311898",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Nafcillin 50 MG/ML Oral Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0001dc",
+            "black_list": false,
+            "code": "311899",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Nafcillin 500 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0001dd",
+            "black_list": false,
+            "code": "311988",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Nitrofurantoin 100 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0001de",
+            "black_list": false,
+            "code": "311989",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Nitrofurantoin 5 MG/ML Oral Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0001df",
+            "black_list": false,
+            "code": "311992",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Nitrofurantoin 100 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0001e0",
+            "black_list": false,
+            "code": "311994",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Nitrofurantoin 25 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0001e1",
+            "black_list": false,
+            "code": "311995",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Nitrofurantoin 50 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0001e2",
+            "black_list": false,
+            "code": "312127",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Oxacillin 100 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0001e3",
+            "black_list": false,
+            "code": "312128",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Oxacillin 20 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0001e4",
+            "black_list": false,
+            "code": "312130",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Oxacillin 167 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0001e5",
+            "black_list": false,
+            "code": "312443",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Piperacillin 60 MG/ML / tazobactam 7.5 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0001e6",
+            "black_list": false,
+            "code": "312444",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Piperacillin 400 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0001e7",
+            "black_list": false,
+            "code": "312446",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Piperacillin 40 MG/ML / tazobactam 5 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0001e8",
+            "black_list": false,
+            "code": "312447",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Piperacillin 200 MG/ML / tazobactam 25 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0001e9",
+            "black_list": false,
+            "code": "312821",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Rifampin 60 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0001ea",
+            "black_list": false,
+            "code": "313115",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Streptomycin 400 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0001eb",
+            "black_list": false,
+            "code": "313133",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Sulfamethoxazole 1000 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0001ec",
+            "black_list": false,
+            "code": "313134",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Sulfamethoxazole 40 MG/ML / Trimethoprim 8 MG/ML Oral Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0001ed",
+            "black_list": false,
+            "code": "313135",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Sulfamethoxazole 100 MG/ML Oral Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0001ee",
+            "black_list": false,
+            "code": "313137",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Sulfamethoxazole 80 MG/ML / Trimethoprim 16 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0001ef",
+            "black_list": false,
+            "code": "313251",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Tetracycline 25 MG/ML Oral Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0001f0",
+            "black_list": false,
+            "code": "313252",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Tetracycline 250 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0001f1",
+            "black_list": false,
+            "code": "313253",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Tetracycline 250 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0001f2",
+            "black_list": false,
+            "code": "313254",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Tetracycline 500 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0001f3",
+            "black_list": false,
+            "code": "313401",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Ticarcillin 200 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0001f4",
+            "black_list": false,
+            "code": "313402",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Ticarcillin 300 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0001f5",
+            "black_list": false,
+            "code": "313416",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Tobramycin 10 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0001f6",
+            "black_list": false,
+            "code": "313570",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Vancomycin 125 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0001f7",
+            "black_list": false,
+            "code": "313571",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Vancomycin 250 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0001f8",
+            "black_list": false,
+            "code": "313572",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Vancomycin 50 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0001f9",
+            "black_list": false,
+            "code": "313574",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Vancomycin 5 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0001fa",
+            "black_list": false,
+            "code": "313797",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Amoxicillin 25 MG/ML Oral Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0001fb",
+            "black_list": false,
+            "code": "313799",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Ampicillin 25 MG/ML Oral Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0001fc",
+            "black_list": false,
+            "code": "313800",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Ampicillin 250 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0001fd",
+            "black_list": false,
+            "code": "313819",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Ampicillin 250 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0001fe",
+            "black_list": false,
+            "code": "313850",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Amoxicillin 40 MG/ML Oral Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0001ff",
+            "black_list": false,
+            "code": "313888",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Cefaclor 50 MG/ML Oral Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000200",
+            "black_list": false,
+            "code": "313890",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Ceftazidime 280 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000201",
+            "black_list": false,
+            "code": "313920",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Cefazolin 200 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000202",
+            "black_list": false,
+            "code": "313922",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "cefepime 160 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000203",
+            "black_list": false,
+            "code": "313925",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Cefotetan 20 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000204",
+            "black_list": false,
+            "code": "313926",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Cefuroxime 50 MG/ML Oral Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000205",
+            "black_list": false,
+            "code": "313929",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Cefazolin 330 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000206",
+            "black_list": false,
+            "code": "313996",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Gentamicin Sulfate (USP) 40 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000207",
+            "black_list": false,
+            "code": "314079",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "linezolid 400 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000208",
+            "black_list": false,
+            "code": "314106",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Metronidazole 250 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000209",
+            "black_list": false,
+            "code": "314108",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Minocycline 75 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00020a",
+            "black_list": false,
+            "code": "315090",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Erythromycin 333 MG Enteric Coated Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00020b",
+            "black_list": false,
+            "code": "315209",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Tobramycin 0.8 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00020c",
+            "black_list": false,
+            "code": "315219",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Sulfisoxazole 200 MG/ML Oral Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00020d",
+            "black_list": false,
+            "code": "317127",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Minocycline 20 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00020e",
+            "black_list": false,
+            "code": "318218",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Sulfadiazine 33.4 MG/ML / Sulfamerazine 33.4 MG/ML / Sulfamethazine 33.4 MG/ML Oral Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00020f",
+            "black_list": false,
+            "code": "342904",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Cefoxitin 40 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000210",
+            "black_list": false,
+            "code": "343049",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Cefotetan 400 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000211",
+            "black_list": false,
+            "code": "348719",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Tobramycin 60 MG/ML Inhalant Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000212",
+            "black_list": false,
+            "code": "348869",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Doxycycline 100 MG Enteric Coated Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000213",
+            "black_list": false,
+            "code": "348870",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Doxycycline 75 MG Enteric Coated Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000214",
+            "black_list": false,
+            "code": "351121",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Minocycline 1 MG Oral Powder",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000215",
+            "black_list": false,
+            "code": "351127",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "cefditoren pivoxil 200 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000216",
+            "black_list": false,
+            "code": "351156",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "moxifloxacin 1.6 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000217",
+            "black_list": false,
+            "code": "351239",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Clavulanate 1 MG/ML / Ticarcillin 30 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000218",
+            "black_list": false,
+            "code": "359383",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "24 HR Ciprofloxacin 500 MG Extended Release Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000219",
+            "black_list": false,
+            "code": "359385",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "24 HR Clarithromycin 500 MG Extended Release Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00021a",
+            "black_list": false,
+            "code": "359465",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Doxycycline 75 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00021b",
+            "black_list": false,
+            "code": "388510",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "telithromycin 400 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00021c",
+            "black_list": false,
+            "code": "389025",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Ceftazidime 10 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00021d",
+            "black_list": false,
+            "code": "403840",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Minocycline 75 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00021e",
+            "black_list": false,
+            "code": "403920",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Daptomycin 50 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00021f",
+            "black_list": false,
+            "code": "403921",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "24 HR Ciprofloxacin 1000 MG Extended Release Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000220",
+            "black_list": false,
+            "code": "403945",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Amoxicillin 20 MG/ML Oral Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000221",
+            "black_list": false,
+            "code": "406524",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Doxycycline 75 MG Enteric Coated Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000222",
+            "black_list": false,
+            "code": "406696",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Cephalexin 125 MG Disintegrating Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000223",
+            "black_list": false,
+            "code": "413716",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Sulfisoxazole 400 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000224",
+            "black_list": false,
+            "code": "415059",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Gentamicin Sulfate (USP) 50 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000225",
+            "black_list": false,
+            "code": "415868",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Vancomycin 3 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000226",
+            "black_list": false,
+            "code": "415869",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Vancomycin 4 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000227",
+            "black_list": false,
+            "code": "419849",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Cefixime 40 MG/ML Oral Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000228",
+            "black_list": false,
+            "code": "434018",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Doxycycline 100 MG Enteric Coated Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000229",
+            "black_list": false,
+            "code": "476193",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Cephalexin 250 MG Disintegrating Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00022a",
+            "black_list": false,
+            "code": "476299",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Amoxicillin trihydrate 600 MG Disintegrating Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00022b",
+            "black_list": false,
+            "code": "476322",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Cefaclor 125 MG Chewable Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00022c",
+            "black_list": false,
+            "code": "476325",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Cefaclor 187 MG Chewable Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00022d",
+            "black_list": false,
+            "code": "476327",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Cefaclor 250 MG Chewable Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00022e",
+            "black_list": false,
+            "code": "476576",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "cefdinir 50 MG/ML Oral Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00022f",
+            "black_list": false,
+            "code": "476623",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Cefaclor 375 MG Chewable Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000230",
+            "black_list": false,
+            "code": "477391",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Levofloxacin 25 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000231",
+            "black_list": false,
+            "code": "486912",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Erythromycin Estolate 500 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000232",
+            "black_list": false,
+            "code": "487129",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Erythromycin Estolate 100 MG/ML Oral Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000233",
+            "black_list": false,
+            "code": "562058",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Cefoxitin 95 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000234",
+            "black_list": false,
+            "code": "562251",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Amoxicillin 250 MG / Clavulanate 125 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000235",
+            "black_list": false,
+            "code": "562253",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Amoxicillin 125 MG / Clavulanate 31.2 MG Chewable Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000236",
+            "black_list": false,
+            "code": "562266",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Clindamycin 15 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000237",
+            "black_list": false,
+            "code": "562508",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Amoxicillin 875 MG / Clavulanate 125 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000238",
+            "black_list": false,
+            "code": "562707",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Trimethoprim 10 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000239",
+            "black_list": false,
+            "code": "577378",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Azithromycin 33.3 MG/ML Extended Release Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00023a",
+            "black_list": false,
+            "code": "597194",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Erythromycin Estolate 50 MG/ML Oral Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00023b",
+            "black_list": false,
+            "code": "597298",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "erythromycin lactobionate 50 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00023c",
+            "black_list": false,
+            "code": "597455",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Clarithromycin 1000 MG Extended Release Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00023d",
+            "black_list": false,
+            "code": "597761",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "telithromycin 300 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00023e",
+            "black_list": false,
+            "code": "597808",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Doxycycline 150 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00023f",
+            "black_list": false,
+            "code": "597823",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Tobramycin 40 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000240",
+            "black_list": false,
+            "code": "598006",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Erythromycin 250 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000241",
+            "black_list": false,
+            "code": "598025",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Amoxicillin 250 MG Chewable Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000242",
+            "black_list": false,
+            "code": "617296",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Amoxicillin 500 MG / Clavulanate 125 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000243",
+            "black_list": false,
+            "code": "617302",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Amoxicillin 25 MG/ML / Clavulanate 6.25 MG/ML Oral Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000244",
+            "black_list": false,
+            "code": "617304",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Amoxicillin 250 MG / Clavulanate 62.5 MG Chewable Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000245",
+            "black_list": false,
+            "code": "617309",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Amoxicillin 200 MG / Clavulanate 28.5 MG Chewable Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000246",
+            "black_list": false,
+            "code": "617316",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Amoxicillin 400 MG / Clavulanate 57 MG Chewable Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000247",
+            "black_list": false,
+            "code": "617322",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Amoxicillin 50 MG/ML / Clavulanate 12.5 MG/ML Oral Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000248",
+            "black_list": false,
+            "code": "617423",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Amoxicillin 40 MG/ML / Clavulanate 5.7 MG/ML Oral Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000249",
+            "black_list": false,
+            "code": "617430",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Amoxicillin 80 MG/ML / Clavulanate 11.4 MG/ML Oral Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00024a",
+            "black_list": false,
+            "code": "617993",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Amoxicillin 120 MG/ML / Clavulanate 8.58 MG/ML Oral Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00024b",
+            "black_list": false,
+            "code": "617995",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "12 HR Amoxicillin 1000 MG / Clavulanate 62.5 MG Extended Release Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00024c",
+            "black_list": false,
+            "code": "623677",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "penicillin G benzathine 300000 UNT/ML / penicillin G procaine 300000 UNT/ML Injectable Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00024d",
+            "black_list": false,
+            "code": "623695",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "penicillin G benzathine 150000 UNT/ML / penicillin G procaine 150000 UNT/ML Injectable Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00024e",
+            "black_list": false,
+            "code": "629695",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "24 HR Minocycline 135 MG Extended Release Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00024f",
+            "black_list": false,
+            "code": "629697",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "24 HR Minocycline 45 MG Extended Release Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000250",
+            "black_list": false,
+            "code": "629699",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "24 HR Minocycline 90 MG Extended Release Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000251",
+            "black_list": false,
+            "code": "636559",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "24 HR Metronidazole 750 MG Extended Release Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000252",
+            "black_list": false,
+            "code": "637173",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Cephalexin 750 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000253",
+            "black_list": false,
+            "code": "637560",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "gemifloxacin 320 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000254",
+            "black_list": false,
+            "code": "644541",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "gatifloxacin 40 MG/ML Oral Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000255",
+            "black_list": false,
+            "code": "645617",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Cephalexin 333 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000256",
+            "black_list": false,
+            "code": "686354",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Erythromycin Gluceptate 1 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000257",
+            "black_list": false,
+            "code": "686355",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "erythromycin stearate 250 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000258",
+            "black_list": false,
+            "code": "686383",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Erythromycin Ethylsuccinate 40 MG/ML / Sulfisoxazole 120 MG/ML Oral Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000259",
+            "black_list": false,
+            "code": "686400",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Erythromycin Ethylsuccinate 40 MG/ML Oral Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00025a",
+            "black_list": false,
+            "code": "686405",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Erythromycin Ethylsuccinate 400 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00025b",
+            "black_list": false,
+            "code": "686406",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "erythromycin stearate 500 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00025c",
+            "black_list": false,
+            "code": "686418",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Erythromycin Ethylsuccinate 80 MG/ML Oral Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00025d",
+            "black_list": false,
+            "code": "686447",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Erythromycin Gluceptate 50 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00025e",
+            "black_list": false,
+            "code": "700408",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Doxycycline 75 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00025f",
+            "black_list": false,
+            "code": "728207",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Doxycycline 150 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000260",
+            "black_list": false,
+            "code": "731538",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "2 ML penicillin G benzathine 300000 UNT/ML / penicillin G procaine 300000 UNT/ML Prefilled Syringe",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000261",
+            "black_list": false,
+            "code": "731560",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "penicillin G benzathine 150000 UNT/ML / penicillin G procaine 150000 UNT/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000262",
+            "black_list": false,
+            "code": "731564",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "1 ML penicillin G benzathine 600000 UNT/ML Prefilled Syringe",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000263",
+            "black_list": false,
+            "code": "731567",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "2 ML penicillin G benzathine 600000 UNT/ML Prefilled Syringe",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000264",
+            "black_list": false,
+            "code": "731570",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "4 ML penicillin G benzathine 600000 UNT/ML Prefilled Syringe",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000265",
+            "black_list": false,
+            "code": "731572",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "penicillin G benzathine 600000 UNT/ML Injectable Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000266",
+            "black_list": false,
+            "code": "731575",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "penicillin G benzathine 300000 UNT/ML Injectable Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000267",
+            "black_list": false,
+            "code": "745047",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Penicillin G Potassium 156 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000268",
+            "black_list": false,
+            "code": "745053",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Penicillin G Potassium 25 MG/ML Oral Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000269",
+            "black_list": false,
+            "code": "745276",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Penicillin G Potassium 50 MG/ML Oral Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00026a",
+            "black_list": false,
+            "code": "745278",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Penicillin G Potassium 313 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00026b",
+            "black_list": false,
+            "code": "745280",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Penicillin G Potassium 125 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00026c",
+            "black_list": false,
+            "code": "745282",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Penicillin G Potassium 250 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00026d",
+            "black_list": false,
+            "code": "745302",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Penicillin G Sodium 100000 UNT/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00026e",
+            "black_list": false,
+            "code": "745303",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "penicillin G procaine 300000 UNT/ML Injectable Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00026f",
+            "black_list": false,
+            "code": "745462",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "2 ML penicillin G procaine 600000 UNT/ML Prefilled Syringe",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000270",
+            "black_list": false,
+            "code": "745519",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Penicillin G Potassium 500 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000271",
+            "black_list": false,
+            "code": "745560",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "1 ML penicillin G procaine 600000 UNT/ML Prefilled Syringe",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000272",
+            "black_list": false,
+            "code": "745561",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "penicillin G procaine 600000 UNT/ML Injectable Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000273",
+            "black_list": false,
+            "code": "745585",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Penicillin G Potassium 31.3 MG/ML Oral Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000274",
+            "black_list": false,
+            "code": "749780",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "{3 (Azithromycin 500 MG Oral Tablet) } Pack",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000275",
+            "black_list": false,
+            "code": "749783",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "{6 (Azithromycin 250 MG Oral Tablet) } Pack",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000276",
+            "black_list": false,
+            "code": "756189",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Sulfisoxazole 100 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000277",
+            "black_list": false,
+            "code": "756192",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Tetracycline 25 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000278",
+            "black_list": false,
+            "code": "757460",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "{31 (Doxycycline 100 MG Oral Tablet) } Pack",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000279",
+            "black_list": false,
+            "code": "757464",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "{31 (Doxycycline 75 MG Oral Tablet) } Pack",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00027a",
+            "black_list": false,
+            "code": "757466",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "{60 (Doxycycline 100 MG Oral Tablet) } Pack",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00027b",
+            "black_list": false,
+            "code": "761979",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "{5 (moxifloxacin 400 MG Oral Tablet) } Pack",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00027c",
+            "black_list": false,
+            "code": "762666",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "{5 (Levofloxacin 750 MG Oral Tablet) } Pack",
+            "white_list": false
+          },
+          {
+            "_id": "521f533b0017f7454b00027d",
+            "black_list": false,
+            "code": "762893",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "{10 (cefdinir 300 MG Oral Capsule) } Pack",
+            "white_list": false
+          },
+          {
+            "_id": "521f533b0017f7454b00027e",
+            "black_list": false,
+            "code": "789980",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Ampicillin 100 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533b0017f7454b00027f",
+            "black_list": false,
+            "code": "796301",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Cefazolin 100 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533b0017f7454b000280",
+            "black_list": false,
+            "code": "796484",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Vancomycin 6.67 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533b0017f7454b000281",
+            "black_list": false,
+            "code": "796486",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Vancomycin 8.33 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533b0017f7454b000282",
+            "black_list": false,
+            "code": "796488",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Vancomycin 10 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533b0017f7454b000283",
+            "black_list": false,
+            "code": "796490",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Vancomycin 7 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533b0017f7454b000284",
+            "black_list": false,
+            "code": "796492",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Vancomycin 8 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533b0017f7454b000285",
+            "black_list": false,
+            "code": "799048",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Doxycycline 150 MG Enteric Coated Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533b0017f7454b000286",
+            "black_list": false,
+            "code": "802550",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Amoxicillin 775 MG Extended Release Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533b0017f7454b000287",
+            "black_list": false,
+            "code": "808917",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Fosfomycin 33.3 MG/ML Oral Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f533b0017f7454b000288",
+            "black_list": false,
+            "code": "835341",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "{14 (24 HR Clarithromycin 500 MG Extended Release Tablet) } Pack",
+            "white_list": false
+          },
+          {
+            "_id": "521f533b0017f7454b000289",
+            "black_list": false,
+            "code": "835700",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "{30 (Doxycycline 150 MG Oral Tablet) } Pack",
+            "white_list": false
+          },
+          {
+            "_id": "521f533b0017f7454b00028a",
+            "black_list": false,
+            "code": "836306",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "2 ML penicillin G benzathine 450000 UNT/ML / penicillin G procaine 150000 UNT/ML Prefilled Syringe",
+            "white_list": false
+          },
+          {
+            "_id": "521f533b0017f7454b00028b",
+            "black_list": false,
+            "code": "847360",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "cefditoren pivoxil 400 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533b0017f7454b00028c",
+            "black_list": false,
+            "code": "852868",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "{60 (Doxycycline 150 MG Oral Capsule) } Pack",
+            "white_list": false
+          },
+          {
+            "_id": "521f533b0017f7454b00028d",
+            "black_list": false,
+            "code": "858062",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "24 HR Minocycline 115 MG Extended Release Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533b0017f7454b00028e",
+            "black_list": false,
+            "code": "858372",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "24 HR Minocycline 65 MG Extended Release Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533b0017f7454b00028f",
+            "black_list": false,
+            "code": "860441",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Vancomycin 100 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533b0017f7454b000290",
+            "black_list": false,
+            "code": "861416",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Azithromycin 16.7 MG/ML Oral Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f533b0017f7454b000291",
+            "black_list": false,
+            "code": "863538",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Penicillin G Potassium 1000000 UNT/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533b0017f7454b000292",
+            "black_list": false,
+            "code": "877486",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Ofloxacin 600 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f533b0017f7454b000293",
+            "black_list": false,
+            "code": "895915",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Levofloxacin 25 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533b0017f7454b000294",
+            "black_list": false,
+            "code": "895924",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Cefotetan 200 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533b0017f7454b000295",
+            "black_list": false,
+            "code": "901610",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Aztreonam 75 MG/ML Inhalant Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533b0017f7454b000296",
+            "black_list": false,
+            "code": "904288",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Cefuroxime 100 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533b0017f7454b000297",
+            "black_list": false,
+            "code": "905143",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Amikacin Sulfate 250 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533b0017f7454b000298",
+            "black_list": false,
+            "code": "905148",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Amikacin Sulfate 50 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533b0017f7454b000299",
+            "black_list": false,
+            "code": "993109",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Ampicillin 20 MG/ML / Sulbactam 10 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533b0017f7454b00029a",
+            "black_list": false,
+            "code": "997632",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Cefuroxime 225 MG/ML Injectable Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f533b0017f7454b00029b",
+            "black_list": false,
+            "code": "997656",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Ampicillin 10 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533b0017f7454b00029c",
+            "black_list": false,
+            "code": "997665",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Ampicillin 40 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533b0017f7454b00029d",
+            "black_list": false,
+            "code": "997999",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "erythromycin lactobionate 4 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533b0017f7454b00029e",
+            "black_list": false,
+            "code": "998004",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "erythromycin lactobionate 5 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533b0017f7454b00029f",
+            "black_list": false,
+            "code": "998239",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Vancomycin 6 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533b0017f7454b0002a0",
+            "black_list": false,
+            "code": "998241",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Vancomycin 3.5 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f533b0017f7454b0002a1",
+            "black_list": false,
+            "code": "998756",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Ciprofloxacin 10 MG/ML Injectable Solution",
+            "white_list": false
+          }
+        ],
+        "display_name": "Antibiotic Medications",
+        "oid": "2.16.840.1.113883.3.464.1003.196.12.1001",
+        "version": "20130614"
+      },
+      {
+        "_id": "521f533a0017f7454b000015",
+        "concepts": [
+          {
+            "_id": "521f533a0017f7454b000016",
+            "black_list": false,
+            "code": "17741008",
+            "code_system": "2.16.840.1.113883.6.96",
+            "code_system_name": "SNOMED-CT",
+            "code_system_version": null,
+            "display_name": "Acute tonsillitis (disorder)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000017",
+            "black_list": false,
+            "code": "195666007",
+            "code_system": "2.16.840.1.113883.6.96",
+            "code_system_name": "SNOMED-CT",
+            "code_system_version": null,
+            "display_name": "Acute erythematous tonsillitis (disorder)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000018",
+            "black_list": false,
+            "code": "195667003",
+            "code_system": "2.16.840.1.113883.6.96",
+            "code_system_name": "SNOMED-CT",
+            "code_system_version": null,
+            "display_name": "Acute follicular tonsillitis (disorder)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000019",
+            "black_list": false,
+            "code": "195668008",
+            "code_system": "2.16.840.1.113883.6.96",
+            "code_system_name": "SNOMED-CT",
+            "code_system_version": null,
+            "display_name": "Acute ulcerative tonsillitis (disorder)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00001a",
+            "black_list": false,
+            "code": "195669000",
+            "code_system": "2.16.840.1.113883.6.96",
+            "code_system_name": "SNOMED-CT",
+            "code_system_version": null,
+            "display_name": "Acute catarrhal tonsillitis (disorder)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00001b",
+            "black_list": false,
+            "code": "195670004",
+            "code_system": "2.16.840.1.113883.6.96",
+            "code_system_name": "SNOMED-CT",
+            "code_system_version": null,
+            "display_name": "Acute gangrenous tonsillitis (disorder)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00001c",
+            "black_list": false,
+            "code": "195671000",
+            "code_system": "2.16.840.1.113883.6.96",
+            "code_system_name": "SNOMED-CT",
+            "code_system_version": null,
+            "display_name": "Acute bacterial tonsillitis (disorder)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00001d",
+            "black_list": false,
+            "code": "195672007",
+            "code_system": "2.16.840.1.113883.6.96",
+            "code_system_name": "SNOMED-CT",
+            "code_system_version": null,
+            "display_name": "Acute pneumococcal tonsillitis (disorder)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00001e",
+            "black_list": false,
+            "code": "195673002",
+            "code_system": "2.16.840.1.113883.6.96",
+            "code_system_name": "SNOMED-CT",
+            "code_system_version": null,
+            "display_name": "Acute staphylococcal tonsillitis (disorder)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00001f",
+            "black_list": false,
+            "code": "195676005",
+            "code_system": "2.16.840.1.113883.6.96",
+            "code_system_name": "SNOMED-CT",
+            "code_system_version": null,
+            "display_name": "Acute viral tonsillitis (disorder)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000020",
+            "black_list": false,
+            "code": "195677001",
+            "code_system": "2.16.840.1.113883.6.96",
+            "code_system_name": "SNOMED-CT",
+            "code_system_version": null,
+            "display_name": "Recurrent acute tonsillitis (disorder)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000021",
+            "black_list": false,
+            "code": "302911003",
+            "code_system": "2.16.840.1.113883.6.96",
+            "code_system_name": "SNOMED-CT",
+            "code_system_version": null,
+            "display_name": "Acute lingual tonsillitis (disorder)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000022",
+            "black_list": false,
+            "code": "463",
+            "code_system": "2.16.840.1.113883.6.103",
+            "code_system_name": "ICD-9-CM",
+            "code_system_version": null,
+            "display_name": "Acute tonsillitis",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000023",
+            "black_list": false,
+            "code": "J03.80",
+            "code_system": "2.16.840.1.113883.6.90",
+            "code_system_name": "ICD-10-CM",
+            "code_system_version": null,
+            "display_name": "Acute tonsillitis due to other specified organisms",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000024",
+            "black_list": false,
+            "code": "J03.81",
+            "code_system": "2.16.840.1.113883.6.90",
+            "code_system_name": "ICD-10-CM",
+            "code_system_version": null,
+            "display_name": "Acute recurrent tonsillitis due to other specified organisms",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000025",
+            "black_list": false,
+            "code": "J03.90",
+            "code_system": "2.16.840.1.113883.6.90",
+            "code_system_name": "ICD-10-CM",
+            "code_system_version": null,
+            "display_name": "Acute tonsillitis, unspecified",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000026",
+            "black_list": false,
+            "code": "J03.91",
+            "code_system": "2.16.840.1.113883.6.90",
+            "code_system_name": "ICD-10-CM",
+            "code_system_version": null,
+            "display_name": "Acute recurrent tonsillitis, unspecified",
+            "white_list": false
+          }
+        ],
+        "display_name": "Acute Tonsillitis",
+        "oid": "2.16.840.1.113883.3.464.1003.102.12.1012",
+        "version": "20130614"
+      },
+      {
+        "_id": "521f533a0017f7454b000001",
+        "concepts": [
+          {
+            "_id": "521f533a0017f7454b000002",
+            "black_list": false,
+            "code": "034.0",
+            "code_system": "2.16.840.1.113883.6.103",
+            "code_system_name": "ICD-9-CM",
+            "code_system_version": null,
+            "display_name": "Streptococcal sore throat",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000003",
+            "black_list": false,
+            "code": "1532007",
+            "code_system": "2.16.840.1.113883.6.96",
+            "code_system_name": "SNOMED-CT",
+            "code_system_version": null,
+            "display_name": "Viral pharyngitis (disorder)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000004",
+            "black_list": false,
+            "code": "195655000",
+            "code_system": "2.16.840.1.113883.6.96",
+            "code_system_name": "SNOMED-CT",
+            "code_system_version": null,
+            "display_name": "Acute gangrenous pharyngitis (disorder)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000005",
+            "black_list": false,
+            "code": "195656004",
+            "code_system": "2.16.840.1.113883.6.96",
+            "code_system_name": "SNOMED-CT",
+            "code_system_version": null,
+            "display_name": "Acute phlegmonous pharyngitis (disorder)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000006",
+            "black_list": false,
+            "code": "195657008",
+            "code_system": "2.16.840.1.113883.6.96",
+            "code_system_name": "SNOMED-CT",
+            "code_system_version": null,
+            "display_name": "Acute ulcerative pharyngitis (disorder)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000007",
+            "black_list": false,
+            "code": "195658003",
+            "code_system": "2.16.840.1.113883.6.96",
+            "code_system_name": "SNOMED-CT",
+            "code_system_version": null,
+            "display_name": "Acute bacterial pharyngitis (disorder)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000008",
+            "black_list": false,
+            "code": "195659006",
+            "code_system": "2.16.840.1.113883.6.96",
+            "code_system_name": "SNOMED-CT",
+            "code_system_version": null,
+            "display_name": "Acute pneumococcal pharyngitis (disorder)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000009",
+            "black_list": false,
+            "code": "195660001",
+            "code_system": "2.16.840.1.113883.6.96",
+            "code_system_name": "SNOMED-CT",
+            "code_system_version": null,
+            "display_name": "Acute staphylococcal pharyngitis (disorder)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00000a",
+            "black_list": false,
+            "code": "195662009",
+            "code_system": "2.16.840.1.113883.6.96",
+            "code_system_name": "SNOMED-CT",
+            "code_system_version": null,
+            "display_name": "Acute viral pharyngitis (disorder)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00000b",
+            "black_list": false,
+            "code": "232399005",
+            "code_system": "2.16.840.1.113883.6.96",
+            "code_system_name": "SNOMED-CT",
+            "code_system_version": null,
+            "display_name": "Acute herpes simplex pharyngitis (disorder)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00000c",
+            "black_list": false,
+            "code": "232400003",
+            "code_system": "2.16.840.1.113883.6.96",
+            "code_system_name": "SNOMED-CT",
+            "code_system_version": null,
+            "display_name": "Acute herpes zoster pharyngitis (disorder)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00000d",
+            "black_list": false,
+            "code": "363746003",
+            "code_system": "2.16.840.1.113883.6.96",
+            "code_system_name": "SNOMED-CT",
+            "code_system_version": null,
+            "display_name": "Acute pharyngitis (disorder)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00000e",
+            "black_list": false,
+            "code": "40766000",
+            "code_system": "2.16.840.1.113883.6.96",
+            "code_system_name": "SNOMED-CT",
+            "code_system_version": null,
+            "display_name": "Enteroviral lymphonodular pharyngitis (disorder)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00000f",
+            "black_list": false,
+            "code": "43878008",
+            "code_system": "2.16.840.1.113883.6.96",
+            "code_system_name": "SNOMED-CT",
+            "code_system_version": null,
+            "display_name": "Streptococcal sore throat (disorder)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000010",
+            "black_list": false,
+            "code": "462",
+            "code_system": "2.16.840.1.113883.6.103",
+            "code_system_name": "ICD-9-CM",
+            "code_system_version": null,
+            "display_name": "Acute pharyngitis",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000011",
+            "black_list": false,
+            "code": "55355000",
+            "code_system": "2.16.840.1.113883.6.96",
+            "code_system_name": "SNOMED-CT",
+            "code_system_version": null,
+            "display_name": "Acute laryngopharyngitis (disorder)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000012",
+            "black_list": false,
+            "code": "58031004",
+            "code_system": "2.16.840.1.113883.6.96",
+            "code_system_name": "SNOMED-CT",
+            "code_system_version": null,
+            "display_name": "Suppurative pharyngitis (disorder)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000013",
+            "black_list": false,
+            "code": "J02.8",
+            "code_system": "2.16.840.1.113883.6.90",
+            "code_system_name": "ICD-10-CM",
+            "code_system_version": null,
+            "display_name": "Acute pharyngitis due to other specified organisms",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000014",
+            "black_list": false,
+            "code": "J02.9",
+            "code_system": "2.16.840.1.113883.6.90",
+            "code_system_name": "ICD-10-CM",
+            "code_system_version": null,
+            "display_name": "Acute pharyngitis, unspecified",
+            "white_list": false
+          }
+        ],
+        "display_name": "Acute Pharyngitis",
+        "oid": "2.16.840.1.113883.3.464.1003.102.12.1011",
+        "version": "20130614"
+      },
+      {
+        "_id": "521f533a0017f7454b000027",
+        "concepts": [
+          {
+            "_id": "521f533a0017f7454b000028",
+            "black_list": false,
+            "code": "12843005",
+            "code_system": "2.16.840.1.113883.6.96",
+            "code_system_name": "SNOMED-CT",
+            "code_system_version": null,
+            "display_name": "Subsequent hospital visit by physician (procedure)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000029",
+            "black_list": false,
+            "code": "18170008",
+            "code_system": "2.16.840.1.113883.6.96",
+            "code_system_name": "SNOMED-CT",
+            "code_system_version": null,
+            "display_name": "Subsequent nursing facility visit (procedure)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00002a",
+            "black_list": false,
+            "code": "185349003",
+            "code_system": "2.16.840.1.113883.6.96",
+            "code_system_name": "SNOMED-CT",
+            "code_system_version": null,
+            "display_name": "Encounter for \"check-up\" (procedure)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00002b",
+            "black_list": false,
+            "code": "185463005",
+            "code_system": "2.16.840.1.113883.6.96",
+            "code_system_name": "SNOMED-CT",
+            "code_system_version": null,
+            "display_name": "Visit out of hours (procedure)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00002c",
+            "black_list": false,
+            "code": "185465003",
+            "code_system": "2.16.840.1.113883.6.96",
+            "code_system_name": "SNOMED-CT",
+            "code_system_version": null,
+            "display_name": "Weekend visit (procedure)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00002d",
+            "black_list": false,
+            "code": "19681004",
+            "code_system": "2.16.840.1.113883.6.96",
+            "code_system_name": "SNOMED-CT",
+            "code_system_version": null,
+            "display_name": "Nursing evaluation of patient and report (procedure)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00002e",
+            "black_list": false,
+            "code": "207195004",
+            "code_system": "2.16.840.1.113883.6.96",
+            "code_system_name": "SNOMED-CT",
+            "code_system_version": null,
+            "display_name": "History and physical examination with evaluation and management of nursing facility patient (procedure)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00002f",
+            "black_list": false,
+            "code": "270427003",
+            "code_system": "2.16.840.1.113883.6.96",
+            "code_system_name": "SNOMED-CT",
+            "code_system_version": null,
+            "display_name": "Patient-initiated encounter (procedure)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000030",
+            "black_list": false,
+            "code": "270430005",
+            "code_system": "2.16.840.1.113883.6.96",
+            "code_system_name": "SNOMED-CT",
+            "code_system_version": null,
+            "display_name": "Provider-initiated encounter (procedure)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000031",
+            "black_list": false,
+            "code": "308335008",
+            "code_system": "2.16.840.1.113883.6.96",
+            "code_system_name": "SNOMED-CT",
+            "code_system_version": null,
+            "display_name": "Patient encounter procedure (procedure)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000032",
+            "black_list": false,
+            "code": "390906007",
+            "code_system": "2.16.840.1.113883.6.96",
+            "code_system_name": "SNOMED-CT",
+            "code_system_version": null,
+            "display_name": "Follow-up encounter (procedure)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000033",
+            "black_list": false,
+            "code": "406547006",
+            "code_system": "2.16.840.1.113883.6.96",
+            "code_system_name": "SNOMED-CT",
+            "code_system_version": null,
+            "display_name": "Urgent follow-up (procedure)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000034",
+            "black_list": false,
+            "code": "439708006",
+            "code_system": "2.16.840.1.113883.6.96",
+            "code_system_name": "SNOMED-CT",
+            "code_system_version": null,
+            "display_name": "Home visit (procedure)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000035",
+            "black_list": false,
+            "code": "4525004",
+            "code_system": "2.16.840.1.113883.6.96",
+            "code_system_name": "SNOMED-CT",
+            "code_system_version": null,
+            "display_name": "Emergency department patient visit (procedure)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000036",
+            "black_list": false,
+            "code": "87790002",
+            "code_system": "2.16.840.1.113883.6.96",
+            "code_system_name": "SNOMED-CT",
+            "code_system_version": null,
+            "display_name": "Follow-up inpatient consultation visit (procedure)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000037",
+            "black_list": false,
+            "code": "90526000",
+            "code_system": "2.16.840.1.113883.6.96",
+            "code_system_name": "SNOMED-CT",
+            "code_system_version": null,
+            "display_name": "Initial evaluation and management of healthy individual (procedure)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000038",
+            "black_list": false,
+            "code": "99201",
+            "code_system": "2.16.840.1.113883.6.12",
+            "code_system_name": "CPT",
+            "code_system_version": null,
+            "display_name": "Office or other outpatient visit for the evaluation and management of a new patient, which requires these 3 key components: A problem focused history; A problem focused examination; Straightforward medical decision making. Counseling and/or coordination of care with other physicians, other qualified health care professionals, or agencies are provided consistent with the nature of the problem(s) and the patient's and/or family's needs. Usually, the presenting problem(s) are self limited or minor. Typically, 10 minutes are spent face-to-face with the patient and/or family.",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000039",
+            "black_list": false,
+            "code": "99202",
+            "code_system": "2.16.840.1.113883.6.12",
+            "code_system_name": "CPT",
+            "code_system_version": null,
+            "display_name": "Office or other outpatient visit for the evaluation and management of a new patient, which requires these 3 key components: An expanded problem focused history; An expanded problem focused examination; Straightforward medical decision making. Counseling and/or coordination of care with other physicians, other qualified health care professionals, or agencies are provided consistent with the nature of the problem(s) and the patient's and/or family's needs. Usually, the presenting problem(s) are of low to moderate severity. Typically, 20 minutes are spent face-to-face with the patient and/or family.",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00003a",
+            "black_list": false,
+            "code": "99203",
+            "code_system": "2.16.840.1.113883.6.12",
+            "code_system_name": "CPT",
+            "code_system_version": null,
+            "display_name": "Office or other outpatient visit for the evaluation and management of a new patient, which requires these 3 key components: A detailed history; A detailed examination; Medical decision making of low complexity. Counseling and/or coordination of care with other physicians, other qualified health care professionals, or agencies are provided consistent with the nature of the problem(s) and the patient's and/or family's needs. Usually, the presenting problem(s) are of moderate severity. Typically, 30 minutes are spent face-to-face with the patient and/or family.",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00003b",
+            "black_list": false,
+            "code": "99204",
+            "code_system": "2.16.840.1.113883.6.12",
+            "code_system_name": "CPT",
+            "code_system_version": null,
+            "display_name": "Office or other outpatient visit for the evaluation and management of a new patient, which requires these 3 key components: A comprehensive history; A comprehensive examination; Medical decision making of moderate complexity. Counseling and/or coordination of care with other physicians, other qualified health care professionals, or agencies are provided consistent with the nature of the problem(s) and the patient's and/or family's needs. Usually, the presenting problem(s) are of moderate to high severity. Typically, 45 minutes are spent face-to-face with the patient and/or family.",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00003c",
+            "black_list": false,
+            "code": "99205",
+            "code_system": "2.16.840.1.113883.6.12",
+            "code_system_name": "CPT",
+            "code_system_version": null,
+            "display_name": "Office or other outpatient visit for the evaluation and management of a new patient, which requires these 3 key components: A comprehensive history; A comprehensive examination; Medical decision making of high complexity. Counseling and/or coordination of care with other physicians, other qualified health care professionals, or agencies are provided consistent with the nature of the problem(s) and the patient's and/or family's needs. Usually, the presenting problem(s) are of moderate to high severity. Typically, 60 minutes are spent face-to-face with the patient and/or family.",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00003d",
+            "black_list": false,
+            "code": "99212",
+            "code_system": "2.16.840.1.113883.6.12",
+            "code_system_name": "CPT",
+            "code_system_version": null,
+            "display_name": "Office or other outpatient visit for the evaluation and management of an established patient, which requires at least 2 of these 3 key components: A problem focused history; A problem focused examination; Straightforward medical decision making. Counseling and/or coordination of care with other physicians, other qualified health care professionals, or agencies are provided consistent with the nature of the problem(s) and the patient's and/or family's needs. Usually, the presenting problem(s) are self limited or minor. Typically, 10 minutes are spent face-to-face with the patient and/or family.",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00003e",
+            "black_list": false,
+            "code": "99213",
+            "code_system": "2.16.840.1.113883.6.12",
+            "code_system_name": "CPT",
+            "code_system_version": null,
+            "display_name": "Office or other outpatient visit for the evaluation and management of an established patient, which requires at least 2 of these 3 key components: An expanded problem focused history; An expanded problem focused examination; Medical decision making of low complexity. Counseling and coordination of care with other physicians, other qualified health care professionals, or agencies are provided consistent with the nature of the problem(s) and the patient's and/or family's needs. Usually, the presenting problem(s) are of low to moderate severity. Typically, 15 minutes are spent face-to-face with the patient and/or family.",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00003f",
+            "black_list": false,
+            "code": "99214",
+            "code_system": "2.16.840.1.113883.6.12",
+            "code_system_name": "CPT",
+            "code_system_version": null,
+            "display_name": "Office or other outpatient visit for the evaluation and management of an established patient, which requires at least 2 of these 3 key components: A detailed history; A detailed examination; Medical decision making of moderate complexity. Counseling and/or coordination of care with other physicians, other qualified health care professionals, or agencies are provided consistent with the nature of the problem(s) and the patient's and/or family's needs. Usually, the presenting problem(s) are of moderate to high severity. Typically, 25 minutes are spent face-to-face with the patient and/or family.",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000040",
+            "black_list": false,
+            "code": "99215",
+            "code_system": "2.16.840.1.113883.6.12",
+            "code_system_name": "CPT",
+            "code_system_version": null,
+            "display_name": "Office or other outpatient visit for the evaluation and management of an established patient, which requires at least 2 of these 3 key components: A comprehensive history; A comprehensive examination; Medical decision making of high complexity. Counseling and/or coordination of care with other physicians, other qualified health care professionals, or agencies are provided consistent with the nature of the problem(s) and the patient's and/or family's needs. Usually, the presenting problem(s) are of moderate to high severity. Typically, 40 minutes are spent face-to-face with the patient and/or family.",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000041",
+            "black_list": false,
+            "code": "99218",
+            "code_system": "2.16.840.1.113883.6.12",
+            "code_system_name": "CPT",
+            "code_system_version": null,
+            "display_name": "Initial observation care, per day, for the evaluation and management of a patient which requires these 3 key components: A detailed or comprehensive history; A detailed or comprehensive examination; and Medical decision making that is straightforward or of low complexity. Counseling and/or coordination of care with other physicians, other qualified health care professionals, or agencies are provided consistent with the nature of the problem(s) and the patient's and/or family's needs. Usually, the problem(s) requiring admission to \"observation status\" are of low severity. Typically, 30 minutes are spent at the bedside and on the patient's hospital floor or unit.",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000042",
+            "black_list": false,
+            "code": "99219",
+            "code_system": "2.16.840.1.113883.6.12",
+            "code_system_name": "CPT",
+            "code_system_version": null,
+            "display_name": "Initial observation care, per day, for the evaluation and management of a patient, which requires these 3 key components: A comprehensive history; A comprehensive examination; and Medical decision making of moderate complexity. Counseling and/or coordination of care with other physicians, other qualified health care professionals, or agencies are provided consistent with the nature of the problem(s) and the patient's and/or family's needs. Usually, the problem(s) requiring admission to \"observation status\" are of moderate severity. Typically, 50 minutes are spent at the bedside and on the patient's hospital floor or unit.",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000043",
+            "black_list": false,
+            "code": "99220",
+            "code_system": "2.16.840.1.113883.6.12",
+            "code_system_name": "CPT",
+            "code_system_version": null,
+            "display_name": "Initial observation care, per day, for the evaluation and management of a patient, which requires these 3 key components: A comprehensive history; A comprehensive examination; and Medical decision making of high complexity. Counseling and/or coordination of care with other physicians, other qualified health care professionals, or agencies are provided consistent with the nature of the problem(s) and the patient's and/or family's needs. Usually, the problem(s) requiring admission to \"observation status\" are of high severity. Typically, 70 minutes are spent at the bedside and on the patient's hospital floor or unit.",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000044",
+            "black_list": false,
+            "code": "99281",
+            "code_system": "2.16.840.1.113883.6.12",
+            "code_system_name": "CPT",
+            "code_system_version": null,
+            "display_name": "Emergency department visit for the evaluation and management of a patient, which requires these 3 key components: A problem focused history; A problem focused examination; and Straightforward medical decision making. Counseling and/or coordination of care with other physicians, other qualified health care professionals, or agencies are provided consistent with the nature of the problem(s) and the patient's and/or family's needs. Usually, the presenting problem(s) are self limited or minor.",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000045",
+            "black_list": false,
+            "code": "99282",
+            "code_system": "2.16.840.1.113883.6.12",
+            "code_system_name": "CPT",
+            "code_system_version": null,
+            "display_name": "Emergency department visit for the evaluation and management of a patient, which requires these 3 key components: An expanded problem focused history; An expanded problem focused examination; and Medical decision making of low complexity. Counseling and/or coordination of care with other physicians, other qualified health care professionals, or agencies are provided consistent with the nature of the problem(s) and the patient's and/or family's needs. Usually, the presenting problem(s) are of low to moderate severity.",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000046",
+            "black_list": false,
+            "code": "99283",
+            "code_system": "2.16.840.1.113883.6.12",
+            "code_system_name": "CPT",
+            "code_system_version": null,
+            "display_name": "Emergency department visit for the evaluation and management of a patient, which requires these 3 key components: An expanded problem focused history; An expanded problem focused examination; and Medical decision making of moderate complexity. Counseling and/or coordination of care with other physicians, other qualified health care professionals, or agencies are provided consistent with the nature of the problem(s) and the patient's and/or family's needs. Usually, the presenting problem(s) are of moderate severity.",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000047",
+            "black_list": false,
+            "code": "99284",
+            "code_system": "2.16.840.1.113883.6.12",
+            "code_system_name": "CPT",
+            "code_system_version": null,
+            "display_name": "Emergency department visit for the evaluation and management of a patient, which requires these 3 key components: A detailed history; A detailed examination; and Medical decision making of moderate complexity. Counseling and/or coordination of care with other physicians, other qualified health care professionals, or agencies are provided consistent with the nature of the problem(s) and the patient's and/or family's needs. Usually, the presenting problem(s) are of high severity, and require urgent evaluation by the physician physicians, or other qualified health care professionals but do not pose an immediate significant threat to life or physiologic function.",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000048",
+            "black_list": false,
+            "code": "99285",
+            "code_system": "2.16.840.1.113883.6.12",
+            "code_system_name": "CPT",
+            "code_system_version": null,
+            "display_name": "Emergency department visit for the evaluation and management of a patient, which requires these 3 key components within the constraints imposed by the urgency of the patient's clinical condition and/or mental status: A comprehensive history; A comprehensive examination; and Medical decision making of high complexity. Counseling and/or coordination of care with other physicians, other qualified health care professionals, or agencies are provided consistent with the nature of the problem(s) and the patient's and/or family's needs. Usually, the presenting problem(s) are of high severity and pose an immediate significant threat to life or physiologic function.",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000049",
+            "black_list": false,
+            "code": "99381",
+            "code_system": "2.16.840.1.113883.6.12",
+            "code_system_name": "CPT",
+            "code_system_version": null,
+            "display_name": "Initial comprehensive preventive medicine evaluation and management of an individual including an age and gender appropriate history, examination, counseling/anticipatory guidance/risk factor reduction interventions, and the ordering of laboratory/diagnostic procedures, new patient; infant (age younger than 1 year)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00004a",
+            "black_list": false,
+            "code": "99382",
+            "code_system": "2.16.840.1.113883.6.12",
+            "code_system_name": "CPT",
+            "code_system_version": null,
+            "display_name": "Initial comprehensive preventive medicine evaluation and management of an individual including an age and gender appropriate history, examination, counseling/anticipatory guidance/risk factor reduction interventions, and the ordering of laboratory/diagnostic procedures, new patient; early childhood (age 1 through 4 years)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00004b",
+            "black_list": false,
+            "code": "99383",
+            "code_system": "2.16.840.1.113883.6.12",
+            "code_system_name": "CPT",
+            "code_system_version": null,
+            "display_name": "Initial comprehensive preventive medicine evaluation and management of an individual including an age and gender appropriate history, examination, counseling/anticipatory guidance/risk factor reduction interventions, and the ordering of laboratory/diagnostic procedures, new patient; late childhood (age 5 through 11 years)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00004c",
+            "black_list": false,
+            "code": "99384",
+            "code_system": "2.16.840.1.113883.6.12",
+            "code_system_name": "CPT",
+            "code_system_version": null,
+            "display_name": "Initial comprehensive preventive medicine evaluation and management of an individual including an age and gender appropriate history, examination, counseling/anticipatory guidance/risk factor reduction interventions, and the ordering of laboratory/diagnostic procedures, new patient; adolescent (age 12 through 17 years)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00004d",
+            "black_list": false,
+            "code": "99385",
+            "code_system": "2.16.840.1.113883.6.12",
+            "code_system_name": "CPT",
+            "code_system_version": null,
+            "display_name": "Initial comprehensive preventive medicine evaluation and management of an individual including an age and gender appropriate history, examination, counseling/anticipatory guidance/risk factor reduction interventions, and the ordering of laboratory/diagnostic procedures, new patient; 18-39 years",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00004e",
+            "black_list": false,
+            "code": "99386",
+            "code_system": "2.16.840.1.113883.6.12",
+            "code_system_name": "CPT",
+            "code_system_version": null,
+            "display_name": "Initial comprehensive preventive medicine evaluation and management of an individual including an age and gender appropriate history, examination, counseling/anticipatory guidance/risk factor reduction interventions, and the ordering of laboratory/diagnostic procedures, new patient; 40-64 years",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00004f",
+            "black_list": false,
+            "code": "99387",
+            "code_system": "2.16.840.1.113883.6.12",
+            "code_system_name": "CPT",
+            "code_system_version": null,
+            "display_name": "Initial comprehensive preventive medicine evaluation and management of an individual including an age and gender appropriate history, examination, counseling/anticipatory guidance/risk factor reduction interventions, and the ordering of laboratory/diagnostic procedures, new patient; 65 years and older",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000050",
+            "black_list": false,
+            "code": "99391",
+            "code_system": "2.16.840.1.113883.6.12",
+            "code_system_name": "CPT",
+            "code_system_version": null,
+            "display_name": "Periodic comprehensive preventive medicine reevaluation and management of an individual including an age and gender appropriate history, examination, counseling/anticipatory guidance/risk factor reduction interventions, and the ordering of laboratory/diagnostic procedures, established patient; infant (age younger than 1 year)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000051",
+            "black_list": false,
+            "code": "99392",
+            "code_system": "2.16.840.1.113883.6.12",
+            "code_system_name": "CPT",
+            "code_system_version": null,
+            "display_name": "Periodic comprehensive preventive medicine reevaluation and management of an individual including an age and gender appropriate history, examination, counseling/anticipatory guidance/risk factor reduction interventions, and the ordering of laboratory/diagnostic procedures, established patient; early childhood (age 1 through 4 years)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000052",
+            "black_list": false,
+            "code": "99393",
+            "code_system": "2.16.840.1.113883.6.12",
+            "code_system_name": "CPT",
+            "code_system_version": null,
+            "display_name": "Periodic comprehensive preventive medicine reevaluation and management of an individual including an age and gender appropriate history, examination, counseling/anticipatory guidance/risk factor reduction interventions, and the ordering of laboratory/diagnostic procedures, established patient; late childhood (age 5 through 11 years)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000053",
+            "black_list": false,
+            "code": "99394",
+            "code_system": "2.16.840.1.113883.6.12",
+            "code_system_name": "CPT",
+            "code_system_version": null,
+            "display_name": "Periodic comprehensive preventive medicine reevaluation and management of an individual including an age and gender appropriate history, examination, counseling/anticipatory guidance/risk factor reduction interventions, and the ordering of laboratory/diagnostic procedures, established patient; adolescent (age 12 through 17 years)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000054",
+            "black_list": false,
+            "code": "99395",
+            "code_system": "2.16.840.1.113883.6.12",
+            "code_system_name": "CPT",
+            "code_system_version": null,
+            "display_name": "Periodic comprehensive preventive medicine reevaluation and management of an individual including an age and gender appropriate history, examination, counseling/anticipatory guidance/risk factor reduction interventions, and the ordering of laboratory/diagnostic procedures, established patient; 18-39 years",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000055",
+            "black_list": false,
+            "code": "99396",
+            "code_system": "2.16.840.1.113883.6.12",
+            "code_system_name": "CPT",
+            "code_system_version": null,
+            "display_name": "Periodic comprehensive preventive medicine reevaluation and management of an individual including an age and gender appropriate history, examination, counseling/anticipatory guidance/risk factor reduction interventions, and the ordering of laboratory/diagnostic procedures, established patient; 40-64 years",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000056",
+            "black_list": false,
+            "code": "99397",
+            "code_system": "2.16.840.1.113883.6.12",
+            "code_system_name": "CPT",
+            "code_system_version": null,
+            "display_name": "Periodic comprehensive preventive medicine reevaluation and management of an individual including an age and gender appropriate history, examination, counseling/anticipatory guidance/risk factor reduction interventions, and the ordering of laboratory/diagnostic procedures, established patient; 65 years and older",
+            "white_list": false
+          }
+        ],
+        "display_name": "Ambulatory/ED Visit",
+        "oid": "2.16.840.1.113883.3.464.1003.101.12.1061",
+        "version": "20130614"
+      },
+      {
+        "_id": "521f533a0017f7454b000057",
+        "concepts": [
+          {
+            "_id": "521f533a0017f7454b000058",
+            "black_list": false,
+            "code": "F",
+            "code_system": "2.16.840.1.113883.18.2",
+            "code_system_name": "AdministrativeSex",
+            "code_system_version": null,
+            "display_name": "Female",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000059",
+            "black_list": false,
+            "code": "M",
+            "code_system": "2.16.840.1.113883.18.2",
+            "code_system_name": "AdministrativeSex",
+            "code_system_version": null,
+            "display_name": "Male",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00005a",
+            "black_list": false,
+            "code": "U",
+            "code_system": "2.16.840.1.113883.18.2",
+            "code_system_name": "AdministrativeSex",
+            "code_system_version": null,
+            "display_name": "Unknown",
+            "white_list": false
+          }
+        ],
+        "display_name": "ONC Administrative Sex",
+        "oid": "2.16.840.1.113762.1.4.1",
+        "version": "20121025"
+      }
+    ]
   },
   {
     "_id": "40280381-3D61-56A7-013E-65C9C3043E54",
@@ -2513,7 +9385,7 @@
     },
     "title": "Use of High-Risk Medications in the Elderly",
     "type": "ep",
-    "updated_at": "2014-02-19T15:29:02Z",
+    "updated_at": "2014-02-26T01:48:01Z",
     "user_id": "501fdba3044a111b98000001",
     "value_set_oids": [
       "2.16.840.1.113762.1.4.1",
@@ -2530,6 +9402,9222 @@
       "2.16.840.1.113883.3.526.3.1240",
       "2.16.840.1.113883.3.464.1003.101.12.1016"
     ],
-    "version": null
+    "version": null,
+    "value_sets": [
+      {
+        "_id": "521f533a0017f7454b000062",
+        "concepts": [
+          {
+            "_id": "521f533a0017f7454b000063",
+            "black_list": false,
+            "code": "2135-2",
+            "code_system": "2.16.840.1.113883.6.238",
+            "code_system_name": "CDC Race",
+            "code_system_version": null,
+            "display_name": "Hispanic or Latino",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000064",
+            "black_list": false,
+            "code": "2186-5",
+            "code_system": "2.16.840.1.113883.6.238",
+            "code_system_name": "CDC Race",
+            "code_system_version": null,
+            "display_name": "Not Hispanic or Latino",
+            "white_list": false
+          }
+        ],
+        "display_name": "Ethnicity",
+        "oid": "2.16.840.1.114222.4.11.837",
+        "version": "20121025"
+      },
+      {
+        "_id": "521f533a0017f7454b00005b",
+        "concepts": [
+          {
+            "_id": "521f533a0017f7454b00005c",
+            "black_list": false,
+            "code": "1002-5",
+            "code_system": "2.16.840.1.113883.6.238",
+            "code_system_name": "CDC Race",
+            "code_system_version": null,
+            "display_name": "American Indian or Alaska Native",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00005d",
+            "black_list": false,
+            "code": "2028-9",
+            "code_system": "2.16.840.1.113883.6.238",
+            "code_system_name": "CDC Race",
+            "code_system_version": null,
+            "display_name": "Asian",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00005e",
+            "black_list": false,
+            "code": "2054-5",
+            "code_system": "2.16.840.1.113883.6.238",
+            "code_system_name": "CDC Race",
+            "code_system_version": null,
+            "display_name": "Black or African American",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00005f",
+            "black_list": false,
+            "code": "2076-8",
+            "code_system": "2.16.840.1.113883.6.238",
+            "code_system_name": "CDC Race",
+            "code_system_version": null,
+            "display_name": "Native Hawaiian or Other Pacific Islander",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000060",
+            "black_list": false,
+            "code": "2106-3",
+            "code_system": "2.16.840.1.113883.6.238",
+            "code_system_name": "CDC Race",
+            "code_system_version": null,
+            "display_name": "White",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000061",
+            "black_list": false,
+            "code": "2131-1",
+            "code_system": "2.16.840.1.113883.6.238",
+            "code_system_name": "CDC Race",
+            "code_system_version": null,
+            "display_name": "Other Race",
+            "white_list": false
+          }
+        ],
+        "display_name": "Race",
+        "oid": "2.16.840.1.114222.4.11.836",
+        "version": "20121025"
+      },
+      {
+        "_id": "521f533a0017f7454b000065",
+        "concepts": [
+          {
+            "_id": "521f533a0017f7454b000066",
+            "black_list": false,
+            "code": "1",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "MEDICARE",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000067",
+            "black_list": false,
+            "code": "11",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Medicare (Managed Care)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000068",
+            "black_list": false,
+            "code": "111",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Medicare HMO",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000069",
+            "black_list": false,
+            "code": "112",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Medicare PPO",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00006a",
+            "black_list": false,
+            "code": "113",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Medicare POS",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00006b",
+            "black_list": false,
+            "code": "119",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Medicare Managed Care Other",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00006c",
+            "black_list": false,
+            "code": "12",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Medicare (Non-managed Care)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00006d",
+            "black_list": false,
+            "code": "121",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Medicare FFS",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00006e",
+            "black_list": false,
+            "code": "122",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Medicare Drug Benefit",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00006f",
+            "black_list": false,
+            "code": "123",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Medicare Medical Savings Account (MSA)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000070",
+            "black_list": false,
+            "code": "129",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Medicare Non-managed Care Other",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000071",
+            "black_list": false,
+            "code": "19",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Medicare Other",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000072",
+            "black_list": false,
+            "code": "2",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "MEDICAID",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000073",
+            "black_list": false,
+            "code": "21",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Medicaid (Managed Care)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000074",
+            "black_list": false,
+            "code": "211",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Medicaid HMO",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000075",
+            "black_list": false,
+            "code": "212",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Medicaid PPO",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000076",
+            "black_list": false,
+            "code": "213",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Medicaid PCCM (Primary Care Case Management)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000077",
+            "black_list": false,
+            "code": "219",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Medicaid Managed Care Other",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000078",
+            "black_list": false,
+            "code": "22",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Medicaid (Non-managed Care Plan)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000079",
+            "black_list": false,
+            "code": "23",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Medicaid/SCHIP",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00007a",
+            "black_list": false,
+            "code": "24",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Medicaid Applicant",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00007b",
+            "black_list": false,
+            "code": "25",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Medicaid - Out of State",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00007c",
+            "black_list": false,
+            "code": "29",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Medicaid Other",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00007d",
+            "black_list": false,
+            "code": "3",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "OTHER GOVERNMENT (Federal/State/Local) (excluding Department of Corrections)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00007e",
+            "black_list": false,
+            "code": "31",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Department of Defense",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00007f",
+            "black_list": false,
+            "code": "311",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "TRICARE (CHAMPUS)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000080",
+            "black_list": false,
+            "code": "3111",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "TRICARE Prime-HMO",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000081",
+            "black_list": false,
+            "code": "3112",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "TRICARE Extra-PPO",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000082",
+            "black_list": false,
+            "code": "3113",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "TRICARE Standard - Fee For Service",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000083",
+            "black_list": false,
+            "code": "3114",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "TRICARE For Life--Medicare Supplement",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000084",
+            "black_list": false,
+            "code": "3115",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "TRICARE Reserve Select",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000085",
+            "black_list": false,
+            "code": "3116",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Uniformed Services Family Health Plan (USFHP) -- HMO",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000086",
+            "black_list": false,
+            "code": "3119",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Department of Defense - (other)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000087",
+            "black_list": false,
+            "code": "312",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Military Treatment Facility",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000088",
+            "black_list": false,
+            "code": "3121",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Enrolled Prime-HMO",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000089",
+            "black_list": false,
+            "code": "3122",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Non-enrolled Space Available",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00008a",
+            "black_list": false,
+            "code": "3123",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "TRICARE For Life (TFL)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00008b",
+            "black_list": false,
+            "code": "313",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Dental --Stand Alone",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00008c",
+            "black_list": false,
+            "code": "32",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Department of Veterans Affairs",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00008d",
+            "black_list": false,
+            "code": "321",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Veteran care--Care provided to Veterans",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00008e",
+            "black_list": false,
+            "code": "3211",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Direct Care--Care provided in VA facilities",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00008f",
+            "black_list": false,
+            "code": "3212",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Indirect Care--Care provided outside VA facilities",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000090",
+            "black_list": false,
+            "code": "32121",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Fee Basis",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000091",
+            "black_list": false,
+            "code": "32122",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Foreign Fee/Foreign Medical Program(FMP)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000092",
+            "black_list": false,
+            "code": "32123",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Contract Nursing Home/Community Nursing Home",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000093",
+            "black_list": false,
+            "code": "32124",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "State Veterans Home",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000094",
+            "black_list": false,
+            "code": "32125",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Sharing Agreements",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000095",
+            "black_list": false,
+            "code": "32126",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Other Federal Agency",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000096",
+            "black_list": false,
+            "code": "322",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Non-veteran care",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000097",
+            "black_list": false,
+            "code": "3221",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Civilian Health and Medical Program for the VA (CHAMPVA)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000098",
+            "black_list": false,
+            "code": "3222",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Spina Bifida Health Care Program (SB)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000099",
+            "black_list": false,
+            "code": "3223",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Children of Women Vietnam Veterans (CWVV)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00009a",
+            "black_list": false,
+            "code": "3229",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Other non-veteran care",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00009b",
+            "black_list": false,
+            "code": "33",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Indian Health Service or Tribe",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00009c",
+            "black_list": false,
+            "code": "331",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Indian Health Service - Regular",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00009d",
+            "black_list": false,
+            "code": "332",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Indian Health Service - Contract",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00009e",
+            "black_list": false,
+            "code": "333",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Indian Health Service - Managed Care",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00009f",
+            "black_list": false,
+            "code": "334",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Indian Tribe - Sponsored Coverage",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000a0",
+            "black_list": false,
+            "code": "34",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "HRSA Program",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000a1",
+            "black_list": false,
+            "code": "341",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Title V (MCH Block Grant)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000a2",
+            "black_list": false,
+            "code": "342",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Migrant Health Program",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000a3",
+            "black_list": false,
+            "code": "343",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Ryan White Act",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000a4",
+            "black_list": false,
+            "code": "349",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Other",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000a5",
+            "black_list": false,
+            "code": "35",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Black Lung",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000a6",
+            "black_list": false,
+            "code": "36",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "State Government",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000a7",
+            "black_list": false,
+            "code": "361",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "State SCHIP program (codes for individual states)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000a8",
+            "black_list": false,
+            "code": "362",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Specific state programs (list/ local code)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000a9",
+            "black_list": false,
+            "code": "369",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "State, not otherwise specified (other state)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000aa",
+            "black_list": false,
+            "code": "37",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Local Government",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000ab",
+            "black_list": false,
+            "code": "371",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Local - Managed care",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000ac",
+            "black_list": false,
+            "code": "3711",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "HMO",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000ad",
+            "black_list": false,
+            "code": "3712",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "PPO",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000ae",
+            "black_list": false,
+            "code": "3713",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "POS",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000af",
+            "black_list": false,
+            "code": "372",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "FFS/Indemnity",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000b0",
+            "black_list": false,
+            "code": "379",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Local, not otherwise specified (other local, county)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000b1",
+            "black_list": false,
+            "code": "38",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Other Government (Federal, State, Local not specified)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000b2",
+            "black_list": false,
+            "code": "381",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Federal, State, Local not specified managed care",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000b3",
+            "black_list": false,
+            "code": "3811",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Federal, State, Local not specified - HMO",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000b4",
+            "black_list": false,
+            "code": "3812",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Federal, State, Local not specified - PPO",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000b5",
+            "black_list": false,
+            "code": "3813",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Federal, State, Local not specified - POS",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000b6",
+            "black_list": false,
+            "code": "3819",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Federal, State, Local not specified - not specified managed care",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000b7",
+            "black_list": false,
+            "code": "382",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Federal, State, Local not specified - FFS",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000b8",
+            "black_list": false,
+            "code": "389",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Federal, State, Local not specified - Other",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000b9",
+            "black_list": false,
+            "code": "39",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Other Federal",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000ba",
+            "black_list": false,
+            "code": "4",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "DEPARTMENTS OF CORRECTIONS",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000bb",
+            "black_list": false,
+            "code": "41",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Corrections Federal",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000bc",
+            "black_list": false,
+            "code": "42",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Corrections State",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000bd",
+            "black_list": false,
+            "code": "43",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Corrections Local",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000be",
+            "black_list": false,
+            "code": "44",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Corrections Unknown Level",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000bf",
+            "black_list": false,
+            "code": "5",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "PRIVATE HEALTH INSURANCE",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000c0",
+            "black_list": false,
+            "code": "51",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Managed Care (Private)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000c1",
+            "black_list": false,
+            "code": "511",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Commercial Managed Care - HMO",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000c2",
+            "black_list": false,
+            "code": "512",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Commercial Managed Care - PPO",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000c3",
+            "black_list": false,
+            "code": "513",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Commercial Managed Care - POS",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000c4",
+            "black_list": false,
+            "code": "514",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Exclusive Provider Organization",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000c5",
+            "black_list": false,
+            "code": "515",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Gatekeeper PPO (GPPO)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000c6",
+            "black_list": false,
+            "code": "519",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Managed Care, Other (non HMO)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000c7",
+            "black_list": false,
+            "code": "52",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Private Health Insurance - Indemnity",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000c8",
+            "black_list": false,
+            "code": "521",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Commercial Indemnity",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000c9",
+            "black_list": false,
+            "code": "522",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Self-insured (ERISA) Administrative Services Only (ASO) plan",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000ca",
+            "black_list": false,
+            "code": "523",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Medicare supplemental policy (as second payer)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000cb",
+            "black_list": false,
+            "code": "529",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Private health insurance-other commercial Indemnity",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000cc",
+            "black_list": false,
+            "code": "53",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Managed Care (private) or private health insurance (indemnity), not otherwise specified",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000cd",
+            "black_list": false,
+            "code": "54",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Organized Delivery System",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000ce",
+            "black_list": false,
+            "code": "55",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Small Employer Purchasing Group",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000cf",
+            "black_list": false,
+            "code": "59",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Other Private Insurance",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000d0",
+            "black_list": false,
+            "code": "6",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "BLUE CROSS/BLUE SHIELD",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000d1",
+            "black_list": false,
+            "code": "61",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "BC Managed Care",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000d2",
+            "black_list": false,
+            "code": "611",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "BC Managed Care - HMO",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000d3",
+            "black_list": false,
+            "code": "612",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "BC Managed Care - PPO",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000d4",
+            "black_list": false,
+            "code": "613",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "BC Managed Care - POS",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000d5",
+            "black_list": false,
+            "code": "619",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "BC Managed Care - Other",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000d6",
+            "black_list": false,
+            "code": "62",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "BC Indemnity",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000d7",
+            "black_list": false,
+            "code": "63",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "BC (Indemnity or Managed Care) - Out of State",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000d8",
+            "black_list": false,
+            "code": "64",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "BC (Indemnity or Managed Care) - Unspecified",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000d9",
+            "black_list": false,
+            "code": "69",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "BC (Indemnity or Managed Care) - Other",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000da",
+            "black_list": false,
+            "code": "7",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "MANAGED CARE, UNSPECIFIED (to be used only if one can't distinguish public from private)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000db",
+            "black_list": false,
+            "code": "71",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "HMO",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000dc",
+            "black_list": false,
+            "code": "72",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "PPO",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000dd",
+            "black_list": false,
+            "code": "73",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "POS",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000de",
+            "black_list": false,
+            "code": "79",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Other Managed Care, Unknown if public or private",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000df",
+            "black_list": false,
+            "code": "8",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "NO PAYMENT from an Organization/Agency/Program/Private Payer Listed",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000e0",
+            "black_list": false,
+            "code": "81",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Self-pay",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000e1",
+            "black_list": false,
+            "code": "82",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "No Charge",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000e2",
+            "black_list": false,
+            "code": "821",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Charity",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000e3",
+            "black_list": false,
+            "code": "822",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Professional Courtesy",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000e4",
+            "black_list": false,
+            "code": "823",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Research/Clinical Trial",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000e5",
+            "black_list": false,
+            "code": "83",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Refusal to Pay/Bad Debt",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000e6",
+            "black_list": false,
+            "code": "84",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Hill Burton Free Care",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000e7",
+            "black_list": false,
+            "code": "85",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Research/Donor",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000e8",
+            "black_list": false,
+            "code": "89",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "No Payment, Other",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000e9",
+            "black_list": false,
+            "code": "9",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "MISCELLANEOUS/OTHER",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000ea",
+            "black_list": false,
+            "code": "91",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Foreign National",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000eb",
+            "black_list": false,
+            "code": "92",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Other (Non-government)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000ec",
+            "black_list": false,
+            "code": "93",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Disability Insurance",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000ed",
+            "black_list": false,
+            "code": "94",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Long-term Care Insurance",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000ee",
+            "black_list": false,
+            "code": "95",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Worker's Compensation",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000ef",
+            "black_list": false,
+            "code": "951",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Worker's Comp HMO",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000f0",
+            "black_list": false,
+            "code": "953",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Worker's Comp Fee-for-Service",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000f1",
+            "black_list": false,
+            "code": "954",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Worker's Comp Other Managed Care",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000f2",
+            "black_list": false,
+            "code": "959",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Worker's Comp, Other unspecified",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000f3",
+            "black_list": false,
+            "code": "96",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Auto Insurance (no fault)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000f4",
+            "black_list": false,
+            "code": "98",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Other specified (includes Hospice - Unspecified plan)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000f5",
+            "black_list": false,
+            "code": "99",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "No Typology Code available for payment source",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b0000f6",
+            "black_list": false,
+            "code": "9999",
+            "code_system": "2.16.840.1.113883.3.221.5",
+            "code_system_name": "SOP",
+            "code_system_version": null,
+            "display_name": "Unavailable / Unknown",
+            "white_list": false
+          }
+        ],
+        "display_name": "Payer",
+        "oid": "2.16.840.1.114222.4.11.3591",
+        "version": "20121025"
+      },
+      {
+        "_id": "521f533b0017f7454b0002b0",
+        "concepts": [
+          {
+            "_id": "521f533b0017f7454b0002b1",
+            "black_list": false,
+            "code": "21112-8",
+            "code_system": "2.16.840.1.113883.6.1",
+            "code_system_name": "LOINC",
+            "code_system_version": null,
+            "display_name": "Birth date",
+            "white_list": false
+          }
+        ],
+        "display_name": "birth date",
+        "oid": "2.16.840.1.113883.3.560.100.4",
+        "version": "20130401"
+      },
+      {
+        "_id": "521f53410017f7454b00104e",
+        "concepts": [
+          {
+            "_id": "521f53410017f7454b00104f",
+            "black_list": false,
+            "code": "G0438",
+            "code_system": "2.16.840.1.113883.6.285",
+            "code_system_name": "HCPCS",
+            "code_system_version": null,
+            "display_name": "ANNUAL WELLNESS VISIT; INCLUDES A PERSONALIZED PREVENTION PLAN OF SERVICE (PPS), INITIAL VISIT",
+            "white_list": false
+          },
+          {
+            "_id": "521f53410017f7454b001050",
+            "black_list": false,
+            "code": "G0439",
+            "code_system": "2.16.840.1.113883.6.285",
+            "code_system_name": "HCPCS",
+            "code_system_version": null,
+            "display_name": "ANNUAL WELLNESS VISIT, INCLUDES A PERSONALIZED PREVENTION PLAN OF SERVICE (PPS), SUBSEQUENT VISIT",
+            "white_list": false
+          }
+        ],
+        "display_name": "Annual Wellness Visit",
+        "oid": "2.16.840.1.113883.3.526.3.1240",
+        "version": "20130614"
+      },
+      {
+        "_id": "521f53450017f7454b0013c8",
+        "concepts": [
+          {
+            "_id": "521f53450017f7454b0013c9",
+            "black_list": false,
+            "code": "1232194",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Zolpidem tartrate 1.75 MG Sublingual Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0013ca",
+            "black_list": false,
+            "code": "1232202",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Zolpidem tartrate 3.5 MG Sublingual Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0013cb",
+            "black_list": false,
+            "code": "311988",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Nitrofurantoin 100 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0013cc",
+            "black_list": false,
+            "code": "311989",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Nitrofurantoin 5 MG/ML Oral Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0013cd",
+            "black_list": false,
+            "code": "311992",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Nitrofurantoin 100 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0013ce",
+            "black_list": false,
+            "code": "311994",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Nitrofurantoin 25 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0013cf",
+            "black_list": false,
+            "code": "311995",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Nitrofurantoin 50 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0013d0",
+            "black_list": false,
+            "code": "313761",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "zaleplon 10 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0013d1",
+            "black_list": false,
+            "code": "313762",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "zaleplon 5 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0013d2",
+            "black_list": false,
+            "code": "485440",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Eszopiclone 1 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0013d3",
+            "black_list": false,
+            "code": "485442",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Eszopiclone 2 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0013d4",
+            "black_list": false,
+            "code": "485465",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Eszopiclone 3 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0013d5",
+            "black_list": false,
+            "code": "828692",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Zolpidem tartrate 5 MG/ACTUAT Oral Spray",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0013d6",
+            "black_list": false,
+            "code": "836641",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Zolpidem tartrate 10 MG Sublingual Tablet",
+            "white_list": true
+          },
+          {
+            "_id": "521f53450017f7454b0013d7",
+            "black_list": false,
+            "code": "836647",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Zolpidem tartrate 5 MG Sublingual Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0013d8",
+            "black_list": false,
+            "code": "854873",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Zolpidem tartrate 10 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0013d9",
+            "black_list": false,
+            "code": "854876",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Zolpidem tartrate 5 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0013da",
+            "black_list": false,
+            "code": "854880",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Zolpidem tartrate 12.5 MG Extended Release Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0013db",
+            "black_list": false,
+            "code": "854894",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Zolpidem tartrate 6.25 MG Extended Release Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0013dc",
+            "black_list": false,
+            "code": "891888",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Morphine Sulfate 30 MG Extended Release Tablet",
+            "white_list": false
+          }
+        ],
+        "display_name": "High-Risk Medications With Days Supply Criteria",
+        "oid": "2.16.840.1.113883.3.464.1003.196.12.1254",
+        "version": "20130614"
+      },
+      {
+        "_id": "521f53450017f7454b001113",
+        "concepts": [
+          {
+            "_id": "521f53450017f7454b001114",
+            "black_list": false,
+            "code": "1000351",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Estrogens, Conjugated (USP) 0.3 MG / medroxyprogesterone acetate 1.5 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001115",
+            "black_list": false,
+            "code": "1000352",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Estrogens, Conjugated (USP) 0.45 MG / medroxyprogesterone acetate 1.5 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001116",
+            "black_list": false,
+            "code": "1000355",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Estrogens, Conjugated (USP) 0.625 MG / medroxyprogesterone acetate 2.5 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001117",
+            "black_list": false,
+            "code": "1000356",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Estrogens, Conjugated (USP) 0.625 MG / medroxyprogesterone acetate 5 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001118",
+            "black_list": false,
+            "code": "1000486",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "{14 (Estrogens, Conjugated (USP) 0.625 MG / medroxyprogesterone acetate 5 MG Oral Tablet) / 14 (Estrogens, Conjugated (USP) 0.625 MG Oral Tablet) } Pack",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001119",
+            "black_list": false,
+            "code": "1000490",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "{28 (Estrogens, Conjugated (USP) 0.3 MG / medroxyprogesterone acetate 1.5 MG Oral Tablet) } Pack",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00111a",
+            "black_list": false,
+            "code": "1000496",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "{28 (Estrogens, Conjugated (USP) 0.45 MG / medroxyprogesterone acetate 1.5 MG Oral Tablet) } Pack",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00111b",
+            "black_list": false,
+            "code": "1010696",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Carbinoxamine maleate 0.8 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00111c",
+            "black_list": false,
+            "code": "1010807",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "12 HR Carbinoxamine maleate 8 MG / Pseudoephedrine Hydrochloride 120 MG Extended Release Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00111d",
+            "black_list": false,
+            "code": "1010946",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Carbinoxamine maleate 0.8 MG/ML / Dextromethorphan Hydrobromide 3 MG/ML / Pseudoephedrine Hydrochloride 12 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00111e",
+            "black_list": false,
+            "code": "1010980",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Carbinoxamine maleate 1 MG/ML / Dextromethorphan Hydrobromide 4 MG/ML / Pseudoephedrine Hydrochloride 15 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00111f",
+            "black_list": false,
+            "code": "1012650",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Carbinoxamine maleate 2 MG/ML / Dextromethorphan Hydrobromide 3 MG/ML / Phenylephrine Hydrochloride 2 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001120",
+            "black_list": false,
+            "code": "1012690",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Carbinoxamine maleate 2 MG/ML / Phenylephrine Hydrochloride 2 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001121",
+            "black_list": false,
+            "code": "1012757",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Carbinoxamine maleate 1 MG/ML / Phenylephrine Hydrochloride 2 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001122",
+            "black_list": false,
+            "code": "1012764",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Carbinoxamine maleate 8 MG / Phenylephrine Hydrochloride 40 MG Extended Release Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001123",
+            "black_list": false,
+            "code": "1012904",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Carbinoxamine maleate 4 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001124",
+            "black_list": false,
+            "code": "1012940",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Carbinoxamine Tannate 0.4 MG/ML / PSEUDOEPHEDRINE TANNATE 3 MG/ML Oral Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001125",
+            "black_list": false,
+            "code": "1012950",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Carbinoxamine Tannate 0.4 MG/ML Oral Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001126",
+            "black_list": false,
+            "code": "1012956",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Carbinoxamine maleate 1 MG/ML / Pseudoephedrine Hydrochloride 15 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001127",
+            "black_list": false,
+            "code": "1012963",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Carbinoxamine maleate 1.5 MG/ML / Phenylephrine Hydrochloride 1.5 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001128",
+            "black_list": false,
+            "code": "1012972",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Carbinoxamine Tannate 0.64 MG/ML Oral Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001129",
+            "black_list": false,
+            "code": "1012974",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Carbinoxamine Tannate 0.72 MG/ML / DEXTROMETHORPHAN TANNATE 5.5 MG/ML / PSEUDOEPHEDRINE TANNATE 9.04 MG/ML Extended Release Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00112a",
+            "black_list": false,
+            "code": "1012980",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Carbinoxamine Tannate 0.72 MG/ML / PSEUDOEPHEDRINE TANNATE 9.04 MG/ML Extended Release Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00112b",
+            "black_list": false,
+            "code": "1012982",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Carbinoxamine Tannate 0.72 MG/ML Extended Release Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00112c",
+            "black_list": false,
+            "code": "1012995",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Carbinoxamine maleate 0.334 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00112d",
+            "black_list": false,
+            "code": "1020477",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Diphenhydramine Hydrochloride 50 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00112e",
+            "black_list": false,
+            "code": "1037364",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Brompheniramine Tannate 1 MG/ML / Phenylephrine Tannate 1 MG/ML Oral Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00112f",
+            "black_list": false,
+            "code": "1037379",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Brompheniramine Tannate 0.8 MG/ML / Phenylephrine Tannate 1 MG/ML Oral Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001130",
+            "black_list": false,
+            "code": "1041814",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "thyroid (USP) 97.5 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001131",
+            "black_list": false,
+            "code": "1042684",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Acetaminophen 33.3 MG/ML / Dextromethorphan Hydrobromide 1 MG/ML / doxylamine succinate 0.417 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001132",
+            "black_list": false,
+            "code": "1043400",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Acetaminophen 21.7 MG/ML / Dextromethorphan Hydrobromide 1 MG/ML / doxylamine succinate 0.417 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001133",
+            "black_list": false,
+            "code": "1046751",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Acetaminophen 325 MG / Diphenhydramine Hydrochloride 25 MG / Phenylephrine Hydrochloride 5 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001134",
+            "black_list": false,
+            "code": "1047494",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "12 HR Chlorpheniramine Maleate 6 MG / Phenylephrine Hydrochloride 15 MG Extended Release Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001135",
+            "black_list": false,
+            "code": "1049091",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Benzethonium Chloride 0.0015 MG/MG / Diphenhydramine Hydrochloride 0.02 MG/MG / Zinc Acetate 0.00215 MG/MG Topical Gel",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001136",
+            "black_list": false,
+            "code": "1049289",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "1 ML Diphenhydramine Hydrochloride 50 MG/ML Prefilled Syringe",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001137",
+            "black_list": false,
+            "code": "1049630",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Diphenhydramine Hydrochloride 25 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001138",
+            "black_list": false,
+            "code": "1049633",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Diphenhydramine Hydrochloride 50 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001139",
+            "black_list": false,
+            "code": "1049723",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Diphenhydramine Hydrochloride 0.01 MG/MG Topical Gel",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00113a",
+            "black_list": false,
+            "code": "1049880",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Diphenhydramine Hydrochloride 0.02 MG/MG Topical Gel",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00113b",
+            "black_list": false,
+            "code": "1049898",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Diphenhydramine Hydrochloride 10 MG/ML Topical Spray",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00113c",
+            "black_list": false,
+            "code": "1049900",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Diphenhydramine Hydrochloride 12.5 MG Chewable Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00113d",
+            "black_list": false,
+            "code": "1049904",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Diphenhydramine Hydrochloride 12.5 MG Oral Strip",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00113e",
+            "black_list": false,
+            "code": "1049906",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Diphenhydramine Hydrochloride 2.5 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00113f",
+            "black_list": false,
+            "code": "1049909",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Diphenhydramine Hydrochloride 25 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001140",
+            "black_list": false,
+            "code": "1049918",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Diphenhydramine Hydrochloride 25 MG Oral Strip",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001141",
+            "black_list": false,
+            "code": "1050077",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Diphenhydramine Hydrochloride 20 MG/ML Topical Cream",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001142",
+            "black_list": false,
+            "code": "1050080",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Diphenhydramine Hydrochloride 20 MG/ML Topical Spray",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001143",
+            "black_list": false,
+            "code": "1052462",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Acetaminophen 325 MG / Diphenhydramine Hydrochloride 12.5 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001144",
+            "black_list": false,
+            "code": "1052647",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Acetaminophen 325 MG / doxylamine succinate 6.25 MG / Phenylephrine Hydrochloride 5 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001145",
+            "black_list": false,
+            "code": "1052928",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Diphenhydramine Hydrochloride 25 MG / Phenylephrine Hydrochloride 10 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001146",
+            "black_list": false,
+            "code": "1053138",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Diphenhydramine Hydrochloride 20 MG/ML / Zinc Acetate 1 MG/ML Topical Spray",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001147",
+            "black_list": false,
+            "code": "1053618",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Chlorpheniramine Maleate 0.4 MG/ML / Pseudoephedrine Hydrochloride 6 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001148",
+            "black_list": false,
+            "code": "1053629",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Chlorpheniramine Maleate 8 MG / Pseudoephedrine Hydrochloride 120 MG Extended Release Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001149",
+            "black_list": false,
+            "code": "1085945",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Diphenhydramine Hydrochloride 50 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00114a",
+            "black_list": false,
+            "code": "1086463",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Chlorpheniramine Maleate 0.8 MG/ML / Phenylephrine Hydrochloride 2 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00114b",
+            "black_list": false,
+            "code": "1086475",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "12 HR Chlorpheniramine Maleate 8 MG / Phenylephrine Hydrochloride 20 MG Extended Release Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00114c",
+            "black_list": false,
+            "code": "1086720",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Diphenhydramine Hydrochloride 2.5 MG/ML / Phenylephrine Hydrochloride 1 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00114d",
+            "black_list": false,
+            "code": "1087026",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Diphenhydramine Hydrochloride 20 MG/ML / Zinc Acetate 1 MG/ML Topical Cream",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00114e",
+            "black_list": false,
+            "code": "1087459",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "12 HR Chlorpheniramine Maleate 1.6 MG/ML / Hydrocodone Bitartrate 2 MG/ML Extended Release Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00114f",
+            "black_list": false,
+            "code": "1087607",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Acetaminophen 500 MG / Diphenhydramine Hydrochloride 50 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001150",
+            "black_list": false,
+            "code": "1088936",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Chlorzoxazone 750 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001151",
+            "black_list": false,
+            "code": "1089822",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Acetaminophen 325 MG / Dextromethorphan Hydrobromide 15 MG / doxylamine succinate 6.25 MG / Pseudoephedrine Hydrochloride 30 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001152",
+            "black_list": false,
+            "code": "1090532",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Chlorpheniramine Maleate 1 MG/ML / Phenylephrine Hydrochloride 3.5 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001153",
+            "black_list": false,
+            "code": "1092189",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Acetaminophen 500 MG / Diphenhydramine Hydrochloride 25 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001154",
+            "black_list": false,
+            "code": "1092373",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Acetaminophen 33.3 MG/ML / Diphenhydramine Hydrochloride 1.67 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001155",
+            "black_list": false,
+            "code": "1092398",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Aspirin 500 MG / Diphenhydramine Hydrochloride 25 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001156",
+            "black_list": false,
+            "code": "1092411",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "{24 (Acetaminophen 500 MG / Diphenhydramine Hydrochloride 25 MG Oral Tablet) / 50 (Acetaminophen 500 MG Oral Tablet) } Pack",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001157",
+            "black_list": false,
+            "code": "1092566",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "{7 (24 HR Guanfacine 1 MG Extended Release Tablet) / 7 (24 HR Guanfacine 2 MG Extended Release Tablet) } Pack",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001158",
+            "black_list": false,
+            "code": "1092570",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "{21 (24 HR Guanfacine 1 MG Extended Release Tablet) / 28 (24 HR Guanfacine 2 MG Extended Release Tablet) } Pack",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001159",
+            "black_list": false,
+            "code": "1093075",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Acetaminophen 325 MG / Diphenhydramine Hydrochloride 50 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00115a",
+            "black_list": false,
+            "code": "1093083",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Acetaminophen 650 MG / Diphenhydramine Hydrochloride 50 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00115b",
+            "black_list": false,
+            "code": "1093098",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Diphenhydramine Hydrochloride 25 MG Disintegrating Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00115c",
+            "black_list": false,
+            "code": "1094131",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Acetaminophen 65 MG/ML / Dextromethorphan Hydrobromide 2 MG/ML / Diphenhydramine Hydrochloride 2.5 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00115d",
+            "black_list": false,
+            "code": "1094330",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Brompheniramine Maleate 0.8 MG/ML / Pseudoephedrine Hydrochloride 4 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00115e",
+            "black_list": false,
+            "code": "1094350",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Dextromethorphan Hydrobromide 3 MG/ML / doxylamine succinate 1.25 MG/ML / Pseudoephedrine Hydrochloride 6 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00115f",
+            "black_list": false,
+            "code": "1094355",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "doxylamine succinate 1.25 MG/ML / Pseudoephedrine Hydrochloride 6 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001160",
+            "black_list": false,
+            "code": "1094406",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "chlophedianol hydrochloride 5 MG/ML / Triprolidine Hydrochloride 0.5 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001161",
+            "black_list": false,
+            "code": "1094434",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Phenylephrine Hydrochloride 2 MG/ML / Triprolidine Hydrochloride 0.5 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001162",
+            "black_list": false,
+            "code": "1094473",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Diphenhydramine Hydrochloride 10 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001163",
+            "black_list": false,
+            "code": "1094501",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "chlophedianol hydrochloride 5 MG/ML / Phenylephrine Hydrochloride 2 MG/ML / Triprolidine Hydrochloride 0.5 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001164",
+            "black_list": false,
+            "code": "1094549",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Acetaminophen 325 MG / Dextromethorphan Hydrobromide 15 MG / doxylamine succinate 6.25 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001165",
+            "black_list": false,
+            "code": "1098443",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "{10 (Acetaminophen 325 MG / Dextromethorphan Hydrobromide 10 MG / Guaifenesin 100 MG / Phenylephrine Hydrochloride 5 MG Oral Tablet) / 10 (Acetaminophen 325 MG / Diphenhydramine Hydrochloride 25 MG / Phenylephrine Hydrochloride 5 MG Oral Tablet) } Pack",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001166",
+            "black_list": false,
+            "code": "1098881",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "chlophedianol hydrochloride 2.5 MG/ML / Pseudoephedrine Hydrochloride 6 MG/ML / Triprolidine Hydrochloride 0.25 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001167",
+            "black_list": false,
+            "code": "1098906",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Brompheniramine Maleate 0.4 MG/ML / Guaifenesin 40 MG/ML / Hydrocodone Bitartrate 1 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001168",
+            "black_list": false,
+            "code": "1099308",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Pseudoephedrine Hydrochloride 6 MG/ML / Triprolidine Hydrochloride 0.25 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001169",
+            "black_list": false,
+            "code": "1099446",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Pseudoephedrine Hydrochloride 60 MG / Triprolidine Hydrochloride 2.5 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00116a",
+            "black_list": false,
+            "code": "1099644",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Acetaminophen 500 MG / Pseudoephedrine Hydrochloride 30 MG / Triprolidine Hydrochloride 1.25 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00116b",
+            "black_list": false,
+            "code": "1099653",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Dextromethorphan Hydrobromide 4 MG/ML / Pseudoephedrine Hydrochloride 10 MG/ML / Triprolidine Hydrochloride 0.938 MG/ML Oral Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00116c",
+            "black_list": false,
+            "code": "1099654",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Hydrocodone Bitartrate 0.5 MG/ML / Pseudoephedrine Hydrochloride 6 MG/ML / Triprolidine Hydrochloride 0.25 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00116d",
+            "black_list": false,
+            "code": "1099659",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Phenylephrine Hydrochloride 10 MG / Triprolidine Hydrochloride 2.5 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00116e",
+            "black_list": false,
+            "code": "1099668",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Pseudoephedrine Hydrochloride 10 MG/ML / Triprolidine Hydrochloride 0.938 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00116f",
+            "black_list": false,
+            "code": "1099677",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Pseudoephedrine Hydrochloride 9 MG/ML / Triprolidine Hydrochloride 0.25 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001170",
+            "black_list": false,
+            "code": "1099684",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Triprolidine Hydrochloride 0.25 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001171",
+            "black_list": false,
+            "code": "1099694",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Triprolidine Hydrochloride 2.5 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001172",
+            "black_list": false,
+            "code": "1099711",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Codeine Phosphate 20 MG / Pseudoephedrine Hydrochloride 60 MG / Triprolidine Hydrochloride 4 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001173",
+            "black_list": false,
+            "code": "1099779",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "PSEUDOEPHEDRINE TANNATE 9 MG/ML / triprolidine tannate 0.5 MG/ML Extended Release Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001174",
+            "black_list": false,
+            "code": "1099788",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "triprolidine tannate 0.5 MG/ML Extended Release Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001175",
+            "black_list": false,
+            "code": "1099872",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Acetaminophen 500 MG / Diphenhydramine Citrate 38 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001176",
+            "black_list": false,
+            "code": "1099948",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "thyroid (USP) 48.8 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001177",
+            "black_list": false,
+            "code": "1100501",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Chlorpheniramine Maleate 0.8 MG/ML / Phenylephrine Hydrochloride 2.5 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001178",
+            "black_list": false,
+            "code": "1101427",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "doxylamine succinate 1 MG/ML Oral Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001179",
+            "black_list": false,
+            "code": "1101439",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "doxylamine succinate 5 MG Chewable Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00117a",
+            "black_list": false,
+            "code": "1101446",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "doxylamine succinate 25 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00117b",
+            "black_list": false,
+            "code": "1101457",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "doxylamine succinate 1 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00117c",
+            "black_list": false,
+            "code": "1101855",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "12 HR Chlorpheniramine Maleate 8 MG / methscopolamine nitrate 2.5 MG Extended Release Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00117d",
+            "black_list": false,
+            "code": "1101858",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Chlorpheniramine Maleate 8 MG / methscopolamine nitrate 2.5 MG Extended Release Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00117e",
+            "black_list": false,
+            "code": "1112489",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Chlorpheniramine Maleate 1 MG/ML / Phenylephrine Hydrochloride 2.5 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00117f",
+            "black_list": false,
+            "code": "1112779",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "12 HR Chlorpheniramine Maleate 8 MG / Pseudoephedrine Hydrochloride 120 MG Extended Release Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001180",
+            "black_list": false,
+            "code": "1113380",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Chlorpheniramine Maleate 0.8 MG/ML / Pseudoephedrine Hydrochloride 9 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001181",
+            "black_list": false,
+            "code": "1113998",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Chlorpheniramine Maleate 0.4 MG/ML / Codeine Phosphate 1.6 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001182",
+            "black_list": false,
+            "code": "1115329",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Dextromethorphan Hydrobromide 1.5 MG/ML / doxylamine succinate 0.625 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001183",
+            "black_list": false,
+            "code": "1117245",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Acetaminophen 500 MG / Diphenhydramine Hydrochloride 25 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001184",
+            "black_list": false,
+            "code": "1119420",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Promethazine Hydrochloride 1 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001185",
+            "black_list": false,
+            "code": "1145951",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Diphenhydramine Hydrochloride 0.02 MG/MG / Menthol 0.01 MG/MG Topical Gel",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001186",
+            "black_list": false,
+            "code": "1147619",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Acetaminophen 650 MG / Diphenhydramine Hydrochloride 25 MG / Phenylephrine Hydrochloride 10 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001187",
+            "black_list": false,
+            "code": "1148155",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Brompheniramine Maleate 0.8 MG/ML / Dextromethorphan Hydrobromide 4 MG/ML / Phenylephrine Hydrochloride 2 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001188",
+            "black_list": false,
+            "code": "1149632",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "84 HR Estradiol 0.00313 MG/HR Transdermal Patch",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001189",
+            "black_list": false,
+            "code": "1189337",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Cyclobenzaprine hydrochloride 1 MG/ML Oral Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00118a",
+            "black_list": false,
+            "code": "1190448",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "12 HR Diphenhydramine Hydrochloride 100 MG / Pseudoephedrine Hydrochloride 120 MG Extended Release Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00118b",
+            "black_list": false,
+            "code": "1232642",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Calamine 140 MG/ML / Diphenhydramine Hydrochloride 20 MG/ML Topical Cream",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00118c",
+            "black_list": false,
+            "code": "1233546",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "{20 (Acetaminophen 325 MG / Dextromethorphan Hydrobromide 10 MG / Phenylephrine Hydrochloride 5 MG Oral Capsule) / 20 (Acetaminophen 325 MG / Dextromethorphan Hydrobromide 15 MG / doxylamine succinate 6.25 MG Oral Capsule) } Pack",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00118d",
+            "black_list": false,
+            "code": "1234386",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Dextromethorphan Hydrobromide 1 MG/ML / doxylamine succinate 0.417 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00118e",
+            "black_list": false,
+            "code": "1236048",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Diphenhydramine Hydrochloride 1.25 MG/ML / Phenylephrine Hydrochloride 0.5 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00118f",
+            "black_list": false,
+            "code": "1236387",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Acetaminophen 21.7 MG/ML / Dextromethorphan Hydrobromide 0.667 MG/ML / doxylamine succinate 0.417 MG/ML / Phenylephrine Hydrochloride 0.334 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001190",
+            "black_list": false,
+            "code": "1236395",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Acetaminophen 250 MG / Dextromethorphan Hydrobromide 10 MG / doxylamine succinate 6.25 MG / Pseudoephedrine Hydrochloride 30 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001191",
+            "black_list": false,
+            "code": "1236403",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "4.5 ML Acetaminophen 144 MG/ML / Dextromethorphan Hydrobromide 4.44 MG/ML / doxylamine succinate 2.78 MG/ML / Phenylephrine Hydrochloride 2.22 MG/ML Prefilled Applicator",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001192",
+            "black_list": false,
+            "code": "1236420",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "{1 (177 ML) (Acetaminophen 33.3 MG/ML / Dextromethorphan Hydrobromide 1 MG/ML / doxylamine succinate 0.417 MG/ML / Pseudoephedrine Hydrochloride 2 MG/ML Oral Solution) / 12 (Acetaminophen 250 MG / Dextromethorphan Hydrobromide 10 MG / Pseudoephedrine Hydrochloride 30 MG Oral Capsule) } Pack",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001193",
+            "black_list": false,
+            "code": "1236428",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Acetaminophen 500 MG / doxylamine succinate 6.25 MG / Pseudoephedrine Hydrochloride 30 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001194",
+            "black_list": false,
+            "code": "1236455",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "{20 (Acetaminophen 325 MG / Dextromethorphan Hydrobromide 15 MG / doxylamine succinate 6.25 MG Oral Capsule) / 24 (Acetaminophen 325 MG / Dextromethorphan Hydrobromide 15 MG / Pseudoephedrine Hydrochloride 30 MG Oral Capsule) } Pack",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001195",
+            "black_list": false,
+            "code": "1236459",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "{12 (Acetaminophen 500 MG / doxylamine succinate 6.25 MG / Pseudoephedrine Hydrochloride 30 MG Oral Tablet) / 12 (Acetaminophen 500 MG / Pseudoephedrine Hydrochloride 30 MG Oral Tablet) } Pack",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001196",
+            "black_list": false,
+            "code": "1237035",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Acetaminophen 325 MG / Dextromethorphan Hydrobromide 10 MG / doxylamine succinate 6.25 MG / Pseudoephedrine Hydrochloride 30 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001197",
+            "black_list": false,
+            "code": "1237103",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Acetaminophen 33.3 MG/ML / Dextromethorphan Hydrobromide 1 MG/ML / doxylamine succinate 0.25 MG/ML / Pseudoephedrine Hydrochloride 2 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001198",
+            "black_list": false,
+            "code": "1237110",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Acetaminophen 33.3 MG/ML / Dextromethorphan Hydrobromide 1 MG/ML / doxylamine succinate 0.417 MG/ML / Pseudoephedrine Hydrochloride 2 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001199",
+            "black_list": false,
+            "code": "1237118",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "12 HR Chlorpheniramine Maleate 4 MG / Pseudoephedrine Hydrochloride 60 MG Extended Release Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00119a",
+            "black_list": false,
+            "code": "1242072",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Acetaminophen 5 MG/ML / Dextromethorphan Hydrobromide 0.2 MG/ML / doxylamine succinate 0.125 MG/ML / Phenylephrine Hydrochloride 0.1 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00119b",
+            "black_list": false,
+            "code": "1242502",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Acetaminophen 33.3 MG/ML / Dextromethorphan Hydrobromide 1 MG/ML / doxylamine succinate 0.417 MG/ML / Phenylephrine Hydrochloride 0.333 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00119c",
+            "black_list": false,
+            "code": "1242515",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "doxylamine succinate 10 MG / Vitamin B6 10 MG Enteric Coated Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00119d",
+            "black_list": false,
+            "code": "1242522",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "doxylamine succinate 10 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00119e",
+            "black_list": false,
+            "code": "1242582",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "doxylamine succinate 25 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00119f",
+            "black_list": false,
+            "code": "1242618",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Acetaminophen 250 MG / doxylamine succinate 25 MG / salicylamide 150 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0011a0",
+            "black_list": false,
+            "code": "1242622",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Acetaminophen 5.56 MG/ML / Dextromethorphan Hydrobromide 0.167 MG/ML / doxylamine succinate 0.0694 MG/ML / Pseudoephedrine Hydrochloride 0.333 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0011a1",
+            "black_list": false,
+            "code": "1244523",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Brompheniramine Maleate 1.2 MG/ML / Phenylephrine Hydrochloride 2 MG/ML Oral Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0011a2",
+            "black_list": false,
+            "code": "1244714",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "24 HR Chlorpheniramine Maleate 12 MG / Pseudoephedrine Hydrochloride 100 MG Extended Release Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0011a3",
+            "black_list": false,
+            "code": "1244743",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "thyroid (USP) 114 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0011a4",
+            "black_list": false,
+            "code": "1244747",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "thyroid (USP) 81.3 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0011a5",
+            "black_list": false,
+            "code": "1244918",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Acetaminophen 21.7 MG/ML / Dextromethorphan Hydrobromide 1 MG/ML / doxylamine succinate 0.25 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0011a6",
+            "black_list": false,
+            "code": "1245284",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Chlorpheniramine Maleate 0.8 MG/ML / methscopolamine nitrate 0.25 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0011a7",
+            "black_list": false,
+            "code": "1248057",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Phenylephrine Hydrochloride 1 MG/ML / Promethazine Hydrochloride 1.25 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0011a8",
+            "black_list": false,
+            "code": "1248354",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Diphenhydramine Hydrochloride 1.67 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0011a9",
+            "black_list": false,
+            "code": "1249617",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Acetaminophen 300 MG / butalbital 50 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0011aa",
+            "black_list": false,
+            "code": "1250949",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Chlorpheniramine Maleate 0.4 MG/ML / methscopolamine nitrate 0.25 MG/ML / Phenylephrine Hydrochloride 2 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0011ab",
+            "black_list": false,
+            "code": "1251493",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "84 HR Estradiol 0.00208 MG/HR / norethindrone acetate 0.00583 MG/HR Transdermal Patch",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0011ac",
+            "black_list": false,
+            "code": "1251499",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "84 HR Estradiol 0.00208 MG/HR / norethindrone acetate 0.0104 MG/HR Transdermal Patch",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0011ad",
+            "black_list": false,
+            "code": "1251614",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Butabarbital sodium 30 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0011ae",
+            "black_list": false,
+            "code": "1251621",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Butabarbital sodium 50 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0011af",
+            "black_list": false,
+            "code": "1251625",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Butabarbital sodium 6 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0011b0",
+            "black_list": false,
+            "code": "1251756",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Diphenhydramine Hydrochloride 10 MG/ML Topical Lotion",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0011b1",
+            "black_list": false,
+            "code": "1251762",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Diphenhydramine Hydrochloride 25 MG / Phenylephrine Hydrochloride 10 MG Oral Strip",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0011b2",
+            "black_list": false,
+            "code": "1251770",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Diphenhydramine Hydrochloride 3.33 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0011b3",
+            "black_list": false,
+            "code": "1251771",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Diphenhydramine Hydrochloride 25 MG / Pseudoephedrine Hydrochloride 30 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0011b4",
+            "black_list": false,
+            "code": "1251787",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Diphenhydramine Tannate 25 MG Chewable Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0011b5",
+            "black_list": false,
+            "code": "1251791",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Butabarbital sodium 30 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0011b6",
+            "black_list": false,
+            "code": "1251792",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Butabarbital sodium 15 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0011b7",
+            "black_list": false,
+            "code": "1251794",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Butabarbital sodium 6.66 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0011b8",
+            "black_list": false,
+            "code": "1251836",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Diphenhydramine Hydrochloride 20 MG/ML Topical Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0011b9",
+            "black_list": false,
+            "code": "1251838",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Diphenhydramine Hydrochloride 5 MG/ML Oral Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0011ba",
+            "black_list": false,
+            "code": "1291711",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Acetaminophen 500 MG / Diphenhydramine Hydrochloride 25 MG / Pseudoephedrine Hydrochloride 30 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0011bb",
+            "black_list": false,
+            "code": "1291718",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "{12 (Acetaminophen 500 MG / Chlorpheniramine Maleate 2 MG / Pseudoephedrine Hydrochloride 30 MG Oral Tablet) / 12 (Acetaminophen 500 MG / Diphenhydramine Hydrochloride 25 MG / Pseudoephedrine Hydrochloride 30 MG Oral Tablet) } Pack",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0011bc",
+            "black_list": false,
+            "code": "1291854",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Acetaminophen 650 MG / Diphenhydramine Hydrochloride 50 MG / Pseudoephedrine Hydrochloride 60 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0011bd",
+            "black_list": false,
+            "code": "1291867",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Ammonium Chloride 25 MG/ML / Diphenhydramine Hydrochloride 2.5 MG/ML / sodium citrate 10 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0011be",
+            "black_list": false,
+            "code": "1291868",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Aspirin 325 MG / Diphenhydramine Citrate 38 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0011bf",
+            "black_list": false,
+            "code": "1292097",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Diphenhydramine Hydrochloride 0.02 MG/MG / resorcinol 0.02 MG/MG Topical Ointment",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0011c0",
+            "black_list": false,
+            "code": "1292098",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Diphenhydramine Hydrochloride 1.25 MG/ML / Phenylephrine Hydrochloride 1.25 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0011c1",
+            "black_list": false,
+            "code": "1292313",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Diphenhydramine Hydrochloride 10 MG/ML / Zinc Acetate 1 MG/ML Topical Cream",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0011c2",
+            "black_list": false,
+            "code": "1292314",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Diphenhydramine Hydrochloride 20 MG/ML / Zinc Oxide 20 MG/ML Topical Lotion",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0011c3",
+            "black_list": false,
+            "code": "1292321",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Diphenhydramine Hydrochloride 20 MG/ML / Pramoxine hydrochloride 10 MG/ML Topical Lotion",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0011c4",
+            "black_list": false,
+            "code": "1292322",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Diphenhydramine Hydrochloride 25 MG / Magnesium Salicylate 500 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0011c5",
+            "black_list": false,
+            "code": "1292324",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Diphenhydramine Hydrochloride 5 MG/ML / Hydrocortisone 5 MG/ML Topical Lotion",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0011c6",
+            "black_list": false,
+            "code": "1293036",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Chlorpheniramine Tannate 0.4 MG/ML / methscopolamine nitrate 0.3 MG/ML Oral Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0011c7",
+            "black_list": false,
+            "code": "1293040",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Chlorpheniramine Tannate 2 MG / methscopolamine nitrate 1.5 MG Chewable Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0011c8",
+            "black_list": false,
+            "code": "1293706",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Acetaminophen 80 MG / Diphenhydramine Hydrochloride 6.25 MG / Pseudoephedrine Hydrochloride 7.5 MG Chewable Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0011c9",
+            "black_list": false,
+            "code": "1293710",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Acetaminophen 32 MG/ML / Diphenhydramine Hydrochloride 2.5 MG/ML / Pseudoephedrine Hydrochloride 3 MG/ML Oral Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0011ca",
+            "black_list": false,
+            "code": "1294306",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "12 HR Brompheniramine Maleate 6 MG / Diphenhydramine Hydrochloride 25 MG Extended Release Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0011cb",
+            "black_list": false,
+            "code": "1294313",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "12 HR Brompheniramine Maleate 6 MG / Diphenhydramine Hydrochloride 25 MG / Phenylephrine Hydrochloride 20 MG Extended Release Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0011cc",
+            "black_list": false,
+            "code": "1294322",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Diphenhydramine Hydrochloride 5 MG/ML / Phenylephrine Hydrochloride 1.5 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0011cd",
+            "black_list": false,
+            "code": "1294338",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Aspirin 5.42 MG/ML / Diphenhydramine Citrate 0.633 MG/ML / Phenylpropanolamine Hydrochloride 0.25 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0011ce",
+            "black_list": false,
+            "code": "1294348",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Diphenhydramine Hydrochloride 12.5 MG / Phenylephrine Hydrochloride 5 MG Chewable Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0011cf",
+            "black_list": false,
+            "code": "1294366",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Diphenhydramine Tannate 5 MG/ML / Phenylephrine Tannate 1.5 MG/ML Extended Release Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0011d0",
+            "black_list": false,
+            "code": "1294367",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Diphenhydramine Tannate 5 MG/ML Extended Release Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0011d1",
+            "black_list": false,
+            "code": "1294368",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "CARBETAPENTANE TANNATE 6 MG/ML / Diphenhydramine Tannate 5 MG/ML Extended Release Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0011d2",
+            "black_list": false,
+            "code": "1294370",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "CARBETAPENTANE TANNATE 6 MG/ML / Diphenhydramine Tannate 5 MG/ML / Phenylephrine Tannate 3 MG/ML Extended Release Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0011d3",
+            "black_list": false,
+            "code": "1294371",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "CARBETAPENTANE TANNATE 30 MG / Diphenhydramine Tannate 25 MG / Phenylephrine Tannate 10 MG Extended Release Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0011d4",
+            "black_list": false,
+            "code": "1294372",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "CARBETAPENTANE TANNATE 6 MG/ML / Diphenhydramine Tannate 5 MG/ML / Phenylephrine Tannate 1.5 MG/ML Extended Release Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0011d5",
+            "black_list": false,
+            "code": "1294380",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Diphenhydramine Tannate 5 MG/ML / hydrocodone tannate 0.7 MG/ML / Phenylephrine Tannate 1.5 MG/ML Extended Release Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0011d6",
+            "black_list": false,
+            "code": "1294382",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Diphenhydramine Hydrochloride 2.5 MG/ML / Hydrocodone Bitartrate 0.7 MG/ML / Phenylephrine Hydrochloride 1 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0011d7",
+            "black_list": false,
+            "code": "1294383",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Diphenhydramine Hydrochloride 2.5 MG/ML / Hydrocodone Bitartrate 0.4 MG/ML / Phenylephrine Hydrochloride 1.5 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0011d8",
+            "black_list": false,
+            "code": "1294557",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Diphenhydramine Hydrochloride 25 MG / Pseudoephedrine Hydrochloride 60 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0011d9",
+            "black_list": false,
+            "code": "1294564",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Acetaminophen 500 MG / Diphenhydramine Hydrochloride 12.5 MG / Pseudoephedrine Hydrochloride 30 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0011da",
+            "black_list": false,
+            "code": "1294567",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Acetaminophen 500 MG / Diphenhydramine Hydrochloride 12.5 MG / Pseudoephedrine Hydrochloride 30 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0011db",
+            "black_list": false,
+            "code": "1294572",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Diphenhydramine Hydrochloride 2.5 MG/ML / Pseudoephedrine Hydrochloride 6 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0011dc",
+            "black_list": false,
+            "code": "1294589",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Diphenhydramine Hydrochloride 20 MG/ML / Zinc Acetate 1 MG/ML Topical Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0011dd",
+            "black_list": false,
+            "code": "1294602",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Acetaminophen 32 MG/ML / Diphenhydramine Hydrochloride 2.5 MG/ML / Phenylephrine Hydrochloride 0.5 MG/ML Oral Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0011de",
+            "black_list": false,
+            "code": "1294607",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Acetaminophen 21.7 MG/ML / Diphenhydramine Hydrochloride 0.833 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0011df",
+            "black_list": false,
+            "code": "1297410",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Diphenhydramine Hydrochloride 5 MG/ML Topical Spray",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0011e0",
+            "black_list": false,
+            "code": "1297514",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Diphenhydramine Hydrochloride 20 MG/ML / Menthol 10 MG/ML Topical Spray",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0011e1",
+            "black_list": false,
+            "code": "1297517",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Diphenhydramine Hydrochloride 25 MG / Magnesium Salicylate 580 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0011e2",
+            "black_list": false,
+            "code": "1297947",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Acetaminophen 500 MG / Diphenhydramine Citrate 38 MG Oral Powder",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0011e3",
+            "black_list": false,
+            "code": "1297950",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Diphenhydramine Hydrochloride 5 MG/ML / Hydrocortisone 5 MG/ML Topical Spray",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0011e4",
+            "black_list": false,
+            "code": "1297967",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "12 HR Acetaminophen 575 MG / Dextromethorphan Hydrobromide 30 MG / Diphenhydramine Hydrochloride 37.5 MG / Phenylephrine Hydrochloride 18 MG Extended Release Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0011e5",
+            "black_list": false,
+            "code": "1297974",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Acetaminophen 575 MG / Dextromethorphan Hydrobromide 20 MG / Diphenhydramine Hydrochloride 37.5 MG / Phenylephrine Hydrochloride 10 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0011e6",
+            "black_list": false,
+            "code": "1298267",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Diphenhydramine Hydrochloride 2.5 MG/ML / Guaifenesin 40 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0011e7",
+            "black_list": false,
+            "code": "1298287",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Diphenhydramine Hydrochloride 20 MG/ML / Menthol 10 MG/ML Topical Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0011e8",
+            "black_list": false,
+            "code": "1298288",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Acetaminophen 650 MG / Dextromethorphan Hydrobromide 30 MG / Diphenhydramine Hydrochloride 50 MG / Pseudoephedrine Hydrochloride 60 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0011e9",
+            "black_list": false,
+            "code": "1298295",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Acetaminophen 2.7 MG/ML / Diphenhydramine Hydrochloride 0.104 MG/ML / Phenylephrine Hydrochloride 0.0417 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0011ea",
+            "black_list": false,
+            "code": "1298348",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Acetaminophen 21.7 MG/ML / Diphenhydramine Hydrochloride 0.833 MG/ML / Phenylephrine Hydrochloride 0.333 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0011eb",
+            "black_list": false,
+            "code": "1298442",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Diphenhydramine Hydrochloride 25 MG / Niacin 50 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0011ec",
+            "black_list": false,
+            "code": "1298446",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Diphenhydramine Hydrochloride 25 MG / Pseudoephedrine Hydrochloride 60 MG Extended Release Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0011ed",
+            "black_list": false,
+            "code": "1298799",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Isoxsuprine Hydrochloride 20 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0011ee",
+            "black_list": false,
+            "code": "1298834",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Isoxsuprine Hydrochloride 10 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0011ef",
+            "black_list": false,
+            "code": "1300081",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "12 HR Brompheniramine Maleate 6 MG / Pseudoephedrine Hydrochloride 60 MG Extended Release Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0011f0",
+            "black_list": false,
+            "code": "1300084",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "12 HR Brompheniramine Maleate 12 MG / Pseudoephedrine Hydrochloride 120 MG Extended Release Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0011f1",
+            "black_list": false,
+            "code": "1300164",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Dexbrompheniramine maleate 0.4 MG/ML / Dextromethorphan Hydrobromide 4 MG/ML / Phenylephrine Hydrochloride 2 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0011f2",
+            "black_list": false,
+            "code": "1304533",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Brompheniramine Tannate 1.2 MG/ML / PSEUDOEPHEDRINE TANNATE 6 MG/ML Extended Release Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0011f3",
+            "black_list": false,
+            "code": "1305588",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "12 HR Dexbrompheniramine maleate 6 MG / Pseudoephedrine Hydrochloride 120 MG Extended Release Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0011f4",
+            "black_list": false,
+            "code": "1305775",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "dexchlorpheniramine tannate 0.7 MG/ML / DEXTROMETHORPHAN TANNATE 6 MG/ML / PSEUDOEPHEDRINE TANNATE 9 MG/ML Extended Release Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0011f5",
+            "black_list": false,
+            "code": "1307225",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Chlorpheniramine Tannate 0.8 MG/ML / Phenylephrine Tannate 4 MG/ML Extended Release Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0011f6",
+            "black_list": false,
+            "code": "1308438",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Brompheniramine Maleate 0.4 MG/ML / Codeine Phosphate 2 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0011f7",
+            "black_list": false,
+            "code": "1356800",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Brompheniramine Maleate 4 MG / Codeine Phosphate 10 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0011f8",
+            "black_list": false,
+            "code": "1356807",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Brompheniramine Maleate 4 MG / Codeine Phosphate 20 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0011f9",
+            "black_list": false,
+            "code": "1356833",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "12 HR Brompheniramine Maleate 9 MG / Pseudoephedrine Hydrochloride 90 MG Extended Release Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0011fa",
+            "black_list": false,
+            "code": "1356841",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Brompheniramine Maleate 0.8 MG/ML / Phenylephrine Hydrochloride 2 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0011fb",
+            "black_list": false,
+            "code": "1356848",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Brompheniramine Tannate 12 MG Chewable Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0011fc",
+            "black_list": false,
+            "code": "1356859",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Brompheniramine Tannate 2.4 MG/ML / Phenylephrine Tannate 2 MG/ML Extended Release Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0011fd",
+            "black_list": false,
+            "code": "1356866",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Brompheniramine Maleate 4 MG / Pseudoephedrine Hydrochloride 40 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0011fe",
+            "black_list": false,
+            "code": "1357013",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Brompheniramine Maleate 0.4 MG/ML / Phenylephrine Hydrochloride 1 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0011ff",
+            "black_list": false,
+            "code": "1357389",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Brompheniramine Maleate 0.4 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001200",
+            "black_list": false,
+            "code": "1359123",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Estradiol 0.5 MG / norethindrone acetate 0.1 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001201",
+            "black_list": false,
+            "code": "1359124",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "{28 (Estradiol 0.5 MG / norethindrone acetate 0.1 MG Oral Tablet) } Pack",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001202",
+            "black_list": false,
+            "code": "1359126",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Estradiol 1 MG / norethindrone acetate 0.5 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001203",
+            "black_list": false,
+            "code": "1359127",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "{28 (Estradiol 1 MG / norethindrone acetate 0.5 MG Oral Tablet) } Pack",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001204",
+            "black_list": false,
+            "code": "1362789",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Dexchlorpheniramine maleate 0.2 MG/ML / Hydrocodone Bitartrate 0.4 MG/ML / Phenylephrine Hydrochloride 1 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001205",
+            "black_list": false,
+            "code": "1363011",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "12 HR Brompheniramine Maleate 10 MG / Pseudoephedrine Hydrochloride 120 MG Extended Release Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001206",
+            "black_list": false,
+            "code": "1363504",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Dexbrompheniramine maleate 6 MG Extended Release Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001207",
+            "black_list": false,
+            "code": "1363648",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Brompheniramine Maleate 6 MG / Phenylephrine Hydrochloride 15 MG Chewable Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001208",
+            "black_list": false,
+            "code": "1363651",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Chlorpheniramine Maleate 2 MG / methscopolamine nitrate 1.25 MG / Phenylephrine Hydrochloride 15 MG Chewable Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001209",
+            "black_list": false,
+            "code": "1366953",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Chlorpheniramine Tannate 0.8 MG/ML Oral Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00120a",
+            "black_list": false,
+            "code": "153444",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Estradiol 0.001 MG/MG Topical Gel",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00120b",
+            "black_list": false,
+            "code": "197426",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Acetaminophen 325 MG / butalbital 50 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00120c",
+            "black_list": false,
+            "code": "197427",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Acetaminophen 650 MG / butalbital 50 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00120d",
+            "black_list": false,
+            "code": "197428",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Acetaminophen 650 MG / butalbital 50 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00120e",
+            "black_list": false,
+            "code": "197429",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Aspirin 650 MG / butalbital 50 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00120f",
+            "black_list": false,
+            "code": "197446",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Carisoprodol 350 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001210",
+            "black_list": false,
+            "code": "197447",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Aspirin 325 MG / Carisoprodol 200 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001211",
+            "black_list": false,
+            "code": "197458",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Chloral Hydrate 325 MG Rectal Suppository",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001212",
+            "black_list": false,
+            "code": "197459",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Chloral Hydrate 500 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001213",
+            "black_list": false,
+            "code": "197460",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Chloral Hydrate 500 MG Rectal Suppository",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001214",
+            "black_list": false,
+            "code": "197461",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Chloral Hydrate 650 MG Rectal Suppository",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001215",
+            "black_list": false,
+            "code": "197495",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Chlorpropamide 100 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001216",
+            "black_list": false,
+            "code": "197496",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Chlorpropamide 250 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001217",
+            "black_list": false,
+            "code": "197501",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Chlorzoxazone 250 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001218",
+            "black_list": false,
+            "code": "197502",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Chlorzoxazone 500 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001219",
+            "black_list": false,
+            "code": "197622",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Dipyridamole 50 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00121a",
+            "black_list": false,
+            "code": "197647",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "ergoloid mesylates, USP 1 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00121b",
+            "black_list": false,
+            "code": "197657",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Estradiol 0.5 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00121c",
+            "black_list": false,
+            "code": "197658",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Estradiol 1 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00121d",
+            "black_list": false,
+            "code": "197659",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Estradiol 2 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00121e",
+            "black_list": false,
+            "code": "197660",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Estrogens, Conjugated (USP) 0.3 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00121f",
+            "black_list": false,
+            "code": "197661",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Estrogens, Conjugated (USP) 0.9 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001220",
+            "black_list": false,
+            "code": "197662",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Estrogens, Conjugated (USP) 1.25 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001221",
+            "black_list": false,
+            "code": "197663",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Estrogens, Conjugated (USP) 2.5 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001222",
+            "black_list": false,
+            "code": "197666",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Estrogens, Esterified (USP) 0.3 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001223",
+            "black_list": false,
+            "code": "197667",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Estrogens, Esterified (USP) 0.625 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001224",
+            "black_list": false,
+            "code": "197668",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Estrogens, Esterified (USP) 1.25 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001225",
+            "black_list": false,
+            "code": "197669",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Estrogens, Esterified (USP) 2.5 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001226",
+            "black_list": false,
+            "code": "197670",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Estrogens, Esterified (USP) 1.25 MG / Methyltestosterone 2.5 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001227",
+            "black_list": false,
+            "code": "197737",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Glyburide 1.25 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001228",
+            "black_list": false,
+            "code": "197743",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Guanabenz 4 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001229",
+            "black_list": false,
+            "code": "197744",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Guanabenz 8 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00122a",
+            "black_list": false,
+            "code": "197745",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Guanfacine 1 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00122b",
+            "black_list": false,
+            "code": "197746",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Guanfacine 2 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00122c",
+            "black_list": false,
+            "code": "197817",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Indomethacin 25 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00122d",
+            "black_list": false,
+            "code": "197818",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Indomethacin 50 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00122e",
+            "black_list": false,
+            "code": "197819",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Indomethacin 50 MG Rectal Suppository",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00122f",
+            "black_list": false,
+            "code": "197923",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Mephobarbital 100 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001230",
+            "black_list": false,
+            "code": "197924",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Mephobarbital 32 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001231",
+            "black_list": false,
+            "code": "197925",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Mephobarbital 50 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001232",
+            "black_list": false,
+            "code": "197928",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Meprobamate 200 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001233",
+            "black_list": false,
+            "code": "197929",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Meprobamate 400 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001234",
+            "black_list": false,
+            "code": "197930",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Aspirin 325 MG / Meprobamate 200 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001235",
+            "black_list": false,
+            "code": "197935",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "metaxalone 400 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001236",
+            "black_list": false,
+            "code": "197943",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Methocarbamol 500 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001237",
+            "black_list": false,
+            "code": "197944",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Methocarbamol 750 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001238",
+            "black_list": false,
+            "code": "197945",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Aspirin 325 MG / Methocarbamol 400 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001239",
+            "black_list": false,
+            "code": "197956",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Methyldopa 250 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00123a",
+            "black_list": false,
+            "code": "197957",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Methyldopa 50 MG/ML Oral Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00123b",
+            "black_list": false,
+            "code": "197958",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Methyldopa 500 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00123c",
+            "black_list": false,
+            "code": "197960",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Hydrochlorothiazide 25 MG / Methyldopa 250 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00123d",
+            "black_list": false,
+            "code": "197963",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Hydrochlorothiazide 15 MG / Methyldopa 250 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00123e",
+            "black_list": false,
+            "code": "198032",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Nifedipine 10 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00123f",
+            "black_list": false,
+            "code": "198033",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Nifedipine 20 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001240",
+            "black_list": false,
+            "code": "198034",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "24 HR Nifedipine 30 MG Extended Release Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001241",
+            "black_list": false,
+            "code": "198035",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "24 HR Nifedipine 60 MG Extended Release Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001242",
+            "black_list": false,
+            "code": "198036",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "24 HR Nifedipine 90 MG Extended Release Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001243",
+            "black_list": false,
+            "code": "198083",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Phenobarbital 100 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001244",
+            "black_list": false,
+            "code": "198084",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Phenobarbital 16 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001245",
+            "black_list": false,
+            "code": "198085",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Phenobarbital 16 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001246",
+            "black_list": false,
+            "code": "198086",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Phenobarbital 16.2 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001247",
+            "black_list": false,
+            "code": "198089",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Phenobarbital 60 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001248",
+            "black_list": false,
+            "code": "198270",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Thioridazine 100 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001249",
+            "black_list": false,
+            "code": "198274",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Thioridazine 25 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00124a",
+            "black_list": false,
+            "code": "198275",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Thioridazine 50 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00124b",
+            "black_list": false,
+            "code": "198276",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "thyroid (USP) 120 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00124c",
+            "black_list": false,
+            "code": "198277",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "thyroid (USP) 130 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00124d",
+            "black_list": false,
+            "code": "198278",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "thyroid (USP) 180 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00124e",
+            "black_list": false,
+            "code": "198280",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "thyroid (USP) 60 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00124f",
+            "black_list": false,
+            "code": "198368",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Phenobarbital 65 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001250",
+            "black_list": false,
+            "code": "199164",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Phenobarbital 97.2 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001251",
+            "black_list": false,
+            "code": "199167",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Phenobarbital 32.4 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001252",
+            "black_list": false,
+            "code": "199168",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Phenobarbital 64.8 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001253",
+            "black_list": false,
+            "code": "199208",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "thyroid (USP) 64.8 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001254",
+            "black_list": false,
+            "code": "199314",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Dipyridamole 100 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001255",
+            "black_list": false,
+            "code": "199329",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Nifedipine 5 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001256",
+            "black_list": false,
+            "code": "199340",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Mephobarbital 60 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001257",
+            "black_list": false,
+            "code": "199341",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Mephobarbital 200 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001258",
+            "black_list": false,
+            "code": "199543",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Disopyramide 10 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001259",
+            "black_list": false,
+            "code": "199549",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Indomethacin 100 MG Rectal Suppository",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00125a",
+            "black_list": false,
+            "code": "199607",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Estradiol 0.025 MG Vaginal Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00125b",
+            "black_list": false,
+            "code": "199782",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Nifedipine 20 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00125c",
+            "black_list": false,
+            "code": "199820",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Trimipramine 25 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00125d",
+            "black_list": false,
+            "code": "200330",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "thyroid (USP) 30 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00125e",
+            "black_list": false,
+            "code": "200331",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "thyroid (USP) 90 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00125f",
+            "black_list": false,
+            "code": "200332",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "thyroid (USP) 240 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001260",
+            "black_list": false,
+            "code": "200335",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "thyroid (USP) 32.4 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001261",
+            "black_list": false,
+            "code": "204434",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Meprobamate 600 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001262",
+            "black_list": false,
+            "code": "204452",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Methyldopate 50 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001263",
+            "black_list": false,
+            "code": "205254",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Brompheniramine 5.75 MG / Pseudoephedrine 60 MG Extended Release Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001264",
+            "black_list": false,
+            "code": "205333",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Estradiol 1.5 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001265",
+            "black_list": false,
+            "code": "208545",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "thyroid (USP) 120 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001266",
+            "black_list": false,
+            "code": "235760",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Pentobarbital 30 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001267",
+            "black_list": false,
+            "code": "238003",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "168 HR Estradiol 0.00208 MG/HR Transdermal Patch",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001268",
+            "black_list": false,
+            "code": "238004",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "168 HR Estradiol 0.00417 MG/HR Transdermal Patch",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001269",
+            "black_list": false,
+            "code": "238006",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Estrogens, Esterified (USP) 0.625 MG / Methyltestosterone 1.25 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00126a",
+            "black_list": false,
+            "code": "238090",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Pentobarbital 50 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00126b",
+            "black_list": false,
+            "code": "238133",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Pentazocine 30 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00126c",
+            "black_list": false,
+            "code": "238134",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Aspirin 325 MG / butalbital 50 MG / Caffeine 40 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00126d",
+            "black_list": false,
+            "code": "238135",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Aspirin 325 MG / butalbital 50 MG / Caffeine 40 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00126e",
+            "black_list": false,
+            "code": "238153",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Acetaminophen 325 MG / butalbital 50 MG / Caffeine 40 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00126f",
+            "black_list": false,
+            "code": "238154",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Acetaminophen 325 MG / butalbital 50 MG / Caffeine 40 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001270",
+            "black_list": false,
+            "code": "238175",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Methocarbamol 100 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001271",
+            "black_list": false,
+            "code": "240093",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Acetaminophen 500 MG / butalbital 50 MG / Caffeine 40 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001272",
+            "black_list": false,
+            "code": "240826",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "dexbrompheniramine 2 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001273",
+            "black_list": false,
+            "code": "241527",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "168 HR Estradiol 0.00312 MG/HR Transdermal Patch",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001274",
+            "black_list": false,
+            "code": "241946",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "84 HR Estradiol 0.00156 MG/HR Transdermal Patch",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001275",
+            "black_list": false,
+            "code": "242333",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "168 HR Estradiol 0.00104 MG/HR Transdermal Patch",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001276",
+            "black_list": false,
+            "code": "242891",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "84 HR Estradiol 0.00208 MG/HR Transdermal Patch",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001277",
+            "black_list": false,
+            "code": "242892",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "84 HR Estradiol 0.00417 MG/HR Transdermal Patch",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001278",
+            "black_list": false,
+            "code": "243025",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Chlorpheniramine 4 MG / Phenylephrine 20 MG Extended Release Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001279",
+            "black_list": false,
+            "code": "243220",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "dexchlorpheniramine 0.4 MG/ML / Guaifenesin 20 MG/ML / Pseudoephedrine 4 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00127a",
+            "black_list": false,
+            "code": "243628",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Chloral Hydrate 250 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00127b",
+            "black_list": false,
+            "code": "245373",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Trimipramine 50 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00127c",
+            "black_list": false,
+            "code": "248139",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Brompheniramine 0.8 MG/ML / Pseudoephedrine 12 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00127d",
+            "black_list": false,
+            "code": "248478",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "84 HR Estradiol 0.00104 MG/HR Transdermal Patch",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00127e",
+            "black_list": false,
+            "code": "282462",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Phenobarbital 30 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00127f",
+            "black_list": false,
+            "code": "282463",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Phenobarbital 60 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001280",
+            "black_list": false,
+            "code": "283463",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Chlorpheniramine 0.9 MG/ML / Phenylephrine 1 MG/ML Oral Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001281",
+            "black_list": false,
+            "code": "284437",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "thyroid (USP) 15 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001282",
+            "black_list": false,
+            "code": "284438",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "thyroid (USP) 180 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001283",
+            "black_list": false,
+            "code": "308162",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Amobarbital 100 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001284",
+            "black_list": false,
+            "code": "308163",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Amobarbital 15 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001285",
+            "black_list": false,
+            "code": "308164",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Amobarbital 30 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001286",
+            "black_list": false,
+            "code": "308165",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Amobarbital 50 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001287",
+            "black_list": false,
+            "code": "308169",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Amobarbital 200 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001288",
+            "black_list": false,
+            "code": "308170",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Amobarbital 100 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001289",
+            "black_list": false,
+            "code": "308172",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Amobarbital 65 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00128a",
+            "black_list": false,
+            "code": "308322",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Acetaminophen 500 MG / butalbital 50 MG / Caffeine 40 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00128b",
+            "black_list": false,
+            "code": "309232",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Chlorpheniramine 4 MG / Phenylephrine 20 MG Extended Release Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00128c",
+            "black_list": false,
+            "code": "309239",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Chlorpheniramine 8 MG / Pseudoephedrine 120 MG Extended Release Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00128d",
+            "black_list": false,
+            "code": "309243",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Chlorpheniramine 12 MG Extended Release Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00128e",
+            "black_list": false,
+            "code": "309244",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Chlorpheniramine 12 MG Extended Release Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00128f",
+            "black_list": false,
+            "code": "309249",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Chlorpheniramine 8 MG Extended Release Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001290",
+            "black_list": false,
+            "code": "309709",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "dexchlorpheniramine 6 MG Extended Release Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001291",
+            "black_list": false,
+            "code": "309952",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Dipyridamole 25 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001292",
+            "black_list": false,
+            "code": "309953",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Dipyridamole 5 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001293",
+            "black_list": false,
+            "code": "309955",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Dipyridamole 75 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001294",
+            "black_list": false,
+            "code": "309958",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Disopyramide 100 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001295",
+            "black_list": false,
+            "code": "309960",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Disopyramide 150 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001296",
+            "black_list": false,
+            "code": "310143",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "ergoloid mesylates, USP 1 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001297",
+            "black_list": false,
+            "code": "310169",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Estradiol 0.1 MG/ML Vaginal Cream",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001298",
+            "black_list": false,
+            "code": "310197",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Estrogens, Conjugated (USP) 0.625 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001299",
+            "black_list": false,
+            "code": "310203",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Estrogens, Conjugated (USP) 5 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00129a",
+            "black_list": false,
+            "code": "310204",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "estrogens, conjugated synthetic A 0.625 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00129b",
+            "black_list": false,
+            "code": "310205",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "estrogens, conjugated synthetic A 0.9 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00129c",
+            "black_list": false,
+            "code": "310206",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "estrogens, conjugated synthetic A 1.25 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00129d",
+            "black_list": false,
+            "code": "310212",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "estropipate 0.75 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00129e",
+            "black_list": false,
+            "code": "310213",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "estropipate 1.5 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00129f",
+            "black_list": false,
+            "code": "310215",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "estropipate 3 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0012a0",
+            "black_list": false,
+            "code": "310534",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Glyburide 2.5 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0012a1",
+            "black_list": false,
+            "code": "310536",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Glyburide 3 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0012a2",
+            "black_list": false,
+            "code": "310537",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Glyburide 5 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0012a3",
+            "black_list": false,
+            "code": "310539",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Glyburide 6 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0012a4",
+            "black_list": false,
+            "code": "310661",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Guanabenz 16 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0012a5",
+            "black_list": false,
+            "code": "310991",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Indomethacin 5 MG/ML Oral Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0012a6",
+            "black_list": false,
+            "code": "310992",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Indomethacin 75 MG Extended Release Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0012a7",
+            "black_list": false,
+            "code": "311534",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Meprobamate 200 MG Extended Release Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0012a8",
+            "black_list": false,
+            "code": "311536",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Meprobamate 200 MG / Pentaerythritol Tetranitrate 20 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0012a9",
+            "black_list": false,
+            "code": "311538",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Meprobamate 400 MG Extended Release Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0012aa",
+            "black_list": false,
+            "code": "311551",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Mesoridazine 100 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0012ab",
+            "black_list": false,
+            "code": "311552",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Mesoridazine 10 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0012ac",
+            "black_list": false,
+            "code": "311553",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Mesoridazine 25 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0012ad",
+            "black_list": false,
+            "code": "311554",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Mesoridazine 25 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0012ae",
+            "black_list": false,
+            "code": "311555",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Mesoridazine 50 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0012af",
+            "black_list": false,
+            "code": "312288",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Acetaminophen 650 MG / Pentazocine 25 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0012b0",
+            "black_list": false,
+            "code": "312289",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Naloxone 0.5 MG / Pentazocine 50 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0012b1",
+            "black_list": false,
+            "code": "312357",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Phenobarbital 15 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0012b2",
+            "black_list": false,
+            "code": "312362",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Phenobarbital 30 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0012b3",
+            "black_list": false,
+            "code": "312370",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Phenobarbital 130 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0012b4",
+            "black_list": false,
+            "code": "312914",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Secobarbital 100 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0012b5",
+            "black_list": false,
+            "code": "312915",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Secobarbital 200 MG Rectal Suppository",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0012b6",
+            "black_list": false,
+            "code": "313352",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Thioridazine 20 MG/ML Oral Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0012b7",
+            "black_list": false,
+            "code": "313354",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Thioridazine 10 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0012b8",
+            "black_list": false,
+            "code": "313357",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Thioridazine 5 MG/ML Oral Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0012b9",
+            "black_list": false,
+            "code": "313385",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "thyroid (USP) 240 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0012ba",
+            "black_list": false,
+            "code": "313386",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "thyroid (USP) 260 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0012bb",
+            "black_list": false,
+            "code": "313387",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "thyroid (USP) 30 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0012bc",
+            "black_list": false,
+            "code": "313389",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "thyroid (USP) 325 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0012bd",
+            "black_list": false,
+            "code": "313391",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "thyroid (USP) 60 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0012be",
+            "black_list": false,
+            "code": "313393",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "thyroid (USP) 90 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0012bf",
+            "black_list": false,
+            "code": "313396",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "thyroid (USP) 65 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0012c0",
+            "black_list": false,
+            "code": "313406",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Ticlopidine 250 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0012c1",
+            "black_list": false,
+            "code": "313492",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "trimethobenzamide 200 MG Rectal Suppository",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0012c2",
+            "black_list": false,
+            "code": "313496",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Trimipramine 100 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0012c3",
+            "black_list": false,
+            "code": "313497",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Trimipramine 100 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0012c4",
+            "black_list": false,
+            "code": "313498",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Trimipramine 25 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0012c5",
+            "black_list": false,
+            "code": "313499",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Trimipramine 50 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0012c6",
+            "black_list": false,
+            "code": "314000",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Glyburide 1.5 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0012c7",
+            "black_list": false,
+            "code": "314132",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Nifedipine 10 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0012c8",
+            "black_list": false,
+            "code": "314267",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "thyroid (USP) 15 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0012c9",
+            "black_list": false,
+            "code": "315144",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Mesoridazine 25 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0012ca",
+            "black_list": false,
+            "code": "315201",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Secobarbital 50 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0012cb",
+            "black_list": false,
+            "code": "315234",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "thyroid (USP) 195 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0012cc",
+            "black_list": false,
+            "code": "315235",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "thyroid (USP) 300 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0012cd",
+            "black_list": false,
+            "code": "318179",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "ergoloid mesylates, USP 1 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0012ce",
+            "black_list": false,
+            "code": "346508",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Indomethacin 1 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0012cf",
+            "black_list": false,
+            "code": "346713",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Thioridazine 25 MG/ML Oral Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0012d0",
+            "black_list": false,
+            "code": "346714",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Thioridazine 100 MG/ML Oral Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0012d1",
+            "black_list": false,
+            "code": "346966",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Brompheniramine 0.8 MG/ML / Pseudoephedrine 6 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0012d2",
+            "black_list": false,
+            "code": "347151",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "thyroid (USP) 32.5 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0012d3",
+            "black_list": false,
+            "code": "348906",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Estradiol 1 MG / norgestimate 0.09 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0012d4",
+            "black_list": false,
+            "code": "349199",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "valsartan 80 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0012d5",
+            "black_list": false,
+            "code": "349281",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Brompheniramine 0.8 MG/ML / Pseudoephedrine 9 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0012d6",
+            "black_list": false,
+            "code": "349533",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Brompheniramine 2.4 MG/ML Oral Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0012d7",
+            "black_list": false,
+            "code": "349563",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Chlorpheniramine 0.8 MG/ML / Methscopolamine 0.25 MG/ML / Phenylephrine 2 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0012d8",
+            "black_list": false,
+            "code": "351130",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Brompheniramine 1 MG/ML / Pseudoephedrine 15 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0012d9",
+            "black_list": false,
+            "code": "351192",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Dextromethorphan 0.169 MG/ML / Doxylamine 0.106 MG/ML / Phenylephrine 0.0846 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0012da",
+            "black_list": false,
+            "code": "351228",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "estrogens, conjugated synthetic A 0.3 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0012db",
+            "black_list": false,
+            "code": "351254",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "metaxalone 800 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0012dc",
+            "black_list": false,
+            "code": "351262",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "dexchlorpheniramine 0.5 MG/ML / Pseudoephedrine 15 MG/ML Extended Release Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0012dd",
+            "black_list": false,
+            "code": "351263",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "dexchlorpheniramine 0.5 MG/ML / Dextromethorphan 5 MG/ML / Pseudoephedrine 15 MG/ML Extended Release Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0012de",
+            "black_list": false,
+            "code": "359278",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "12 HR Brompheniramine 6 MG / Phenylephrine 7.5 MG Extended Release Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0012df",
+            "black_list": false,
+            "code": "359280",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "12 HR Brompheniramine 6 MG / Pseudoephedrine 45 MG Extended Release Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0012e0",
+            "black_list": false,
+            "code": "359281",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "12 HR Brompheniramine 6 MG Extended Release Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0012e1",
+            "black_list": false,
+            "code": "359375",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Chlorpheniramine 0.8 MG/ML / Pseudoephedrine 16 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0012e2",
+            "black_list": false,
+            "code": "359376",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "12 HR Chlorpheniramine 12 MG / Pseudoephedrine 120 MG Extended Release Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0012e3",
+            "black_list": false,
+            "code": "359431",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "dexchlorpheniramine 0.5 MG/ML / Pseudoephedrine 15 MG/ML Oral Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0012e4",
+            "black_list": false,
+            "code": "359923",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "dexchlorpheniramine 0.2 MG/ML / Dextromethorphan 3 MG/ML / Guaifenesin 20 MG/ML / Phenylephrine 1 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0012e5",
+            "black_list": false,
+            "code": "360042",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "dexchlorpheniramine 0.5 MG/ML / Dextromethorphan 5 MG/ML / Pseudoephedrine 15 MG/ML Oral Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0012e6",
+            "black_list": false,
+            "code": "391980",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Nifedipine 30 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0012e7",
+            "black_list": false,
+            "code": "402242",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Estradiol 0.00208 MG/HR Topical Lotion",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0012e8",
+            "black_list": false,
+            "code": "402250",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "168 HR Estradiol 0.00188 MG/HR / Levonorgestrel 0.000625 MG/HR Transdermal Patch",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0012e9",
+            "black_list": false,
+            "code": "403849",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Estrogens, Conjugated (USP) 0.45 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0012ea",
+            "black_list": false,
+            "code": "403922",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "168 HR Estradiol 0.00156 MG/HR Transdermal Patch",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0012eb",
+            "black_list": false,
+            "code": "403923",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "168 HR Estradiol 0.0025 MG/HR Transdermal Patch",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0012ec",
+            "black_list": false,
+            "code": "403956",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Brompheniramine 0.4 MG/ML / Dextromethorphan 3 MG/ML / Phenylephrine 1.5 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0012ed",
+            "black_list": false,
+            "code": "406590",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "dexbrompheniramine 6 MG / Dextromethorphan 30 MG / Phenylephrine 20 MG Extended Release Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0012ee",
+            "black_list": false,
+            "code": "410205",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Aspirin 650 MG / butalbital 50 MG / Caffeine 40 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0012ef",
+            "black_list": false,
+            "code": "422098",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Chlorpheniramine 0.6 MG/ML / Phenylephrine 1.5 MG/ML Oral Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0012f0",
+            "black_list": false,
+            "code": "425319",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Brompheniramine 0.4 MG/ML / Phenylephrine 1.5 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0012f1",
+            "black_list": false,
+            "code": "435430",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Phenobarbital 15 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0012f2",
+            "black_list": false,
+            "code": "435436",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Phenobarbital 15 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0012f3",
+            "black_list": false,
+            "code": "435462",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Secobarbital 30 MG Rectal Suppository",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0012f4",
+            "black_list": false,
+            "code": "435463",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Secobarbital 60 MG Rectal Suppository",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0012f5",
+            "black_list": false,
+            "code": "435470",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "butalbital 50 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0012f6",
+            "black_list": false,
+            "code": "435475",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Chloral Hydrate 900 MG Rectal Suppository",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0012f7",
+            "black_list": false,
+            "code": "435517",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Aspirin 325 MG / butalbital 15 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0012f8",
+            "black_list": false,
+            "code": "476152",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Acetaminophen 750 MG / butalbital 50 MG / Caffeine 40 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0012f9",
+            "black_list": false,
+            "code": "476540",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "estrogens, conjugated synthetic A 0.45 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0012fa",
+            "black_list": false,
+            "code": "476545",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "168 HR Estradiol 0.000583 MG/HR Transdermal Patch",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0012fb",
+            "black_list": false,
+            "code": "477221",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Carbinoxamine Tannate 0.72 MG/ML / PSEUDOEPHEDRINE TANNATE 9.1 MG/ML Oral Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0012fc",
+            "black_list": false,
+            "code": "477245",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Diphenhydramine Citrate 19 MG Disintegrating Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0012fd",
+            "black_list": false,
+            "code": "477587",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "24 HR Brompheniramine 12 MG Extended Release Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0012fe",
+            "black_list": false,
+            "code": "483169",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Estradiol 0.9 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0012ff",
+            "black_list": false,
+            "code": "485607",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Brompheniramine 0.8 MG/ML Oral Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001300",
+            "black_list": false,
+            "code": "487079",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Chlorpheniramine 0.8 MG/ML / Phenylephrine 4 MG/ML Oral Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001301",
+            "black_list": false,
+            "code": "540358",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Brompheniramine 6 MG Extended Release Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001302",
+            "black_list": false,
+            "code": "542947",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Brompheniramine 1 MG/ML / Pseudoephedrine 12.5 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001303",
+            "black_list": false,
+            "code": "544218",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Chlorpheniramine 2 MG/ML Oral Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001304",
+            "black_list": false,
+            "code": "546174",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "dexchlorpheniramine 3.5 MG / Methscopolamine 1 MG / Pseudoephedrine 45 MG Extended Release Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001305",
+            "black_list": false,
+            "code": "577027",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Estradiol 0.45 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001306",
+            "black_list": false,
+            "code": "577029",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Estradiol 1.8 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001307",
+            "black_list": false,
+            "code": "577154",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Megestrol Acetate 125 MG/ML Oral Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001308",
+            "black_list": false,
+            "code": "584640",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Brompheniramine Tannate 1.6 MG/ML Extended Release Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001309",
+            "black_list": false,
+            "code": "597658",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Brompheniramine 0.8 MG/ML / Phenylephrine 1.5 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00130a",
+            "black_list": false,
+            "code": "597675",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Chlorpheniramine 1 MG/ML / Phenylephrine 2 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00130b",
+            "black_list": false,
+            "code": "602598",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "drospirenone 0.5 MG / Ethinyl Estradiol 1 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00130c",
+            "black_list": false,
+            "code": "618368",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "estrogens, conjugated synthetic B 0.3 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00130d",
+            "black_list": false,
+            "code": "618370",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "estrogens, conjugated synthetic B 0.45 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00130e",
+            "black_list": false,
+            "code": "618376",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "estrogens, conjugated synthetic B 0.625 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00130f",
+            "black_list": false,
+            "code": "618378",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "estrogens, conjugated synthetic B 1.25 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001310",
+            "black_list": false,
+            "code": "628823",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "dexbrompheniramine 6 MG / Dextromethorphan 30 MG / Phenylephrine 20 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001311",
+            "black_list": false,
+            "code": "631644",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Brompheniramine 1.6 MG/ML / Pseudoephedrine 18 MG/ML Extended Release Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001312",
+            "black_list": false,
+            "code": "636382",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "12 HR Chlorpheniramine 8 MG / Methscopolamine 2.5 MG Extended Release Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001313",
+            "black_list": false,
+            "code": "636793",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "12 HR Disopyramide 100 MG Extended Release Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001314",
+            "black_list": false,
+            "code": "636794",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "12 HR Disopyramide 150 MG Extended Release Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001315",
+            "black_list": false,
+            "code": "644096",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Chlorpheniramine 1.6 MG/ML / Phenylephrine 2 MG/ML Oral Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001316",
+            "black_list": false,
+            "code": "644097",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Chlorpheniramine 1.6 MG/ML Oral Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001317",
+            "black_list": false,
+            "code": "647171",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Chlorpheniramine 1.6 MG/ML Extended Release Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001318",
+            "black_list": false,
+            "code": "647172",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Chlorpheniramine 1.6 MG/ML / Phenylephrine 2 MG/ML Extended Release Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001319",
+            "black_list": false,
+            "code": "668535",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "24 HR Brompheniramine 12 MG / Pseudoephedrine 90 MG Extended Release Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00131a",
+            "black_list": false,
+            "code": "672838",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Brompheniramine 0.4 MG/ML / Dextromethorphan 2 MG/ML / Phenylephrine 1 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00131b",
+            "black_list": false,
+            "code": "686523",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "dexchlorpheniramine 0.6 MG/ML / Dextromethorphan 5.5 MG/ML / Pseudoephedrine 10 MG/ML Oral Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00131c",
+            "black_list": false,
+            "code": "688240",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Estrogens, Conjugated (USP) 0.625 MG/ML Vaginal Cream",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00131d",
+            "black_list": false,
+            "code": "688507",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Estradiol 2.5 MG/ML Topical Lotion",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00131e",
+            "black_list": false,
+            "code": "692766",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "dexchlorpheniramine 0.6 MG/ML / Dextromethorphan 5.5 MG/ML / Pseudoephedrine 10 MG/ML Extended Release Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00131f",
+            "black_list": false,
+            "code": "695963",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Aspirin 650 MG / butalbital 50 MG / Caffeine 40 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001320",
+            "black_list": false,
+            "code": "700669",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "dexbrompheniramine 0.8 MG/ML / Pyrilamine 0.7 MG/ML Extended Release Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001321",
+            "black_list": false,
+            "code": "700850",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Brompheniramine 1 MG/ML / Pseudoephedrine 7.5 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001322",
+            "black_list": false,
+            "code": "700851",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Brompheniramine 1 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001323",
+            "black_list": false,
+            "code": "700860",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "dexchlorpheniramine 0.6 MG/ML / Pseudoephedrine 10 MG/ML Oral Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001324",
+            "black_list": false,
+            "code": "701393",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "dexchlorpheniramine 2 MG Extended Release Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001325",
+            "black_list": false,
+            "code": "702220",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "dexchlorpheniramine 0.4 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001326",
+            "black_list": false,
+            "code": "702519",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Phenobarbital 4 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001327",
+            "black_list": false,
+            "code": "707680",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Chlorpheniramine 2 MG/ML / Phenylephrine 6 MG/ML Extended Release Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001328",
+            "black_list": false,
+            "code": "728118",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Estradiol 1.53 MG/ACTUAT Topical Spray",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001329",
+            "black_list": false,
+            "code": "728581",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "thyroid (USP) 16.3 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00132a",
+            "black_list": false,
+            "code": "730794",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Carisoprodol 250 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00132b",
+            "black_list": false,
+            "code": "730878",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "estrogens, conjugated synthetic B 0.9 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00132c",
+            "black_list": false,
+            "code": "731007",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Brompheniramine 6 MG / Phenylephrine 19 MG Extended Release Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00132d",
+            "black_list": false,
+            "code": "731032",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "12 HR Brompheniramine 11 MG Extended Release Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00132e",
+            "black_list": false,
+            "code": "748594",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Chlorpheniramine 0.4 MG/ML / Methscopolamine 0.15 MG/ML / Phenylephrine 1.6 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00132f",
+            "black_list": false,
+            "code": "748802",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "{28 (drospirenone 0.5 MG / Ethinyl Estradiol 1 MG Oral Tablet) } Pack",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001330",
+            "black_list": false,
+            "code": "749850",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "{15 (Estradiol 1 MG / norgestimate 0.09 MG Oral Tablet) / 15 (Estradiol 1 MG Oral Tablet) } Pack",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001331",
+            "black_list": false,
+            "code": "754744",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Chlorpheniramine 0.4 MG/ML / Methscopolamine 0.15 MG/ML / Phenylephrine 2 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001332",
+            "black_list": false,
+            "code": "755584",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Brompheniramine 0.4 MG/ML / Dextromethorphan 1 MG/ML / Phenylephrine 2 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001333",
+            "black_list": false,
+            "code": "755618",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Chloral Hydrate 100 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001334",
+            "black_list": false,
+            "code": "755621",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Chloral Hydrate 50 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001335",
+            "black_list": false,
+            "code": "756245",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Acetaminophen 21.7 MG/ML / butalbital 3.33 MG/ML / Caffeine 2.67 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001336",
+            "black_list": false,
+            "code": "756251",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Amobarbital 8.8 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001337",
+            "black_list": false,
+            "code": "756342",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Secobarbital 4.4 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001338",
+            "black_list": false,
+            "code": "758147",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Brompheniramine 0.8 MG/ML / Dextromethorphan 3 MG/ML / Phenylephrine 1.5 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001339",
+            "black_list": false,
+            "code": "759687",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Chlorpheniramine 12 MG / Pseudoephedrine 120 MG Extended Release Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00133a",
+            "black_list": false,
+            "code": "762986",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "12 HR Brompheniramine 6 MG / Phenylephrine 30 MG Extended Release Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00133b",
+            "black_list": false,
+            "code": "828299",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Cyclobenzaprine hydrochloride 7.5 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00133c",
+            "black_list": false,
+            "code": "828320",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Cyclobenzaprine hydrochloride 5 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00133d",
+            "black_list": false,
+            "code": "828348",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Cyclobenzaprine hydrochloride 10 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00133e",
+            "black_list": false,
+            "code": "828353",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "24 HR Cyclobenzaprine hydrochloride 30 MG Extended Release Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00133f",
+            "black_list": false,
+            "code": "828358",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "24 HR Cyclobenzaprine hydrochloride 15 MG Extended Release Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001340",
+            "black_list": false,
+            "code": "834022",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Ketorolac Tromethamine 10 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001341",
+            "black_list": false,
+            "code": "835564",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Imipramine Hydrochloride 25 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001342",
+            "black_list": false,
+            "code": "835568",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Imipramine Hydrochloride 50 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001343",
+            "black_list": false,
+            "code": "835572",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Imipramine pamoate 75 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001344",
+            "black_list": false,
+            "code": "835577",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Imipramine pamoate 150 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001345",
+            "black_list": false,
+            "code": "835582",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Imipramine Hydrochloride 12.5 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001346",
+            "black_list": false,
+            "code": "835589",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Imipramine pamoate 125 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001347",
+            "black_list": false,
+            "code": "835591",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Imipramine pamoate 100 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001348",
+            "black_list": false,
+            "code": "835593",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Imipramine Hydrochloride 10 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001349",
+            "black_list": false,
+            "code": "848331",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "90 DAY Estradiol 0.00208 MG/HR Vaginal Ring",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00134a",
+            "black_list": false,
+            "code": "856706",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Amitriptyline Hydrochloride 10 MG / Perphenazine 2 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00134b",
+            "black_list": false,
+            "code": "856720",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Amitriptyline Hydrochloride 10 MG / Perphenazine 4 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00134c",
+            "black_list": false,
+            "code": "856762",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Amitriptyline Hydrochloride 100 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00134d",
+            "black_list": false,
+            "code": "856773",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Amitriptyline Hydrochloride 150 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00134e",
+            "black_list": false,
+            "code": "856783",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Amitriptyline Hydrochloride 10 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00134f",
+            "black_list": false,
+            "code": "856797",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Amitriptyline Hydrochloride 25 MG / Perphenazine 2 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001350",
+            "black_list": false,
+            "code": "856825",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Amitriptyline Hydrochloride 25 MG / Perphenazine 4 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001351",
+            "black_list": false,
+            "code": "856834",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Amitriptyline Hydrochloride 25 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001352",
+            "black_list": false,
+            "code": "856840",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Amitriptyline Hydrochloride 50 MG / Perphenazine 4 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001353",
+            "black_list": false,
+            "code": "856845",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Amitriptyline Hydrochloride 50 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001354",
+            "black_list": false,
+            "code": "856853",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Amitriptyline Hydrochloride 75 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001355",
+            "black_list": false,
+            "code": "857291",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Clomipramine Hydrochloride 10 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001356",
+            "black_list": false,
+            "code": "857296",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Clomipramine Hydrochloride 25 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001357",
+            "black_list": false,
+            "code": "857297",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Clomipramine Hydrochloride 25 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001358",
+            "black_list": false,
+            "code": "857301",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Clomipramine Hydrochloride 50 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001359",
+            "black_list": false,
+            "code": "857305",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Clomipramine Hydrochloride 75 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00135a",
+            "black_list": false,
+            "code": "857315",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Clomipramine Hydrochloride 50 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00135b",
+            "black_list": false,
+            "code": "857416",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Clemastine Fumarate 1.34 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00135c",
+            "black_list": false,
+            "code": "857430",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Clemastine Fumarate 0.134 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00135d",
+            "black_list": false,
+            "code": "857461",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Clemastine Fumarate 2.68 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00135e",
+            "black_list": false,
+            "code": "858364",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Ketorolac Tromethamine 4.5 MG/ML Ophthalmic Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00135f",
+            "black_list": false,
+            "code": "858923",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "dexchlorpheniramine 0.4 MG/ML / Hydrocodone Bitartrate 0.8 MG/ML / Phenylephrine 1 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001360",
+            "black_list": false,
+            "code": "859003",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Chlorpheniramine 0.4 MG/ML / Hydrocodone Bitartrate 0.5 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001361",
+            "black_list": false,
+            "code": "859250",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Chlorpheniramine 0.8 MG/ML / Hydrocodone Bitartrate 1 MG/ML Oral Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001362",
+            "black_list": false,
+            "code": "860092",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Ketorolac Tromethamine 15 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001363",
+            "black_list": false,
+            "code": "860096",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Ketorolac Tromethamine 30 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001364",
+            "black_list": false,
+            "code": "860103",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Ketorolac Tromethamine 4 MG/ML Ophthalmic Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001365",
+            "black_list": false,
+            "code": "860107",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Ketorolac Tromethamine 5 MG/ML Ophthalmic Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001366",
+            "black_list": false,
+            "code": "860113",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "1 ML Ketorolac Tromethamine 15 MG/ML Prefilled Syringe",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001367",
+            "black_list": false,
+            "code": "860114",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "1 ML Ketorolac Tromethamine 30 MG/ML Prefilled Syringe",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001368",
+            "black_list": false,
+            "code": "860115",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "2 ML Ketorolac Tromethamine 30 MG/ML Prefilled Syringe",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001369",
+            "black_list": false,
+            "code": "860215",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Megestrol Acetate 20 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00136a",
+            "black_list": false,
+            "code": "860221",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Megestrol Acetate 40 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00136b",
+            "black_list": false,
+            "code": "860225",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Megestrol Acetate 40 MG/ML Oral Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00136c",
+            "black_list": false,
+            "code": "860231",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Megestrol Acetate 160 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00136d",
+            "black_list": false,
+            "code": "860749",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Trimethobenzamide hydrochloride 100 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00136e",
+            "black_list": false,
+            "code": "860767",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Trimethobenzamide hydrochloride 250 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00136f",
+            "black_list": false,
+            "code": "860771",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Trimethobenzamide hydrochloride 300 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001370",
+            "black_list": false,
+            "code": "860792",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "1 ML Meperidine Hydrochloride 75 MG/ML Prefilled Syringe",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001371",
+            "black_list": false,
+            "code": "861447",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Meperidine Hydrochloride 10 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001372",
+            "black_list": false,
+            "code": "861455",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Meperidine Hydrochloride 100 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001373",
+            "black_list": false,
+            "code": "861459",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Meperidine Hydrochloride 100 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001374",
+            "black_list": false,
+            "code": "861463",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Meperidine Hydrochloride 50 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001375",
+            "black_list": false,
+            "code": "861467",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Meperidine Hydrochloride 50 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001376",
+            "black_list": false,
+            "code": "861470",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "2 ML Meperidine Hydrochloride 50 MG/ML Prefilled Syringe",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001377",
+            "black_list": false,
+            "code": "861473",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "1 ML Meperidine Hydrochloride 50 MG/ML Prefilled Syringe",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001378",
+            "black_list": false,
+            "code": "861476",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Meperidine Hydrochloride 25 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001379",
+            "black_list": false,
+            "code": "861479",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Meperidine Hydrochloride 10 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00137a",
+            "black_list": false,
+            "code": "861482",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Meperidine Hydrochloride 75 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00137b",
+            "black_list": false,
+            "code": "861493",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "1 ML Meperidine Hydrochloride 100 MG/ML Prefilled Syringe",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00137c",
+            "black_list": false,
+            "code": "861494",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "1 ML Meperidine Hydrochloride 25 MG/ML Prefilled Syringe",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00137d",
+            "black_list": false,
+            "code": "861509",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "30 ML Meperidine Hydrochloride 10 MG/ML Prefilled Syringe",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00137e",
+            "black_list": false,
+            "code": "861573",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Meperidine Hydrochloride 25 MG/ML / Promethazine Hydrochloride 25 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00137f",
+            "black_list": false,
+            "code": "861578",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Meperidine Hydrochloride 50 MG / Promethazine Hydrochloride 25 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001380",
+            "black_list": false,
+            "code": "861743",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Glyburide 1.25 MG / Metformin hydrochloride 250 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001381",
+            "black_list": false,
+            "code": "861748",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Glyburide 2.5 MG / Metformin hydrochloride 500 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001382",
+            "black_list": false,
+            "code": "861753",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Glyburide 5 MG / Metformin hydrochloride 500 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001383",
+            "black_list": false,
+            "code": "861846",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Ketorolac Tromethamine 10 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001384",
+            "black_list": false,
+            "code": "862006",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "24 HR Guanfacine 1 MG Extended Release Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001385",
+            "black_list": false,
+            "code": "862013",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "24 HR Guanfacine 2 MG Extended Release Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001386",
+            "black_list": false,
+            "code": "862019",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "24 HR Guanfacine 3 MG Extended Release Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001387",
+            "black_list": false,
+            "code": "862025",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "24 HR Guanfacine 4 MG Extended Release Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001388",
+            "black_list": false,
+            "code": "863669",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Tamsulosin hydrochloride 0.4 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001389",
+            "black_list": false,
+            "code": "866021",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Cyproheptadine hydrochloride 0.4 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00138a",
+            "black_list": false,
+            "code": "866144",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Cyproheptadine hydrochloride 4 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00138b",
+            "black_list": false,
+            "code": "881320",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Cyclobenzaprine hydrochloride 1 MG/ML / methylsulfonylmethane 65 MG/ML Oral Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00138c",
+            "black_list": false,
+            "code": "882504",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Diphenhydramine Hydrochloride 12.5 MG Disintegrating Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00138d",
+            "black_list": false,
+            "code": "884707",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Estradiol 0.01 MG Vaginal Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00138e",
+            "black_list": false,
+            "code": "885209",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "benztropine mesylate 2 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00138f",
+            "black_list": false,
+            "code": "885213",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "benztropine mesylate 1 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001390",
+            "black_list": false,
+            "code": "885219",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "benztropine mesylate 0.5 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001391",
+            "black_list": false,
+            "code": "889520",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Acetaminophen 300 MG / butalbital 50 MG / Caffeine 40 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001392",
+            "black_list": false,
+            "code": "895664",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Diphenhydramine Citrate 38 MG / Ibuprofen 200 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001393",
+            "black_list": false,
+            "code": "901814",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Diphenhydramine Hydrochloride 25 MG / Ibuprofen 200 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001394",
+            "black_list": false,
+            "code": "905269",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Trihexyphenidyl Hydrochloride 2 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001395",
+            "black_list": false,
+            "code": "905273",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Trihexyphenidyl Hydrochloride 0.4 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001396",
+            "black_list": false,
+            "code": "905283",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Trihexyphenidyl Hydrochloride 5 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001397",
+            "black_list": false,
+            "code": "905295",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Trihexyphenidyl Hydrochloride 5 MG Extended Release Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001398",
+            "black_list": false,
+            "code": "991486",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Codeine Phosphate 2 MG/ML / Promethazine Hydrochloride 1.25 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b001399",
+            "black_list": false,
+            "code": "991528",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Dextromethorphan 3 MG/ML / Promethazine Hydrochloride 1.25 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00139a",
+            "black_list": false,
+            "code": "992432",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Promethazine Hydrochloride 1.25 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00139b",
+            "black_list": false,
+            "code": "992438",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Promethazine Hydrochloride 12.5 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00139c",
+            "black_list": false,
+            "code": "992441",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Promethazine Hydrochloride 12.5 MG Rectal Suppository",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00139d",
+            "black_list": false,
+            "code": "992447",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Promethazine Hydrochloride 25 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00139e",
+            "black_list": false,
+            "code": "992454",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Promethazine Hydrochloride 25 MG Rectal Suppository",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b00139f",
+            "black_list": false,
+            "code": "992460",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Promethazine Hydrochloride 25 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0013a0",
+            "black_list": false,
+            "code": "992475",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Promethazine Hydrochloride 50 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0013a1",
+            "black_list": false,
+            "code": "992478",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Promethazine Hydrochloride 50 MG Rectal Suppository",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0013a2",
+            "black_list": false,
+            "code": "992858",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Promethazine Hydrochloride 50 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0013a3",
+            "black_list": false,
+            "code": "992900",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Promethazine Hydrochloride 10 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0013a4",
+            "black_list": false,
+            "code": "993943",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Acetaminophen 325 MG / butalbital 50 MG / Caffeine 40 MG / Codeine Phosphate 30 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0013a5",
+            "black_list": false,
+            "code": "994012",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Acetaminophen 500 MG / Chlorpheniramine 4 MG / Codeine Phosphate 20 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0013a6",
+            "black_list": false,
+            "code": "994226",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Aspirin 325 MG / Carisoprodol 200 MG / Codeine Phosphate 16 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0013a7",
+            "black_list": false,
+            "code": "994237",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Aspirin 325 MG / butalbital 50 MG / Caffeine 40 MG / Codeine Phosphate 30 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0013a8",
+            "black_list": false,
+            "code": "994521",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "12 HR Orphenadrine Citrate 100 MG Extended Release Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0013a9",
+            "black_list": false,
+            "code": "994528",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Aspirin 385 MG / Caffeine 30 MG / Orphenadrine Citrate 25 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0013aa",
+            "black_list": false,
+            "code": "994535",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Aspirin 770 MG / Caffeine 60 MG / Orphenadrine Citrate 50 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0013ab",
+            "black_list": false,
+            "code": "994541",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Orphenadrine Citrate 30 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0013ac",
+            "black_list": false,
+            "code": "994824",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Orphenadrine Hydrochloride 50 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0013ad",
+            "black_list": false,
+            "code": "995062",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Chlorpheniramine 0.2 MG/ML / Codeine Phosphate 1 MG/ML Oral Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0013ae",
+            "black_list": false,
+            "code": "995082",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Chlorpheniramine 0.267 MG/ML / Codeine Phosphate 1 MG/ML Oral Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0013af",
+            "black_list": false,
+            "code": "995123",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Chlorpheniramine 0.4 MG/ML / Codeine Phosphate 1 MG/ML Oral Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0013b0",
+            "black_list": false,
+            "code": "995128",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Chlorpheniramine 0.4 MG/ML / Codeine Phosphate 1.8 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0013b1",
+            "black_list": false,
+            "code": "995211",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Chlorpheniramine 4 MG / Codeine Phosphate 10 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0013b2",
+            "black_list": false,
+            "code": "995214",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Chlorpheniramine 4 MG / Codeine Phosphate 20 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0013b3",
+            "black_list": false,
+            "code": "995218",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Hydroxyzine Hydrochloride 10 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0013b4",
+            "black_list": false,
+            "code": "995232",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Hydroxyzine Hydrochloride 100 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0013b5",
+            "black_list": false,
+            "code": "995235",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Hydroxyzine Hydrochloride 100 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0013b6",
+            "black_list": false,
+            "code": "995241",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Hydroxyzine Hydrochloride 2 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0013b7",
+            "black_list": false,
+            "code": "995253",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Hydroxyzine Hydrochloride 25 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0013b8",
+            "black_list": false,
+            "code": "995258",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Hydroxyzine Hydrochloride 25 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0013b9",
+            "black_list": false,
+            "code": "995270",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Hydroxyzine Hydrochloride 25 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0013ba",
+            "black_list": false,
+            "code": "995274",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Hydroxyzine Hydrochloride 5 MG/ML Oral Suspension",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0013bb",
+            "black_list": false,
+            "code": "995278",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Hydroxyzine Hydrochloride 50 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0013bc",
+            "black_list": false,
+            "code": "995281",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Hydroxyzine Hydrochloride 50 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0013bd",
+            "black_list": false,
+            "code": "995285",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Hydroxyzine Hydrochloride 50 MG/ML Injectable Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0013be",
+            "black_list": false,
+            "code": "995428",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Hydroxyzine Hydrochloride 10 MG Oral Capsule",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0013bf",
+            "black_list": false,
+            "code": "995591",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Hydroxyzine Hydrochloride 10 MG / Pentaerythritol Tetranitrate 10 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0013c0",
+            "black_list": false,
+            "code": "995592",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Hydroxyzine Hydrochloride 10 MG / Pentaerythritol Tetranitrate 20 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0013c1",
+            "black_list": false,
+            "code": "996640",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Codeine Phosphate 2 MG/ML / Pseudoephedrine Hydrochloride 6 MG/ML / Triprolidine Hydrochloride 0.25 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0013c2",
+            "black_list": false,
+            "code": "996757",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Codeine Phosphate 2 MG/ML / Phenylephrine Hydrochloride 1 MG/ML / Promethazine Hydrochloride 1.25 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0013c3",
+            "black_list": false,
+            "code": "997008",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Chlorpheniramine Maleate 0.4 MG/ML / Codeine Phosphate 2 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0013c4",
+            "black_list": false,
+            "code": "997272",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Codeine Phosphate 2 MG/ML / Pseudoephedrine Hydrochloride 3 MG/ML / Triprolidine Hydrochloride 0.25 MG/ML Oral Solution",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0013c5",
+            "black_list": false,
+            "code": "998254",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Chlorpheniramine Maleate 4 MG / Pseudoephedrine Hydrochloride 60 MG Oral Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0013c6",
+            "black_list": false,
+            "code": "999434",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Chlorpheniramine Maleate 2 MG / methscopolamine nitrate 1.25 MG / Phenylephrine Hydrochloride 10 MG Chewable Tablet",
+            "white_list": false
+          },
+          {
+            "_id": "521f53450017f7454b0013c7",
+            "black_list": false,
+            "code": "999731",
+            "code_system": "2.16.840.1.113883.6.88",
+            "code_system_name": "RxNorm",
+            "code_system_version": null,
+            "display_name": "Cyclobenzaprine hydrochloride 10 MG / Magnesium Oxide 200 MG Oral Capsule",
+            "white_list": false
+          }
+        ],
+        "display_name": "High Risk Medications for the Elderly",
+        "oid": "2.16.840.1.113883.3.464.1003.196.12.1253",
+        "version": "20130614"
+      },
+      {
+        "_id": "521f533c0017f7454b0005e4",
+        "concepts": [
+          {
+            "_id": "521f533c0017f7454b0005e5",
+            "black_list": false,
+            "code": "12843005",
+            "code_system": "2.16.840.1.113883.6.96",
+            "code_system_name": "SNOMED-CT",
+            "code_system_version": null,
+            "display_name": "Subsequent hospital visit by physician (procedure)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533c0017f7454b0005e6",
+            "black_list": false,
+            "code": "18170008",
+            "code_system": "2.16.840.1.113883.6.96",
+            "code_system_name": "SNOMED-CT",
+            "code_system_version": null,
+            "display_name": "Subsequent nursing facility visit (procedure)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533c0017f7454b0005e7",
+            "black_list": false,
+            "code": "185349003",
+            "code_system": "2.16.840.1.113883.6.96",
+            "code_system_name": "SNOMED-CT",
+            "code_system_version": null,
+            "display_name": "Encounter for \"check-up\" (procedure)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533c0017f7454b0005e8",
+            "black_list": false,
+            "code": "185463005",
+            "code_system": "2.16.840.1.113883.6.96",
+            "code_system_name": "SNOMED-CT",
+            "code_system_version": null,
+            "display_name": "Visit out of hours (procedure)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533c0017f7454b0005e9",
+            "black_list": false,
+            "code": "185465003",
+            "code_system": "2.16.840.1.113883.6.96",
+            "code_system_name": "SNOMED-CT",
+            "code_system_version": null,
+            "display_name": "Weekend visit (procedure)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533c0017f7454b0005ea",
+            "black_list": false,
+            "code": "19681004",
+            "code_system": "2.16.840.1.113883.6.96",
+            "code_system_name": "SNOMED-CT",
+            "code_system_version": null,
+            "display_name": "Nursing evaluation of patient and report (procedure)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533c0017f7454b0005eb",
+            "black_list": false,
+            "code": "207195004",
+            "code_system": "2.16.840.1.113883.6.96",
+            "code_system_name": "SNOMED-CT",
+            "code_system_version": null,
+            "display_name": "History and physical examination with evaluation and management of nursing facility patient (procedure)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533c0017f7454b0005ec",
+            "black_list": false,
+            "code": "270427003",
+            "code_system": "2.16.840.1.113883.6.96",
+            "code_system_name": "SNOMED-CT",
+            "code_system_version": null,
+            "display_name": "Patient-initiated encounter (procedure)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533c0017f7454b0005ed",
+            "black_list": false,
+            "code": "270430005",
+            "code_system": "2.16.840.1.113883.6.96",
+            "code_system_name": "SNOMED-CT",
+            "code_system_version": null,
+            "display_name": "Provider-initiated encounter (procedure)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533c0017f7454b0005ee",
+            "black_list": false,
+            "code": "308335008",
+            "code_system": "2.16.840.1.113883.6.96",
+            "code_system_name": "SNOMED-CT",
+            "code_system_version": null,
+            "display_name": "Patient encounter procedure (procedure)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533c0017f7454b0005ef",
+            "black_list": false,
+            "code": "390906007",
+            "code_system": "2.16.840.1.113883.6.96",
+            "code_system_name": "SNOMED-CT",
+            "code_system_version": null,
+            "display_name": "Follow-up encounter (procedure)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533c0017f7454b0005f0",
+            "black_list": false,
+            "code": "406547006",
+            "code_system": "2.16.840.1.113883.6.96",
+            "code_system_name": "SNOMED-CT",
+            "code_system_version": null,
+            "display_name": "Urgent follow-up (procedure)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533c0017f7454b0005f1",
+            "black_list": false,
+            "code": "439708006",
+            "code_system": "2.16.840.1.113883.6.96",
+            "code_system_name": "SNOMED-CT",
+            "code_system_version": null,
+            "display_name": "Home visit (procedure)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533c0017f7454b0005f2",
+            "black_list": false,
+            "code": "4525004",
+            "code_system": "2.16.840.1.113883.6.96",
+            "code_system_name": "SNOMED-CT",
+            "code_system_version": null,
+            "display_name": "Emergency department patient visit (procedure)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533c0017f7454b0005f3",
+            "black_list": false,
+            "code": "87790002",
+            "code_system": "2.16.840.1.113883.6.96",
+            "code_system_name": "SNOMED-CT",
+            "code_system_version": null,
+            "display_name": "Follow-up inpatient consultation visit (procedure)",
+            "white_list": false
+          },
+          {
+            "_id": "521f533c0017f7454b0005f4",
+            "black_list": false,
+            "code": "90526000",
+            "code_system": "2.16.840.1.113883.6.96",
+            "code_system_name": "SNOMED-CT",
+            "code_system_version": null,
+            "display_name": "Initial evaluation and management of healthy individual (procedure)",
+            "white_list": false
+          }
+        ],
+        "display_name": "Face-to-Face Interaction",
+        "oid": "2.16.840.1.113883.3.464.1003.101.12.1048",
+        "version": "20130614"
+      },
+      {
+        "_id": "521f53410017f7454b001040",
+        "concepts": [
+          {
+            "_id": "521f53410017f7454b001041",
+            "black_list": false,
+            "code": "99395",
+            "code_system": "2.16.840.1.113883.6.12",
+            "code_system_name": "CPT",
+            "code_system_version": null,
+            "display_name": "Periodic comprehensive preventive medicine reevaluation and management of an individual including an age and gender appropriate history, examination, counseling/anticipatory guidance/risk factor reduction interventions, and the ordering of laboratory/diagnostic procedures, established patient; 18-39 years",
+            "white_list": false
+          },
+          {
+            "_id": "521f53410017f7454b001042",
+            "black_list": false,
+            "code": "99396",
+            "code_system": "2.16.840.1.113883.6.12",
+            "code_system_name": "CPT",
+            "code_system_version": null,
+            "display_name": "Periodic comprehensive preventive medicine reevaluation and management of an individual including an age and gender appropriate history, examination, counseling/anticipatory guidance/risk factor reduction interventions, and the ordering of laboratory/diagnostic procedures, established patient; 40-64 years",
+            "white_list": false
+          },
+          {
+            "_id": "521f53410017f7454b001043",
+            "black_list": false,
+            "code": "99397",
+            "code_system": "2.16.840.1.113883.6.12",
+            "code_system_name": "CPT",
+            "code_system_version": null,
+            "display_name": "Periodic comprehensive preventive medicine reevaluation and management of an individual including an age and gender appropriate history, examination, counseling/anticipatory guidance/risk factor reduction interventions, and the ordering of laboratory/diagnostic procedures, established patient; 65 years and older",
+            "white_list": false
+          }
+        ],
+        "display_name": "Preventive Care Services - Established Office Visit, 18 and Up",
+        "oid": "2.16.840.1.113883.3.464.1003.101.12.1025",
+        "version": "20130614"
+      },
+      {
+        "_id": "521f53410017f7454b00103c",
+        "concepts": [
+          {
+            "_id": "521f53410017f7454b00103d",
+            "black_list": false,
+            "code": "99385",
+            "code_system": "2.16.840.1.113883.6.12",
+            "code_system_name": "CPT",
+            "code_system_version": null,
+            "display_name": "Initial comprehensive preventive medicine evaluation and management of an individual including an age and gender appropriate history, examination, counseling/anticipatory guidance/risk factor reduction interventions, and the ordering of laboratory/diagnostic procedures, new patient; 18-39 years",
+            "white_list": false
+          },
+          {
+            "_id": "521f53410017f7454b00103e",
+            "black_list": false,
+            "code": "99386",
+            "code_system": "2.16.840.1.113883.6.12",
+            "code_system_name": "CPT",
+            "code_system_version": null,
+            "display_name": "Initial comprehensive preventive medicine evaluation and management of an individual including an age and gender appropriate history, examination, counseling/anticipatory guidance/risk factor reduction interventions, and the ordering of laboratory/diagnostic procedures, new patient; 40-64 years",
+            "white_list": false
+          },
+          {
+            "_id": "521f53410017f7454b00103f",
+            "black_list": false,
+            "code": "99387",
+            "code_system": "2.16.840.1.113883.6.12",
+            "code_system_name": "CPT",
+            "code_system_version": null,
+            "display_name": "Initial comprehensive preventive medicine evaluation and management of an individual including an age and gender appropriate history, examination, counseling/anticipatory guidance/risk factor reduction interventions, and the ordering of laboratory/diagnostic procedures, new patient; 65 years and older",
+            "white_list": false
+          }
+        ],
+        "display_name": "Preventive Care Services-Initial Office Visit, 18 and Up",
+        "oid": "2.16.840.1.113883.3.464.1003.101.12.1023",
+        "version": "20130614"
+      },
+      {
+        "_id": "521f53410017f7454b001044",
+        "concepts": [
+          {
+            "_id": "521f53410017f7454b001045",
+            "black_list": false,
+            "code": "99341",
+            "code_system": "2.16.840.1.113883.6.12",
+            "code_system_name": "CPT",
+            "code_system_version": null,
+            "display_name": "Home visit for the evaluation and management of a new patient, which requires these 3 key components: A problem focused history; A problem focused examination; and Straightforward medical decision making. Counseling and/or coordination of care with other physicians, other qualified health care professionals, or agencies are provided consistent with the nature of the problem(s) and the patient's and/or family's needs. Usually, the presenting problem(s) are of low severity. Typically, 20 minutes are spent face-to-face with the patient and/or family.",
+            "white_list": false
+          },
+          {
+            "_id": "521f53410017f7454b001046",
+            "black_list": false,
+            "code": "99342",
+            "code_system": "2.16.840.1.113883.6.12",
+            "code_system_name": "CPT",
+            "code_system_version": null,
+            "display_name": "Home visit for the evaluation and management of a new patient, which requires these 3 key components: An expanded problem focused history; An expanded problem focused examination; and Medical decision making of low complexity. Counseling and/or coordination of care with other physicians, other qualified health care professionals, or agencies are provided consistent with the nature of the problem(s) and the patient's and/or family's needs. Usually, the presenting problem(s) are of moderate severity. Typically, 30 minutes are spent face-to-face with the patient and/or family.",
+            "white_list": false
+          },
+          {
+            "_id": "521f53410017f7454b001047",
+            "black_list": false,
+            "code": "99343",
+            "code_system": "2.16.840.1.113883.6.12",
+            "code_system_name": "CPT",
+            "code_system_version": null,
+            "display_name": "Home visit for the evaluation and management of a new patient, which requires these 3 key components: A detailed history; A detailed examination; and Medical decision making of moderate complexity. Counseling and/or coordination of care with other physicians, other qualified health care professionals, or agencies are provided consistent with the nature of the problem(s) and the patient's and/or family's needs. Usually, the presenting problem(s) are of moderate to high severity. Typically, 45 minutes are spent face-to-face with the patient and/or family.",
+            "white_list": false
+          },
+          {
+            "_id": "521f53410017f7454b001048",
+            "black_list": false,
+            "code": "99344",
+            "code_system": "2.16.840.1.113883.6.12",
+            "code_system_name": "CPT",
+            "code_system_version": null,
+            "display_name": "Home visit for the evaluation and management of a new patient, which requires these 3 key components: A comprehensive history; A comprehensive examination; and Medical decision making of moderate complexity. Counseling and/or coordination of care with other physicians, other qualified health care professionals, or agencies are provided consistent with the nature of the problem(s) and the patient's and/or family's needs. Usually, the presenting problem(s) are of high severity. Typically, 60 minutes are spent face-to-face with the patient and/or family.",
+            "white_list": false
+          },
+          {
+            "_id": "521f53410017f7454b001049",
+            "black_list": false,
+            "code": "99345",
+            "code_system": "2.16.840.1.113883.6.12",
+            "code_system_name": "CPT",
+            "code_system_version": null,
+            "display_name": "Home visit for the evaluation and management of a new patient, which requires these 3 key components: A comprehensive history; A comprehensive examination; and Medical decision making of high complexity. Counseling and/or coordination of care with other physicians, other qualified health care professionals, or agencies are provided consistent with the nature of the problem(s) and the patient's and/or family's needs. Usually, the patient is unstable or has developed a significant new problem requiring immediate physician attention. Typically, 75 minutes are spent face-to-face with the patient and/or family.",
+            "white_list": false
+          },
+          {
+            "_id": "521f53410017f7454b00104a",
+            "black_list": false,
+            "code": "99347",
+            "code_system": "2.16.840.1.113883.6.12",
+            "code_system_name": "CPT",
+            "code_system_version": null,
+            "display_name": "Home visit for the evaluation and management of an established patient, which requires at least 2 of these 3 key components: A problem focused interval history; A problem focused examination; Straightforward medical decision making. Counseling and/or coordination of care with other physicians, other qualified health care professionals, or agencies are provided consistent with the nature of the problem(s) and the patient's and/or family's needs. Usually, the presenting problem(s) are self limited or minor. Typically, 15 minutes are spent face-to-face with the patient and/or family.",
+            "white_list": false
+          },
+          {
+            "_id": "521f53410017f7454b00104b",
+            "black_list": false,
+            "code": "99348",
+            "code_system": "2.16.840.1.113883.6.12",
+            "code_system_name": "CPT",
+            "code_system_version": null,
+            "display_name": "Home visit for the evaluation and management of an established patient, which requires at least 2 of these 3 key components: An expanded problem focused interval history; An expanded problem focused examination; Medical decision making of low complexity. Counseling and/or coordination of care with other physicians, other qualified health care professionals, or agencies are provided consistent with the nature of the problem(s) and the patient's and/or family's needs. Usually, the presenting problem(s) are of low to moderate severity. Typically, 25 minutes are spent face-to-face with the patient and/or family.",
+            "white_list": false
+          },
+          {
+            "_id": "521f53410017f7454b00104c",
+            "black_list": false,
+            "code": "99349",
+            "code_system": "2.16.840.1.113883.6.12",
+            "code_system_name": "CPT",
+            "code_system_version": null,
+            "display_name": "Home visit for the evaluation and management of an established patient, which requires at least 2 of these 3 key components: A detailed interval history; A detailed examination; Medical decision making of moderate complexity. Counseling and/or coordination of care with other physicians, other qualified health care professionals, or agencies are provided consistent with the nature of the problem(s) and the patient's and/or family's needs. Usually, the presenting problem(s) are moderate to high severity. Typically, 40 minutes are spent face-to-face with the patient and/or family.",
+            "white_list": false
+          },
+          {
+            "_id": "521f53410017f7454b00104d",
+            "black_list": false,
+            "code": "99350",
+            "code_system": "2.16.840.1.113883.6.12",
+            "code_system_name": "CPT",
+            "code_system_version": null,
+            "display_name": "Home visit for the evaluation and management of an established patient, which requires at least 2 of these 3 key components: A comprehensive interval history; A comprehensive examination; Medical decision making of moderate to high complexity. Counseling and/or coordination of care with other physicians, other qualified health care professionals, or agencies are provided consistent with the nature of the problem(s) and the patient's and/or family's needs. Usually, the presenting problem(s) are of moderate to high severity. The patient may be unstable or may have developed a significant new problem requiring immediate physician attention. Typically, 60 minutes are spent face-to-face with the patient and/or family.",
+            "white_list": false
+          }
+        ],
+        "display_name": "Home Healthcare Services",
+        "oid": "2.16.840.1.113883.3.464.1003.101.12.1016",
+        "version": "20130614"
+      },
+      {
+        "_id": "521f533c0017f7454b0005b8",
+        "concepts": [
+          {
+            "_id": "521f533c0017f7454b0005b9",
+            "black_list": false,
+            "code": "99201",
+            "code_system": "2.16.840.1.113883.6.12",
+            "code_system_name": "CPT",
+            "code_system_version": null,
+            "display_name": "Office or other outpatient visit for the evaluation and management of a new patient, which requires these 3 key components: A problem focused history; A problem focused examination; Straightforward medical decision making. Counseling and/or coordination of care with other physicians, other qualified health care professionals, or agencies are provided consistent with the nature of the problem(s) and the patient's and/or family's needs. Usually, the presenting problem(s) are self limited or minor. Typically, 10 minutes are spent face-to-face with the patient and/or family.",
+            "white_list": false
+          },
+          {
+            "_id": "521f533c0017f7454b0005ba",
+            "black_list": false,
+            "code": "99202",
+            "code_system": "2.16.840.1.113883.6.12",
+            "code_system_name": "CPT",
+            "code_system_version": null,
+            "display_name": "Office or other outpatient visit for the evaluation and management of a new patient, which requires these 3 key components: An expanded problem focused history; An expanded problem focused examination; Straightforward medical decision making. Counseling and/or coordination of care with other physicians, other qualified health care professionals, or agencies are provided consistent with the nature of the problem(s) and the patient's and/or family's needs. Usually, the presenting problem(s) are of low to moderate severity. Typically, 20 minutes are spent face-to-face with the patient and/or family.",
+            "white_list": false
+          },
+          {
+            "_id": "521f533c0017f7454b0005bb",
+            "black_list": false,
+            "code": "99203",
+            "code_system": "2.16.840.1.113883.6.12",
+            "code_system_name": "CPT",
+            "code_system_version": null,
+            "display_name": "Office or other outpatient visit for the evaluation and management of a new patient, which requires these 3 key components: A detailed history; A detailed examination; Medical decision making of low complexity. Counseling and/or coordination of care with other physicians, other qualified health care professionals, or agencies are provided consistent with the nature of the problem(s) and the patient's and/or family's needs. Usually, the presenting problem(s) are of moderate severity. Typically, 30 minutes are spent face-to-face with the patient and/or family.",
+            "white_list": false
+          },
+          {
+            "_id": "521f533c0017f7454b0005bc",
+            "black_list": false,
+            "code": "99204",
+            "code_system": "2.16.840.1.113883.6.12",
+            "code_system_name": "CPT",
+            "code_system_version": null,
+            "display_name": "Office or other outpatient visit for the evaluation and management of a new patient, which requires these 3 key components: A comprehensive history; A comprehensive examination; Medical decision making of moderate complexity. Counseling and/or coordination of care with other physicians, other qualified health care professionals, or agencies are provided consistent with the nature of the problem(s) and the patient's and/or family's needs. Usually, the presenting problem(s) are of moderate to high severity. Typically, 45 minutes are spent face-to-face with the patient and/or family.",
+            "white_list": false
+          },
+          {
+            "_id": "521f533c0017f7454b0005bd",
+            "black_list": false,
+            "code": "99205",
+            "code_system": "2.16.840.1.113883.6.12",
+            "code_system_name": "CPT",
+            "code_system_version": null,
+            "display_name": "Office or other outpatient visit for the evaluation and management of a new patient, which requires these 3 key components: A comprehensive history; A comprehensive examination; Medical decision making of high complexity. Counseling and/or coordination of care with other physicians, other qualified health care professionals, or agencies are provided consistent with the nature of the problem(s) and the patient's and/or family's needs. Usually, the presenting problem(s) are of moderate to high severity. Typically, 60 minutes are spent face-to-face with the patient and/or family.",
+            "white_list": false
+          },
+          {
+            "_id": "521f533c0017f7454b0005be",
+            "black_list": false,
+            "code": "99212",
+            "code_system": "2.16.840.1.113883.6.12",
+            "code_system_name": "CPT",
+            "code_system_version": null,
+            "display_name": "Office or other outpatient visit for the evaluation and management of an established patient, which requires at least 2 of these 3 key components: A problem focused history; A problem focused examination; Straightforward medical decision making. Counseling and/or coordination of care with other physicians, other qualified health care professionals, or agencies are provided consistent with the nature of the problem(s) and the patient's and/or family's needs. Usually, the presenting problem(s) are self limited or minor. Typically, 10 minutes are spent face-to-face with the patient and/or family.",
+            "white_list": false
+          },
+          {
+            "_id": "521f533c0017f7454b0005bf",
+            "black_list": false,
+            "code": "99213",
+            "code_system": "2.16.840.1.113883.6.12",
+            "code_system_name": "CPT",
+            "code_system_version": null,
+            "display_name": "Office or other outpatient visit for the evaluation and management of an established patient, which requires at least 2 of these 3 key components: An expanded problem focused history; An expanded problem focused examination; Medical decision making of low complexity. Counseling and coordination of care with other physicians, other qualified health care professionals, or agencies are provided consistent with the nature of the problem(s) and the patient's and/or family's needs. Usually, the presenting problem(s) are of low to moderate severity. Typically, 15 minutes are spent face-to-face with the patient and/or family.",
+            "white_list": false
+          },
+          {
+            "_id": "521f533c0017f7454b0005c0",
+            "black_list": false,
+            "code": "99214",
+            "code_system": "2.16.840.1.113883.6.12",
+            "code_system_name": "CPT",
+            "code_system_version": null,
+            "display_name": "Office or other outpatient visit for the evaluation and management of an established patient, which requires at least 2 of these 3 key components: A detailed history; A detailed examination; Medical decision making of moderate complexity. Counseling and/or coordination of care with other physicians, other qualified health care professionals, or agencies are provided consistent with the nature of the problem(s) and the patient's and/or family's needs. Usually, the presenting problem(s) are of moderate to high severity. Typically, 25 minutes are spent face-to-face with the patient and/or family.",
+            "white_list": false
+          },
+          {
+            "_id": "521f533c0017f7454b0005c1",
+            "black_list": false,
+            "code": "99215",
+            "code_system": "2.16.840.1.113883.6.12",
+            "code_system_name": "CPT",
+            "code_system_version": null,
+            "display_name": "Office or other outpatient visit for the evaluation and management of an established patient, which requires at least 2 of these 3 key components: A comprehensive history; A comprehensive examination; Medical decision making of high complexity. Counseling and/or coordination of care with other physicians, other qualified health care professionals, or agencies are provided consistent with the nature of the problem(s) and the patient's and/or family's needs. Usually, the presenting problem(s) are of moderate to high severity. Typically, 40 minutes are spent face-to-face with the patient and/or family.",
+            "white_list": false
+          }
+        ],
+        "display_name": "Office Visit",
+        "oid": "2.16.840.1.113883.3.464.1003.101.12.1001",
+        "version": "20130614"
+      },
+      {
+        "_id": "521f533a0017f7454b000057",
+        "concepts": [
+          {
+            "_id": "521f533a0017f7454b000058",
+            "black_list": false,
+            "code": "F",
+            "code_system": "2.16.840.1.113883.18.2",
+            "code_system_name": "AdministrativeSex",
+            "code_system_version": null,
+            "display_name": "Female",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b000059",
+            "black_list": false,
+            "code": "M",
+            "code_system": "2.16.840.1.113883.18.2",
+            "code_system_name": "AdministrativeSex",
+            "code_system_version": null,
+            "display_name": "Male",
+            "white_list": false
+          },
+          {
+            "_id": "521f533a0017f7454b00005a",
+            "black_list": false,
+            "code": "U",
+            "code_system": "2.16.840.1.113883.18.2",
+            "code_system_name": "AdministrativeSex",
+            "code_system_version": null,
+            "display_name": "Unknown",
+            "white_list": false
+          }
+        ],
+        "display_name": "ONC Administrative Sex",
+        "oid": "2.16.840.1.113762.1.4.1",
+        "version": "20121025"
+      }
+    ]
   }
 ]


### PR DESCRIPTION
When I removed the value sets from measure JSON in the code, I did the same in the tests, forgetting that in the tests we use the JSON for generating the measure calculation code as well. Adding the value sets back in on the test side only gets our tests passing again.
