### PR TITLE
Fix patient birthdate validation to not use string length

### DIFF
--- a/app/assets/javascripts/models/patient.js.coffee
+++ b/app/assets/javascripts/models/patient.js.coffee
@@ -123,7 +123,7 @@ class Thorax.Models.Patient extends Thorax.Model
     errors = []
     errors.push ['first', 'Name fields cannot be blank'] unless @get('first').length > 0
     errors.push ['last', 'Name fields cannot be blank'] unless @get('last').length > 0
-    errors.push ['birthdate', 'Date of birth cannot be blank'] unless @get('birthdate').length > 0
+    errors.push ['birthdate', 'Date of birth cannot be blank'] unless @get('birthdate')
     return errors if errors.length > 0
 
 class Thorax.Collections.Patients extends Thorax.Collection


### PR DESCRIPTION
- Change patient model's <code>birthdate</code> validation to not use string length property, but rather boolean evaluation based on existence; required for inline cloning or saving of patient models without patient builder interactions
