### PR TITLE
fixes odd highlight issue on materialize

### DIFF
--- a/app/assets/javascripts/templates/logic/data_criteria.hbs
+++ b/app/assets/javascripts/templates/logic/data_criteria.hbs
@@ -14,21 +14,23 @@
     </ul>
   {{/if}}
 {{else}}
-  {{#if dataCriteria.specific_occurrence}}Occurrence {{dataCriteria.specific_occurrence}}: {{/if}}{{dataCriteria.description}}
-  {{#if dataCriteria.value}}
-    {{#ifCond dataCriteria.type '!=' 'characteristic' }}
-      (result{{view "ValueLogic" value=dataCriteria.value measure=../measure tag="span"}})
-    {{/ifCond}}
-  {{/if}}
-  {{#if dataCriteria.field_values}}
-    ({{#each dataCriteria.field_values}}
-      {{key_title}}{{#ifCond type '!=' 'ANYNonNull'}}{{view "ValueLogic" value=this measure=../../measure tag="span"}} {{/ifCond}}
-    {{/each}})
-  {{/if}}
-  {{#if dataCriteria.negation}}
-    (Not Done: {{translate_oid dataCriteria.negation_code_list_id}})
-  {{/if}}
-  <span class="sr-only sr-highlight-status"></span>
+  <span class="criteria-title">
+    {{#if dataCriteria.specific_occurrence}}Occurrence {{dataCriteria.specific_occurrence}}: {{/if}}{{dataCriteria.description}}
+    {{#if dataCriteria.value}}
+      {{#ifCond dataCriteria.type '!=' 'characteristic' }}
+        (result{{view "ValueLogic" value=dataCriteria.value measure=../measure tag="span"}})
+      {{/ifCond}}
+    {{/if}}
+    {{#if dataCriteria.field_values}}
+      ({{#each dataCriteria.field_values}}
+        {{key_title}}{{#ifCond type '!=' 'ANYNonNull'}}{{view "ValueLogic" value=this measure=../../measure tag="span"}} {{/ifCond}}
+      {{/each}})
+    {{/if}}
+    {{#if dataCriteria.negation}}
+      (Not Done: {{translate_oid dataCriteria.negation_code_list_id}})
+    {{/if}}
+    <span class="sr-only sr-highlight-status"></span>
+  </span>
   {{#if dataCriteria.temporal_references}}
     {{#ifCond dataCriteria.temporal_references.length '>' 1}}
       <ul class="multi-temporal">

--- a/app/assets/javascripts/views/logic/population_logic_view.js.coffee
+++ b/app/assets/javascripts/views/logic/population_logic_view.js.coffee
@@ -46,17 +46,20 @@ class Thorax.Views.PopulationLogic extends Thorax.View
           for key, value of rationale
             target = @$(".#{code}_children .#{key}")
             if (target.length > 0)
-              target.addClass(if updatedRationale[code]?[key] is false then 'eval-bad-specifics' else "eval-#{!!value}")
-              target.closest('.panel-heading').addClass(if updatedRationale[code]?[key] is false then 'eval-panel-bad-specifics' else "eval-panel-#{!!value}")
-      @rationaleScreenReaderStatus()
+              if updatedRationale[code]?[key] is false
+                targetClass = 'eval-bad-specifics'
+                targetPanelClass = 'eval-panel-bad-specifics'
+                srTitle = '(status: bad specifics)'
+              else
+                bool = !!value
+                targetClass = "eval-#{bool}"
+                targetPanelClass = "eval-panel-#{bool}"
+                srTitle = "(status: #{bool})"
+              target.addClass(targetClass)
+              target.closest('.panel-heading').addClass(targetPanelClass)
+              target.children('.sr-highlight-status').html(srTitle)
+              target.children('.criteria-title').children('.sr-highlight-status').html(srTitle)
     @expandPopulations()
-
-  rationaleScreenReaderStatus: ->
-    @$('.rationale .rationale-target').find('.sr-highlight-status').html('(status: none)')
-    @$('.eval-bad-specifics').children('.sr-highlight-status').html('(status: bad specifics)')
-    @$('.eval-false').children('.sr-highlight-status').html('(status: false)')
-    @$('.eval-true').children('.sr-highlight-status').html('(status: true)')
-
 
   highlightPatientData: (dataCriteriaKey, populationCriteriaKey) ->
     if @latestResult?.get('finalSpecifics')?[populationCriteriaKey]
@@ -83,7 +86,7 @@ class Thorax.Views.PopulationLogic extends Thorax.View
 
   showCoverage: ->
     @clearRationale()
-    @$('.rationale .rationale-target').addClass('eval-uncovered')
+    @$('.rationale .rationale-target').addClass('eval-uncovered') if @model.coverage().rationaleCriteria.length > 0
     for criteria in @model.coverage().rationaleCriteria
       @$(".#{criteria}").removeClass('eval-uncovered')
       @$(".#{criteria}").addClass('eval-coverage') 

--- a/app/assets/javascripts/views/logic/population_logic_view.js.coffee
+++ b/app/assets/javascripts/views/logic/population_logic_view.js.coffee
@@ -86,9 +86,7 @@ class Thorax.Views.PopulationLogic extends Thorax.View
 
   showCoverage: ->
     @clearRationale()
-    @$('.rationale .rationale-target').addClass('eval-uncovered') if @model.coverage().rationaleCriteria.length > 0
     for criteria in @model.coverage().rationaleCriteria
-      @$(".#{criteria}").removeClass('eval-uncovered')
       @$(".#{criteria}").addClass('eval-coverage') 
     @coverageScreenReaderStatus()
 
@@ -100,7 +98,7 @@ class Thorax.Views.PopulationLogic extends Thorax.View
 
   clearCoverage: ->
     if @$('.eval-coverage').length > 0
-      @$('.rationale .rationale-target').removeClass('eval-coverage eval-uncovered')
+      @$('.rationale .rationale-target').removeClass('eval-coverage')
       @$('.sr-highlight-status').html('')
 
   expandPopulations: ->

--- a/app/assets/javascripts/views/logic/population_logic_view.js.coffee
+++ b/app/assets/javascripts/views/logic/population_logic_view.js.coffee
@@ -58,6 +58,8 @@ class Thorax.Views.PopulationLogic extends Thorax.View
               target.addClass(targetClass)
               target.closest('.panel-heading').addClass(targetPanelClass)
               target.children('.sr-highlight-status').html(srTitle)
+              # this second line is there to fix an issue with sr-only in Chrome making text in inline elements not display
+              # by having the sr-only span and the DC title wrapped in a criteria-title span, the odd behavior goes away.
               target.children('.criteria-title').children('.sr-highlight-status').html(srTitle)
     @expandPopulations()
 

--- a/app/assets/javascripts/views/logic/population_logic_view.js.coffee
+++ b/app/assets/javascripts/views/logic/population_logic_view.js.coffee
@@ -46,15 +46,13 @@ class Thorax.Views.PopulationLogic extends Thorax.View
           for key, value of rationale
             target = @$(".#{code}_children .#{key}")
             if (target.length > 0)
-              if updatedRationale[code]?[key] is false
-                targetClass = 'eval-bad-specifics'
-                targetPanelClass = 'eval-panel-bad-specifics'
-                srTitle = '(status: bad specifics)'
+
+              [targetClass, targetPanelClass, srTitle] = if updatedRationale[code]?[key] is false
+                ['eval-bad-specifics', 'eval-panel-bad-specifics', '(status: bad specifics)']
               else
                 bool = !!value
-                targetClass = "eval-#{bool}"
-                targetPanelClass = "eval-panel-#{bool}"
-                srTitle = "(status: #{bool})"
+                ["eval-#{bool}", "eval-panel-#{bool}", "(status: #{bool})"]
+
               target.addClass(targetClass)
               target.closest('.panel-heading').addClass(targetPanelClass)
               target.children('.sr-highlight-status').html(srTitle)

--- a/app/assets/stylesheets/rationale.less
+++ b/app/assets/stylesheets/rationale.less
@@ -33,10 +33,6 @@
     background-color: @blue-lightest;
     color: @blue-darker;
   }
-  .eval-uncovered {
-    background-color: white;
-    color: black;
-  }
   .panel {
     padding: 5px 0;
     .panel-heading {


### PR DESCRIPTION
this fixes an odd highlight issue where the patient builder logic view does not display correctly after re-calculation.  I am not clear what's going on, but wrapping the sr-highlighting with a span seems to resolve the issue
