### PR TITLE
Quick fix for coverage styling bleeding into other logic elements

### DIFF
--- a/app/assets/stylesheets/rationale.less
+++ b/app/assets/stylesheets/rationale.less
@@ -32,6 +32,12 @@
   .eval-coverage {
     background-color: @blue-lightest;
     color: @blue-darker;
+    // FIXME: Back out this change when pophealth logic viz is integrated; intended as short-term fix for coverage
+    li {
+      background-color: white;
+      color: black;
+      font-weight: 400;
+    }
   }
   .panel {
     padding: 5px 0;


### PR DESCRIPTION
#### Story
- https://www.pivotaltracker.com/story/show/67835442
#### Notes
- updated <code>eval_coverage</code> style to reset `<li>` styles to reflect uncovered state rather than editing logic templates
- this is intended as a short-term fix, which will be backed out or overridden when pophealth measure logic gets ported over to bonnie
#### Screenshots
- previous styles with bleeding coverage
  - ![screen shot 2014-03-19 at 3 13 40 pm](https://f.cloud.github.com/assets/456952/2464872/1be678cc-af9c-11e3-81d8-c4c7abc319bc.png)
- updated styles with fixed coverage
  - ![screen shot 2014-03-19 at 3 14 31 pm](https://f.cloud.github.com/assets/456952/2464873/1be97446-af9c-11e3-98bd-ad7d856f96fe.png)
