### PR TITLE
Fix population tabs in measure view if no population titles were specified

### DIFF
--- a/app/assets/javascripts/templates/logic/layout.hbs
+++ b/app/assets/javascripts/templates/logic/layout.hbs
@@ -1,5 +1,5 @@
 {{#collection tag="ul" class="nav nav-tabs" item-context=populationContext}}
-  <li{{#if isActive}} class="active"{{/if}}>{{#button "switchPopulation" href="" tag="a" data-toggle="tab"}}{{title}}{{/button}}</li>
+  <li{{#if isActive}} class="active"{{/if}}>{{#button "switchPopulation" href="" tag="a" data-toggle="tab"}}{{populationTitle}}{{/button}}</li>
 {{/collection}}
 
 {{layout-element}}

--- a/app/assets/javascripts/views/logic/population_logic_view.js.coffee
+++ b/app/assets/javascripts/views/logic/population_logic_view.js.coffee
@@ -9,7 +9,9 @@ class Thorax.Views.PopulationsLogic extends Thorax.LayoutView
   showCoverage: -> @getView().showCoverage()
   clearCoverage: -> @getView().clearCoverage()
   populationContext: (population) ->
-    _(population.toJSON()).extend isActive: population is @collection.first()
+    _(population.toJSON()).extend 
+      isActive: population is @collection.first()
+      populationTitle: population.get('title') || population.get('sub_id')
 
 class Thorax.Views.PopulationLogic extends Thorax.View
 


### PR DESCRIPTION
#### Story
- https://www.pivotaltracker.com/story/show/67617960
#### Notes
- show population <code>sub_id</code> as tab titles if no population <code>title</code> attributes are present
#### Screenshots
- ![screen shot 2014-03-17 at 3 54 21 pm](https://f.cloud.github.com/assets/456952/2440932/fb694e2e-ae0d-11e3-87a9-2d4b6b3da91b.png)
- ![screen shot 2014-03-17 at 3 54 27 pm](https://f.cloud.github.com/assets/456952/2440931/fb691e72-ae0d-11e3-942f-d828fa1ac2d3.png)
