### PR TITLE
Update patient export features

### DIFF
--- a/app/assets/javascripts/templates/measure.hbs
+++ b/app/assets/javascripts/templates/measure.hbs
@@ -5,11 +5,10 @@
     <span class="settings-container">
       <div class="measure-settings">
         {{#button "updateMeasure" class="btn btn-default update-measure"}}<i class="fa fa-upload"></i> Update{{/button}}
-        {{#button "exportPatients" class="btn btn-default export-patients"}}<i class="fa fa-download"></i> Export{{/button}}
         {{#button "deleteMeasure" class="btn btn-danger delete-measure hide"}}<i class="fa fa-times"></i> Delete{{/button}}
         {{#button "showDelete" class="btn btn-danger-inverse delete-icon"}}<i class="fa fa-minus-circle"></i> <span class="sr-only">Show Delete</span>{{/button}}
       </div>
-      {{#button "toggleSettings" tag="a" class="btn-settings" href=""}}<i class="fa fa-cog"></i> <span class="sr-only">Settings</span>{{/button}}
+      {{#button "measureSettings" tag="a" class="btn-settings" href=""}}<i class="fa fa-cog"></i> <span class="sr-only">Measure Settings</span>{{/button}}
     </span>
   </div>
   <div class="measure-dsp">
@@ -26,6 +25,14 @@
 </div>
 
 <div class="right-sidebar">
-  <h1 class="title-bar">Test Patients</h1>
+  <div class="patients-title">
+    <span class="short-title pull-left">Test Patients</span>
+    <span class="settings-container">
+      <div class="patients-settings">
+        {{#button "exportPatients" class="btn btn-default export-patients"}}<i class="fa fa-download"></i> Export{{/button}}
+      </div>
+      {{#button "patientsSettings" tag="a" class="btn-settings" href=""}}<i class="fa fa-cog"></i> <span class="sr-only">Patient Options</span>{{/button}}
+    </span>
+  </div>
   {{view populationCalculation}}
 </div>

--- a/app/assets/javascripts/views/measure_view.js.coffee
+++ b/app/assets/javascripts/views/measure_view.js.coffee
@@ -43,10 +43,14 @@ class Thorax.Views.Measure extends Thorax.View
     @model.destroy()
     bonnie.renderMeasures()
 
-  toggleSettings: (e) ->
+  measureSettings: (e) ->
     e.preventDefault()
     @$('.delete-icon').click() if @$('.delete-measure').is(':visible')
     @$('.measure-settings').toggleClass('measure-settings-expanded')
+
+  patientsSettings: (e) ->
+    e.preventDefault()
+    @$('.patients-settings').toggleClass('patients-settings-expanded')
 
   showDelete: (e) ->
     e.preventDefault()

--- a/app/assets/stylesheets/measure.less
+++ b/app/assets/stylesheets/measure.less
@@ -21,6 +21,50 @@
     padding-top: 30px;
     padding-left: 50px;
   }
+  .patients-title {
+    .make-sm-column(12);
+    .title-bar;
+    margin-bottom: 10px;
+    .short-title {
+      font-size: 1.8em;
+      line-height: 1.75;
+      padding-right: 15px;
+      margin-top: 0;
+      color: black;
+      text-transform: uppercase;
+    }
+    .fa {
+      color: black;
+    }
+    .settings-container {
+      position: absolute;
+      top: 0;
+      right: 15px;
+    }
+    .btn-settings {
+      font-size: 1.8em;
+      line-height: 1.75;
+    }
+    .patients-settings {
+      visibility: hidden;
+      opacity: 0;
+      background-color: @gray-lighter;
+      position: absolute;
+      top: 4px;
+      .transition(opacity 0.5s linear);
+      .export-patients {
+        .fa {
+          color: @brand-primary;
+        }
+      }
+    }
+    .patients-settings-expanded {
+      visibility: visible;
+      opacity: 1;
+      right: 1.8em;
+      white-space: nowrap;
+    }
+  }
 }
 
 .main {

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -37,16 +37,16 @@ class PatientsController < ApplicationController
     qrda_exporter = HealthDataStandards::Export::Cat1.new
     html_exporter = HealthDataStandards::Export::HTML.new
 
-    measures = Measure.all.map(&:as_hqmf_model)
+    measure = Measure.by_user(current_user).where({:hqmf_set_id => params[:hqmf_set_id]}).map(&:as_hqmf_model)
     start_time = Time.new(2012, 1, 1)
     end_time = Time.new(2012, 12, 31)
 
     stringio = Zip::ZipOutputStream::write_buffer do |zip|
       records.each_with_index do |patient, index|
         zip.put_next_entry("qrda_#{index+1}.xml")
-        zip.puts qrda_exporter.export(patient, measures, start_time, end_time)
+        zip.puts qrda_exporter.export(patient, measure, start_time, end_time)
         zip.put_next_entry("patient_#{index+1}.html")
-        zip.puts html_exporter.export(patient, measures)
+        zip.puts html_exporter.export(patient, measure)
       end
     end
 

--- a/lib/tasks/bonnie.rake
+++ b/lib/tasks/bonnie.rake
@@ -92,6 +92,11 @@ namespace :bonnie do
       puts "Resetting #{dest_db} from #{host}:#{source_db}"
       Mongoid.default_session.with(database: dest_db) { |db| db.drop }
       Mongoid.default_session.with(database: 'admin') { |db| db.command copydb: 1, fromhost: host, fromdb: source_db, todb: dest_db }
+      puts "Dropping unneeded collections: measures, bundles, patient_cache, query_cache..."
+      MONGO_DB['bundles'].drop()
+      MONGO_DB['measures'].drop()
+      MONGO_DB['query_cache'].drop()
+      MONGO_DB['patient_cache'].drop()
       Rake::Task['bonnie:patients:update_measure_ids'].invoke
       Rake::Task['bonnie:users:associate_user_with_measures'].invoke
       Rake::Task['bonnie:users:associate_user_with_patients'].invoke


### PR DESCRIPTION
#### Stories
- https://www.pivotaltracker.com/story/show/66688288
  - patient export should not export based on all the measures
- https://www.pivotaltracker.com/story/show/66955040
  - remove unused collections from db reset
- https://www.pivotaltracker.com/story/show/66689010
  - move export button to be next to the test patients label
#### Notes
- retrieve current measure via <code>hqmf_set_id</code> and scoped by current user
- updated <code>rake bonnie:db:reset</code> to drop <code>patient_cache</code>, <code>query_cache</code>, <code>measures</code>, and <code>bundles</code> collections after copying
- added patients settings to the Test Patients header in measure view, updated styling to matched measure title bar
#### Screenshots
- updated measure view
  - ![patientssettings](https://f.cloud.github.com/assets/456952/2336128/923c8ae6-a48b-11e3-92e4-197eef2c86ae.png)
- patients settings expanded
  - ![patientssettingsexpanded](https://f.cloud.github.com/assets/456952/2336129/9240471c-a48b-11e3-996d-66cab63a1063.png)
