### PR TITLE
Make jasmine tests independent of any content in local MongoDB

### DIFF
--- a/spec/javascripts/setup/measures.js.erb
+++ b/spec/javascripts/setup/measures.js.erb
@@ -1,6 +1,9 @@
 <%# encoding: utf-8 %>
 <%# We need to specify UTF-8 in first line above because the measures have UTF-8 characters %>
 
+<%# We want Jasmine to be independent of content in any particular MongoDB instance %>
+<% Mongoid.configure { |config| config.sessions = { default: { database: 'jasmine', hosts: [] } } } %>
+
 <%# Load the JSON for our fixture measures %>
 <% measures_fixture_file = File.join File.dirname(__FILE__), '../fixtures/json/measures.json' %>
 <% measures_json = File.read(measures_fixture_file) %>


### PR DESCRIPTION
We sometimes get Jasmine test failures on Travis that don't happen locally, generally because content in the local MongoDB is required to make the test pass; we don't want _any_ dependency on MongoDB content in the Jasmine tests. This pull request tries to address that by breaking the default MongoDB connection during the test setup.
