### PR TITLE
Tweak inline mongoid configuration for jasmine for TravisCI

### DIFF
--- a/spec/javascripts/setup/measures.js.erb
+++ b/spec/javascripts/setup/measures.js.erb
@@ -2,7 +2,7 @@
 <%# We need to specify UTF-8 in first line above because the measures have UTF-8 characters %>
 
 <%# We want Jasmine to be independent of content in any particular MongoDB instance %>
-<% Mongoid.configure { |config| config.sessions = { default: { database: 'jasmine', hosts: [] } } } %>
+<% Mongoid.configure { |config| config.sessions = { default: { database: 'jasmine', hosts: ['localhost:27017'] } } } %>
 
 <%# Load the JSON for our fixture measures %>
 <% measures_fixture_file = File.join File.dirname(__FILE__), '../fixtures/json/measures.json' %>


### PR DESCRIPTION
Looks like a more specific Mongo config is needed on TravisCI (maybe a different version of MongoDB?). This version makes tests pass again.
