### PR TITLE
change render measures to navigate so that the url gets updated... this ...

### DIFF
--- a/app/assets/javascripts/views/measure_view.js.coffee
+++ b/app/assets/javascripts/views/measure_view.js.coffee
@@ -41,7 +41,7 @@ class Thorax.Views.Measure extends Thorax.View
   deleteMeasure: (e) ->
     @model = $(e.target).model()
     @model.destroy()
-    bonnie.renderMeasures()
+    bonnie.navigate '', trigger: true
 
   measureSettings: (e) ->
     e.preventDefault()


### PR DESCRIPTION
...is important becuase loading measures returns to the source url, so it cannot be wrong on the dashboard
