### PR TITLE
Clone patients from one measure into another

### DIFF
--- a/app/assets/javascripts/templates/measure.hbs
+++ b/app/assets/javascripts/templates/measure.hbs
@@ -57,16 +57,34 @@
   <span class="measure-listing-header">Select Measure:</span>
   <div class="list-group">
     {{#collection measures}}
-      <a class="list-group-item measure-listing measure-{{hqmf_set_id}}">
-        <div class="row">
-          <div class="col-sm-6">
-            {{cms_id}}
+      {{#ifCond hqmf_set_id "!=" ../hqmf_set_id}}
+        <a class="list-group-item measure-listing measure-{{hqmf_set_id}}">
+          <div class="row">
+            <div class="col-sm-6">
+              {{cms_id}}
+            </div>
+            <div class="col-sm-6">
+              {{#button "cloneIntoMeasure" class="btn btn-default btn-clone-patients btn-clone-{{hqmf_set_id}}" style="display: none;" expand-tokens=true}}CLONE{{/button}}
+            </div>
           </div>
-          <div class="col-sm-6">
-            {{#button "cloneIntoMeasure" class="btn btn-default btn-clone-patients btn-clone-{{hqmf_set_id}}" style="display: none;" expand-tokens=true}}CLONE{{/button}}
-          </div>
-        </div>
-      </a>
+        </a>
+      {{/ifCond}}
     {{/collection}}
+  </div>
+</div>
+
+<div class="modal fade" id="clonePatientsDialog" tabindex="-1" role="dialog" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h1>Cloning Patients...</h1>
+      </div>
+      <div class="modal-body">
+        <div class="progress progress-striped active">
+          <div class="progress-bar progress-bar-primary clone-patients-progress-bar" role="progressbar" aria-valuenow="100" aria-valuemin="0" aria-valuemax="100" style="width: 0%">
+            <span class="sr-only">Cloning...</span>
+        </div>
+      </div>
+    </div>
   </div>
 </div>

--- a/app/assets/javascripts/templates/measure.hbs
+++ b/app/assets/javascripts/templates/measure.hbs
@@ -50,24 +50,23 @@
   {{view populationCalculation}}
 </div>
 
-<div class="measure-listing-sidebar col-sm-3" style="display:none;">
+<div class="measure-listing-sidebar" style="display:none;">
   <div class="measures-title">
     <span class="short-title pull-left">Measure Listing</span>
-    {{!-- <span class="settings-container">
-      <div class="patients-settings">
-        {{#button "exportPatients" class="btn btn-default export-patients"}}<i class="fa fa-download"></i> Export{{/button}}
-        {{#button "toggleMeasureListing" class="btn btn-default btn-measure-listing toggle-measure-listing"}}<i class="fa fa-users"></i> <i class="fa fa-arrow-right"></i> <i class="fa fa-tasks"></i>{{/button}}
-      </div>
-      {{#button "patientsSettings" tag="a" class="btn-settings" href=""}}<i class="fa fa-cog"></i> <span class="sr-only">Patient Options</span>{{/button}}
-    </span> --}}
   </div>
   <span class="measure-listing-header">Select Measure:</span>
-  {{#button "cloneIntoMeasure" class="btn btn-primary pull-right"}}CLONE{{/button}}
   <div class="list-group">
     {{#collection measures}}
-      <a class="list-group-item measure-listing measure-{{hqmf_set_id}}">{{cms_id}}</a>
+      <a class="list-group-item measure-listing measure-{{hqmf_set_id}}">
+        <div class="row">
+          <div class="col-sm-6">
+            {{cms_id}}
+          </div>
+          <div class="col-sm-6">
+            {{#button "cloneIntoMeasure" class="btn btn-default btn-clone-patients btn-clone-{{hqmf_set_id}}" style="display: none;" expand-tokens=true}}CLONE{{/button}}
+          </div>
+        </div>
+      </a>
     {{/collection}}
   </div>
-  {{!-- <span class="patients-listing-header" style="display:none;">Select Patients to Clone:</span>
-  {{view populationCalculation}} --}}
 </div>

--- a/app/assets/javascripts/templates/measure.hbs
+++ b/app/assets/javascripts/templates/measure.hbs
@@ -1,4 +1,4 @@
- <div class="main">
+ <div class="main col-sm-8">
   <div class="measure-title">
     <span class="short-title pull-left"><i class="fa fa-tasks"></i> {{cms_id}}:</span>
     <span class="full-title">{{title}}</span>
@@ -41,9 +41,33 @@
     <span class="settings-container">
       <div class="patients-settings">
         {{#button "exportPatients" class="btn btn-default export-patients"}}<i class="fa fa-download"></i> Export{{/button}}
+        {{#button "toggleMeasureListing" class="btn btn-default btn-measure-listing toggle-measure-listing"}}<i class="fa fa-users"></i> <i class="fa fa-arrow-right"></i> <i class="fa fa-tasks"></i>{{/button}}
       </div>
       {{#button "patientsSettings" tag="a" class="btn-settings" href=""}}<i class="fa fa-cog"></i> <span class="sr-only">Patient Options</span>{{/button}}
     </span>
   </div>
+  <span class="patients-listing-header" style="display:none;">Select Patients to Clone:</span>
   {{view populationCalculation}}
+</div>
+
+<div class="measure-listing-sidebar col-sm-3" style="display:none;">
+  <div class="measures-title">
+    <span class="short-title pull-left">Measure Listing</span>
+    {{!-- <span class="settings-container">
+      <div class="patients-settings">
+        {{#button "exportPatients" class="btn btn-default export-patients"}}<i class="fa fa-download"></i> Export{{/button}}
+        {{#button "toggleMeasureListing" class="btn btn-default btn-measure-listing toggle-measure-listing"}}<i class="fa fa-users"></i> <i class="fa fa-arrow-right"></i> <i class="fa fa-tasks"></i>{{/button}}
+      </div>
+      {{#button "patientsSettings" tag="a" class="btn-settings" href=""}}<i class="fa fa-cog"></i> <span class="sr-only">Patient Options</span>{{/button}}
+    </span> --}}
+  </div>
+  <span class="measure-listing-header">Select Measure:</span>
+  {{#button "cloneIntoMeasure" class="btn btn-primary pull-right"}}CLONE{{/button}}
+  <div class="list-group">
+    {{#collection measures}}
+      <a class="list-group-item measure-listing measure-{{hqmf_set_id}}">{{measure_id}}</a>
+    {{/collection}}
+  </div>
+  {{!-- <span class="patients-listing-header" style="display:none;">Select Patients to Clone:</span>
+  {{view populationCalculation}} --}}
 </div>

--- a/app/assets/javascripts/templates/measure.hbs
+++ b/app/assets/javascripts/templates/measure.hbs
@@ -65,7 +65,7 @@
   {{#button "cloneIntoMeasure" class="btn btn-primary pull-right"}}CLONE{{/button}}
   <div class="list-group">
     {{#collection measures}}
-      <a class="list-group-item measure-listing measure-{{hqmf_set_id}}">{{measure_id}}</a>
+      <a class="list-group-item measure-listing measure-{{hqmf_set_id}}">{{cms_id}}</a>
     {{/collection}}
   </div>
   {{!-- <span class="patients-listing-header" style="display:none;">Select Patients to Clone:</span>

--- a/app/assets/javascripts/templates/population_calculation.hbs
+++ b/app/assets/javascripts/templates/population_calculation.hbs
@@ -22,11 +22,15 @@
       <div class="panel-title">
         <div class="patient row">
           <div class="patient-status-icon-col status status-{{status}}">
-            {{#if done}}
-              {{#if match}}
-                <i class="fa fa-check"></i>
-              {{else}}
-                <i class="fa fa-times"></i>
+            {{#if ../patientsListing}}
+              <input type="checkbox" class="select-patient">
+            {{else}}
+              {{#if done}}
+                {{#if match}}
+                  <i class="fa fa-check"></i>
+                {{else}}
+                  <i class="fa fa-times"></i>
+                {{/if}}
               {{/if}}
             {{/if}}
           </div>

--- a/app/assets/javascripts/views/measure_view.js.coffee
+++ b/app/assets/javascripts/views/measure_view.js.coffee
@@ -45,7 +45,7 @@ class Thorax.Views.Measure extends Thorax.View
       failCallback: => @exportPatientsView.fail()
 
   toggleMeasureListing: (e) ->
-    @$('.main').toggleClass('col-sm-8 col-sm-5')
+    @$('.main').toggleClass('col-sm-8 col-sm-6')
     @$('.toggle-measure-listing').toggleClass('btn-default btn-measure-listing btn-primary btn-measure-listing-toggled')
     @$('.patients-listing-header').toggle()
     @trigger 'patients:toggleListing'
@@ -53,8 +53,10 @@ class Thorax.Views.Measure extends Thorax.View
 
   selectMeasureListing: (e) ->
     @$('.measure-listing').removeClass('active')
+    @$('.btn-clone-patients').hide()
     m = @$(e.target).model()
     @$(".measure-#{m.get('hqmf_set_id')}").addClass('active')
+    @$(".btn-clone-#{m.get('hqmf_set_id')}").show()
 
   cloneIntoMeasure: (e) ->
     $d = @$('.select-patient:checked')

--- a/app/assets/javascripts/views/measure_view.js.coffee
+++ b/app/assets/javascripts/views/measure_view.js.coffee
@@ -55,7 +55,7 @@ class Thorax.Views.Measure extends Thorax.View
     @$('.measure-listing').removeClass('active')
     @$('.btn-clone-patients').hide()
     m = @$(e.target).model()
-    if @$('.select-patient:checked').length
+    if @$('.select-patient:checked').size()
       @$(".measure-#{m.get('hqmf_set_id')}").addClass('active')
       @$(".btn-clone-#{m.get('hqmf_set_id')}").show()
 
@@ -63,8 +63,9 @@ class Thorax.Views.Measure extends Thorax.View
     $d = @$('.select-patient:checked')
     measure = @measures.findWhere({hqmf_set_id: @$(e.target).model().get('hqmf_set_id')})
     count = 0
-    # @$("#clonePatientsDialog").modal backdrop: 'static'
+    @$("#clonePatientsDialog").modal backdrop: 'static'
     @$(".rebuild-patients-progress-bar").css('width', '0%')
+    @$("#clonePatientsDialog").on('hidden.bs.modal', -> bonnie.navigate "measures/#{measure.get('hqmf_set_id')}", trigger: true)
     for diff in $d
       difference = @$(diff).model()
       patient = @patients.findWhere({medical_record_number: difference.result.get('medical_record_id')})
@@ -75,12 +76,11 @@ class Thorax.Views.Measure extends Thorax.View
           @patients.add model # make sure that the patient exist in the global patient collection
           measure.get('patients').add model # and the measure's patient collection
           if bonnie.isPortfolio then @measures.each (m) -> m.get('patients').add model
-          count += 1
-          perc = (count / $d.length) * 100
+          count++
+          perc = (count / $d.size()) * 100
           @$(".clone-patients-progress-bar").css('width', perc.toFixed() + '%')
-          if count == $d.length
-            # @$("#clonePatientsDialog").modal 'hide'
-            bonnie.navigate "measures/#{measure.get('hqmf_set_id')}", trigger: true
+          if count == $d.size()
+            @$("#clonePatientsDialog").modal 'hide'
 
   deleteMeasure: (e) ->
     @model = $(e.target).model()

--- a/app/assets/javascripts/views/measure_view.js.coffee
+++ b/app/assets/javascripts/views/measure_view.js.coffee
@@ -5,6 +5,7 @@ class Thorax.Views.Measure extends Thorax.View
     rendered: ->
       @exportPatientsView = new Thorax.Views.ExportPatientsView() # Modal dialogs for exporting
       @exportPatientsView.appendTo(@$el)
+    'click .measure-listing': 'selectMeasureListing'
 
   initialize: ->
     populations = @model.get 'populations'
@@ -23,9 +24,11 @@ class Thorax.Views.Measure extends Thorax.View
     @logicView.listenTo @populationCalculation, 'logicView:clearCoverage', -> @clearCoverage()
 
     @populationCalculation.listenTo @logicView, 'population:update', (population) -> @updatePopulation(population)
+    @populationCalculation.listenTo @, 'patients:toggleListing', -> @togglePatientsListing()
     # FIXME: change the name of these events to reflect what the measure calculation view is actually saying
     @logicView.listenTo @populationCalculation, 'rationale:clear', -> @clearRationale()
     @logicView.listenTo @populationCalculation, 'rationale:show', (result) -> @showRationale(result)
+    @measures = @model.collection
 
   episodesOfCare: ->
     @model.get('source_data_criteria').filter((sdc) => sdc.get('source_data_criteria') in @model.get('episode_ids'))
@@ -40,6 +43,35 @@ class Thorax.Views.Measure extends Thorax.View
     $.fileDownload "patients/export?hqmf_set_id=#{@model.get('hqmf_set_id')}",
       successCallback: => @exportPatientsView.success()
       failCallback: => @exportPatientsView.fail()
+
+  toggleMeasureListing: (e) ->
+    @$('.main').toggleClass('col-sm-8 col-sm-5')
+    @$('.toggle-measure-listing').toggleClass('btn-default btn-measure-listing btn-primary btn-measure-listing-toggled')
+    @$('.patients-listing-header').toggle()
+    @trigger 'patients:toggleListing'
+    @$('.measure-listing-sidebar').toggle()
+
+  selectMeasureListing: (e) ->
+    @$('.measure-listing').removeClass('active')
+    m = @$(e.target).model()
+    @$(".measure-#{m.get('hqmf_set_id')}").addClass('active')
+
+  cloneIntoMeasure: (e) ->
+    $d = @$('.select-patient:checked')
+    measure = @$('.measure-listing.active').model()
+    for diff in $d
+      difference = @$(diff).model()
+      patient = @patients.findWhere({medical_record_number: difference.result.get('medical_record_id')})
+      clonedPatient = patient.deepClone(omit_id: true, dedupName: true)
+      console.log clonedPatient
+      console.log measure.get('hqmf_set_id')
+      clonedPatient.set('measure_ids', [measure.get('hqmf_set_id')])
+      clonedPatient.save()
+      @patients.add clonedPatient
+      console.log clonedPatient
+
+      # console.log difference.result
+      # console.log @patients.findWhere({medical_record_number: difference.result.get('medical_record_id')})
 
   deleteMeasure: (e) ->
     @model = $(e.target).model()

--- a/app/assets/javascripts/views/measure_view.js.coffee
+++ b/app/assets/javascripts/views/measure_view.js.coffee
@@ -63,15 +63,16 @@ class Thorax.Views.Measure extends Thorax.View
       difference = @$(diff).model()
       patient = @patients.findWhere({medical_record_number: difference.result.get('medical_record_id')})
       clonedPatient = patient.deepClone(omit_id: true, dedupName: true)
-      console.log clonedPatient
+      console.log "Saving #{clonedPatient.get('last')}, #{clonedPatient.get('first')}"
       console.log measure.get('hqmf_set_id')
       clonedPatient.set('measure_ids', [measure.get('hqmf_set_id')])
-      clonedPatient.save()
-      @patients.add clonedPatient
-      console.log clonedPatient
-
-      # console.log difference.result
-      # console.log @patients.findWhere({medical_record_number: difference.result.get('medical_record_id')})
+      clonedPatient.save clonedPatient.toJSON(),
+        success: (model) =>
+          @patients.add model # make sure that the patient exist in the global patient collection
+          measure?.get('patients').add model # and the measure's patient collection
+          if bonnie.isPortfolio then @measures.each (m) -> m.get('patients').add model
+          console.log "Succeeded!"
+    bonnie.navigate "measures/#{measure.get('hqmf_set_id')}", trigger: true
 
   deleteMeasure: (e) ->
     @model = $(e.target).model()

--- a/app/assets/javascripts/views/measure_view.js.coffee
+++ b/app/assets/javascripts/views/measure_view.js.coffee
@@ -58,21 +58,20 @@ class Thorax.Views.Measure extends Thorax.View
 
   cloneIntoMeasure: (e) ->
     $d = @$('.select-patient:checked')
-    measure = @$('.measure-listing.active').model()
+    measure = @measures.findWhere({hqmf_set_id: @$('.measure-listing.active').model().get('hqmf_set_id')})
+    count = 0
     for diff in $d
       difference = @$(diff).model()
       patient = @patients.findWhere({medical_record_number: difference.result.get('medical_record_id')})
       clonedPatient = patient.deepClone(omit_id: true, dedupName: true)
-      console.log "Saving #{clonedPatient.get('last')}, #{clonedPatient.get('first')}"
-      console.log measure.get('hqmf_set_id')
       clonedPatient.set('measure_ids', [measure.get('hqmf_set_id')])
       clonedPatient.save clonedPatient.toJSON(),
         success: (model) =>
           @patients.add model # make sure that the patient exist in the global patient collection
-          measure?.get('patients').add model # and the measure's patient collection
+          measure.get('patients').add model # and the measure's patient collection
           if bonnie.isPortfolio then @measures.each (m) -> m.get('patients').add model
-          console.log "Succeeded!"
-    bonnie.navigate "measures/#{measure.get('hqmf_set_id')}", trigger: true
+          count++
+          bonnie.navigate "measures/#{measure.get('hqmf_set_id')}", trigger: true if count == $d.length
 
   deleteMeasure: (e) ->
     @model = $(e.target).model()

--- a/app/assets/javascripts/views/population_calculation_view.js.coffee
+++ b/app/assets/javascripts/views/population_calculation_view.js.coffee
@@ -14,6 +14,7 @@ class Thorax.Views.PopulationCalculation extends Thorax.View
     @differences.sort()
     # Make sure the sort order updates as results come in
     @differences.on 'change', @differences.sort, @differences
+    @patientsListing = false
 
   context: ->
     _(super).extend measure_id: @measure.get('hqmf_set_id')
@@ -70,4 +71,11 @@ class Thorax.Views.PopulationCalculation extends Thorax.View
       @$(".expand-result-icon-#{result.patient.id}").removeClass('fa-angle-right').addClass('fa-angle-down')
       @trigger 'rationale:show', result
       @coverageView.hideCoverage()
+
+  togglePatientsListing: ->
+    @patientsListing = !@patientsListing
+    @$('.coverage-summary').toggle()
+    @render()
+    if @patientsListing then @$('.summary').hide() else @$('.summary').show()
+
 

--- a/app/assets/stylesheets/measure.less
+++ b/app/assets/stylesheets/measure.less
@@ -13,13 +13,14 @@
 }
 
 .measure-listing-sidebar {
+  .make-sm-column(2.5);
   .measures-title {
     .make-sm-column(12);
     .title-bar;
     margin-bottom: 10px;
     .short-title {
-      font-size: 1.8em;
-      line-height: 1.75;
+      font-size: 1.4em;
+      line-height: 2.15;
       margin-top: 0;
       color: black;
       text-transform: uppercase;

--- a/app/assets/stylesheets/measure.less
+++ b/app/assets/stylesheets/measure.less
@@ -12,6 +12,27 @@
   }
 }
 
+.measure-listing-sidebar {
+  .measures-title {
+    .make-sm-column(12);
+    .title-bar;
+    margin-bottom: 10px;
+    .short-title {
+      font-size: 1.8em;
+      line-height: 1.75;
+      margin-top: 0;
+      color: black;
+      text-transform: uppercase;
+    }
+    .fa {
+      color: black;
+    }
+  }
+  .list-group {
+    padding-top: 30px;
+  }
+}
+
 .right-sidebar {
   .make-sm-column(3.5);
   .patient-row {
@@ -52,9 +73,14 @@
       position: absolute;
       top: 4px;
       .transition(opacity 0.5s linear);
-      .export-patients {
+      .export-patients, .btn-measure-listing {
         .fa {
           color: @brand-primary;
+        }
+      }
+      .btn-measure-listing-toggled {
+        .fa {
+          color: white;
         }
       }
     }
@@ -68,7 +94,7 @@
 }
 
 .main {
-  .make-sm-column(8.5);
+  // .make-sm-column(8.5);
   > * {
     padding: 0 15px;
   }

--- a/app/assets/stylesheets/measure.less
+++ b/app/assets/stylesheets/measure.less
@@ -95,7 +95,6 @@
 }
 
 .main {
-  // .make-sm-column(8.5);
   > * {
     padding: 0 15px;
   }


### PR DESCRIPTION
#### Story
- https://www.pivotaltracker.com/story/show/65921508
#### Notes
- updated measure view to include measure listing
- users can select the patient cloning toggle button from the patient settings gear, which modifies the patient results to checkbox selectables, and expands a measure listing into the view with selectable measures by <code>cms_id</code>
- selecting a measure in the measure listing reveals a clone button, which clones the selected patients into the measure, and then re-routes the application to the selected measure's measure view
#### Screenshots
- NQF0105 before cloned patients
  - ![screen shot 2014-03-17 at 11 34 03 am](https://f.cloud.github.com/assets/456952/2437725/1887eb24-adea-11e3-938c-438d3a772ac3.png)
- NQF0104 with new patient cloning settings button
  - ![screen shot 2014-03-17 at 11 34 48 am](https://f.cloud.github.com/assets/456952/2437727/18881a5e-adea-11e3-9222-4ffd8340a3c5.png)
- NQF0104 with patient cloning toggled, patients selected, and NQF0105 selected
  - ![screen shot 2014-03-17 at 11 35 32 am](https://f.cloud.github.com/assets/456952/2437728/188894ca-adea-11e3-94e9-9d21a4e0f299.png)
- NQF0105 after cloned patients from NQF0104
  - ![screen shot 2014-03-17 at 11 35 40 am](https://f.cloud.github.com/assets/456952/2437726/1887e8fe-adea-11e3-8b89-e5faf002b365.png)
