### PR TITLE
eval-uncovered is being applied too often.

### DIFF
--- a/app/assets/javascripts/views/logic/population_logic_view.js.coffee
+++ b/app/assets/javascripts/views/logic/population_logic_view.js.coffee
@@ -83,7 +83,7 @@ class Thorax.Views.PopulationLogic extends Thorax.View
 
   showCoverage: ->
     @clearRationale()
-    @$('.rationale .rationale-target').addClass('eval-uncovered')
+    @$('.rationale .rationale-target').addClass('eval-uncovered') if @model.coverage().rationaleCriteria.length > 0
     for criteria in @model.coverage().rationaleCriteria
       @$(".#{criteria}").removeClass('eval-uncovered')
       @$(".#{criteria}").addClass('eval-coverage') 


### PR DESCRIPTION
eval-uncovered is being applied too often.  It should not be applied unless there is also coverage data to apply
