### PR TITLE
Fix account page forms

### DIFF
--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -12,23 +12,31 @@
   <% end %>
 
   <div class="form-group row">
-    <div class="input-group input-group-lg col-md-6 required">
-      <span class="input-group-addon"><i class="fa fa-user fa-lg fa-fw"></i></span>
-      <%= f.text_field :first_name, class: "form-control", placeholder: "first name*" %>
+    <div class="col-md-6">
+      <div class="input-group input-group-lg required">
+        <span class="input-group-addon"><i class="fa fa-user fa-lg fa-fw"></i></span>
+        <%= f.text_field :first_name, class: "form-control", placeholder: "first name*" %>
+      </div>
     </div>
-    <div class="input-group input-group-lg col-md-6 required">
-      <span class="input-group-addon"><i class="fa fa-user fa-lg fa-fw"></i></span>
-      <%= f.text_field :last_name, class: "form-control", placeholder: "last name*" %>
+    <div class="col-md-6">
+      <div class="input-group input-group-lg required">
+        <span class="input-group-addon"><i class="fa fa-user fa-lg fa-fw"></i></span>
+        <%= f.text_field :last_name, class: "form-control", placeholder: "last name*" %>
+      </div>
     </div>
   </div>
   <div class="form-group row">
-    <div class="input-group input-group-lg col-md-6">
-      <span class="input-group-addon"><i class="fa fa-envelope fa-lg fa-fw"></i></span>
-      <%= f.email_field :email, class: "form-control", placeholder: "email@example.com" %>
+    <div class="col-md-6">
+      <div class="input-group input-group-lg">
+        <span class="input-group-addon"><i class="fa fa-envelope fa-lg fa-fw"></i></span>
+        <%= f.email_field :email, class: "form-control", placeholder: "email@example.com" %>
+      </div>
     </div>
-    <div class="input-group input-group-lg col-md-6">
-      <span class="input-group-addon"><i class="fa fa-mobile fa-lg fa-fw"></i></span>
-      <%= f.text_field :telephone, class: "form-control", placeholder: "(000) 000-0000" %>
+    <div class="col-md-6">
+      <div class="input-group input-group-lg">
+        <span class="input-group-addon"><i class="fa fa-mobile fa-lg fa-fw"></i></span>
+        <%= f.text_field :telephone, class: "form-control", placeholder: "(000) 000-0000" %>
+      </div>
     </div>
   </div>
   <div class="form-group row">
@@ -39,9 +47,11 @@
       </div>
       Must be at least 8 characters long and contain characters from at least two of: lowercase letters, uppercase letters, numbers, and special characters (leave blank if you don't want to change it).
     </div>
-    <div class="input-group input-group-lg col-md-6 required">
-      <span class="input-group-addon"><i class="fa fa-lock fa-lg fa-fw"></i></span>
-      <%= f.password_field :password_confirmation, class: "form-control", placeholder: "confirm password*" %>
+    <div class="col-md-6">
+      <div class="input-group input-group-lg required">
+        <span class="input-group-addon"><i class="fa fa-lock fa-lg fa-fw"></i></span>
+        <%= f.password_field :password_confirmation, class: "form-control", placeholder: "confirm password*" %>
+      </div>
     </div>
   </div>
 
@@ -56,8 +66,8 @@
 
     <div class="col-md-6">
       <div class="row">
-      <div class="col-xs-6"><a class="btn btn-default btn-block btn-lg" href="/">Cancel</a></div>
-      <div class="col-xs-6"><%= f.submit "Save", class: "btn btn-primary btn-block btn-lg" %></div>
+        <div class="col-xs-6"><a class="btn btn-default btn-block btn-lg" href="/">Cancel</a></div>
+        <div class="col-xs-6"><%= f.submit "Save", class: "btn btn-primary btn-block btn-lg" %></div>
       </div>
     </div>
   </div>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -11,23 +11,31 @@
   <% end %>
 
   <div class="form-group row">
-    <div class="input-group input-group-lg col-md-6">
-      <span class="input-group-addon"><i class="fa fa-user fa-lg fa-fw"></i></span>
-      <%= f.text_field :first_name, class: "form-control", placeholder: "first name" %>
+    <div class="col-md-6">
+      <div class="input-group input-group-lg">
+        <span class="input-group-addon"><i class="fa fa-user fa-lg fa-fw"></i></span>
+        <%= f.text_field :first_name, class: "form-control", placeholder: "first name" %>
+      </div>
     </div>
-    <div class="input-group input-group-lg col-md-6">
-      <span class="input-group-addon"><i class="fa fa-user fa-lg fa-fw"></i></span>
-      <%= f.text_field :last_name, class: "form-control", placeholder: "last name" %>
+    <div class="col-md-6">
+      <div class="input-group input-group-lg">
+        <span class="input-group-addon"><i class="fa fa-user fa-lg fa-fw"></i></span>
+        <%= f.text_field :last_name, class: "form-control", placeholder: "last name" %>
+      </div>
     </div>
   </div>
   <div class="form-group row">
-    <div class="input-group input-group-lg col-md-6">
-      <span class="input-group-addon"><i class="fa fa-envelope fa-lg fa-fw"></i></span>
-      <%= f.email_field :email, class: "form-control", placeholder: "email@example.com" %>
+    <div class="col-md-6">
+      <div class="input-group input-group-lg required">
+        <span class="input-group-addon"><i class="fa fa-envelope fa-lg fa-fw"></i></span>
+        <%= f.email_field :email, class: "form-control", placeholder: "email@example.com" %>
+      </div>
     </div>
-    <div class="input-group input-group-lg col-md-6">
-      <span class="input-group-addon"><i class="fa fa-mobile fa-lg fa-fw"></i></span>
-      <%= f.text_field :telephone, class: "form-control", placeholder: "(000) 000-0000" %>
+    <div class="col-md-6">
+      <div class="input-group input-group-lg">
+        <span class="input-group-addon"><i class="fa fa-mobile fa-lg fa-fw"></i></span>
+        <%= f.text_field :telephone, class: "form-control", placeholder: "(000) 000-0000" %>
+      </div>
     </div>
   </div>
   <div class="form-group row">
@@ -38,9 +46,11 @@
       </div>
       Must be at least 8 characters long and contain characters from at least two of: lowercase letters, uppercase letters, numbers, and special characters.
     </div>
-    <div class="input-group input-group-lg col-md-6 required">
-      <span class="input-group-addon"><i class="fa fa-lock fa-lg fa-fw"></i></span>
-      <%= f.password_field :password_confirmation, class: "form-control", placeholder: "confirm password*" %>
+    <div class="col-md-6">
+      <div class="input-group input-group-lg required">
+        <span class="input-group-addon"><i class="fa fa-lock fa-lg fa-fw"></i></span>
+        <%= f.password_field :password_confirmation, class: "form-control", placeholder: "confirm password*" %>
+      </div>
     </div>
   </div>
 


### PR DESCRIPTION
#### Story
- https://www.pivotaltracker.com/story/show/65816846
#### Notes
- fixed grid styling on account edit and registration pages
- ~~added labels to form elements in account edit page (for clarity, can be removed if undesired)~~
#### Screenshots
- **previous** account registration page
  - ![default_accountregister](https://f.cloud.github.com/assets/456952/2274163/00c968a8-9f19-11e3-984e-97b976a62831.png)
- **current** account registration page
  - ![accountregister](https://f.cloud.github.com/assets/456952/2274161/00c86246-9f19-11e3-99d4-5e572ecda429.png)
- **previous** account edit page
  - ![default_accountedit](https://f.cloud.github.com/assets/456952/2274162/00c91420-9f19-11e3-8c63-2f30de4056ae.png)
- **current** account edit page
  - ![screen shot 2014-02-26 at 5 06 32 pm](https://f.cloud.github.com/assets/456952/2276357/5d084d32-9f32-11e3-9fe8-b9357334c36b.png)
