### PR TITLE
Finalize dialog should correctly handle episode of care and patient-based uploads

### DIFF
--- a/app/assets/javascripts/templates/import/finalize_measures.hbs
+++ b/app/assets/javascripts/templates/import/finalize_measures.hbs
@@ -17,20 +17,22 @@
           {{#collection measures tag="div"}}
             <h4>{{title}}</h4>
             <input type="hidden" name="{{@cid}}[hqmf_id]" value="{{hqmf_id}}">
-            <div class="form-group">
-              <label for="episodeSelect_{{@cid}}" class="col-lg-3 control-label">Episode(s) of Care:</label>
-              <div class="col-lg-9">
-                <select multiple="true" class="form-control" id="episodeSelect_{{@cid}}" name="{{@cid}}[episode_ids][]">
-                  {{#each source_data_criteria.models}}
-                    {{#with attributes}}
-                      {{#if specific_occurrence}}
-                        <option value="{{source_data_criteria}}" id="{{@cid}}">{{description}}</option>
-                      {{/if}}
-                    {{/with}}
-                  {{/each}}
-                </select>
+            {{#if episode_of_care}}
+              <div class="form-group">
+                <label for="episodeSelect_{{@cid}}" class="col-lg-3 control-label">Episode(s) of Care:</label>
+                <div class="col-lg-9">
+                  <select multiple="true" class="form-control" id="episodeSelect_{{@cid}}" name="{{@cid}}[episode_ids][]">
+                    {{#each source_data_criteria.models}}
+                      {{#with attributes}}
+                        {{#if specific_occurrence}}
+                          <option value="{{source_data_criteria}}" id="{{@cid}}">{{description}}</option>
+                        {{/if}}
+                      {{/with}}
+                    {{/each}}
+                  </select>
+                </div>
               </div>
-            </div>
+            {{/if}}
             {{#ifCond populations.models.length '>' 1}}
               <div class="form-group">
                 <label for="populationTitles" class="col-lg-3 control-label">Titles:</label>
@@ -60,7 +62,7 @@
       </div>
       <div class="modal-footer">
         <!--button type="button" class="btn btn-default" data-dismiss="modal">Close</button-->
-        <button type="button" id="finalizeMeasureSubmit" class="btn btn-primary">Done</button>
+        <button type="button" id="finalizeMeasureSubmit" class="btn btn-primary" disabled="disabled">Done</button>
       </div>
     </div><!-- /.modal-content -->
   </div><!-- /.modal-dialog -->

--- a/app/assets/javascripts/views/finalize_measures_view.js.coffee
+++ b/app/assets/javascripts/views/finalize_measures_view.js.coffee
@@ -8,6 +8,10 @@ class Thorax.Views.FinalizeMeasures extends Thorax.View
   events:
     'click #finalizeMeasureSubmit': 'submit'
     'ready': 'setup'
+    'change select':  'enableDone'
+
+  enableDone: -> 
+    @$('#finalizeMeasureSubmit').prop('disabled', !@$('select').val()?.length > 0)
 
   setup: ->
     # if we have no measures to finalize than there's nothing to do

--- a/app/assets/javascripts/views/finalize_measures_view.js.coffee
+++ b/app/assets/javascripts/views/finalize_measures_view.js.coffee
@@ -10,8 +10,9 @@ class Thorax.Views.FinalizeMeasures extends Thorax.View
     'ready': 'setup'
     'change select':  'enableDone'
 
-  enableDone: -> 
-    @$('#finalizeMeasureSubmit').prop('disabled', !@$('select').val()?.length > 0)
+  enableDone: ->
+    selects = (@$(s).val()?.length > 0 for s in @$('select'))
+    @$('#finalizeMeasureSubmit').prop('disabled', false in selects)
 
   setup: ->
     # if we have no measures to finalize than there's nothing to do
@@ -25,6 +26,7 @@ class Thorax.Views.FinalizeMeasures extends Thorax.View
       @display()
 
   display: ->
+    @$('#finalizeMeasureSubmit').prop('disabled', @$('select').length > 0)
     @finalizeDialog.modal(
       "backdrop" : "static",
       "keyboard" : true,


### PR DESCRIPTION
#### Story
- https://www.pivotaltracker.com/story/show/67691636
#### Notes
- if measure has <code>episode_of_care</code> as true, then finalize should account for epsiode(s) of care and disable the Done button until sufficient ones are selected
- if measure has <code>episode_of_care</code> as false, then finalize should not display episode(s) of care and enable the Done button by default
#### Screenshots
- upload Patient-based
  - ![screen shot 2014-03-18 at 1 26 41 pm](https://f.cloud.github.com/assets/456952/2451493/d13c025e-aec6-11e3-9b4f-e74f5d60a6fb.png)
- finalize Patient-based
  - ![screen shot 2014-03-18 at 1 48 52 pm](https://f.cloud.github.com/assets/456952/2451495/d13c8576-aec6-11e3-98a4-55bd8b1ae679.png)
- upload episode of care-based
  - ![screen shot 2014-03-18 at 1 49 30 pm](https://f.cloud.github.com/assets/456952/2451491/d13b3482-aec6-11e3-9db8-1f15e2070757.png)
- finalize episode of care-based (disabled)
  - ![screen shot 2014-03-18 at 1 49 58 pm](https://f.cloud.github.com/assets/456952/2451494/d13bfda4-aec6-11e3-8dc5-475e93bdbdf6.png)
- finalize episode of care-based (enabled)
  - ![screen shot 2014-03-18 at 1 50 08 pm](https://f.cloud.github.com/assets/456952/2451492/d13b4562-aec6-11e3-9c5b-330bc2750237.png)
- update episode of care-based
  - ![screen shot 2014-03-18 at 1 50 25 pm](https://f.cloud.github.com/assets/456952/2451490/d13ae4be-aec6-11e3-817c-d7272865dc2c.png)
