### PR TITLE
Fix population order so DENEX comes after DENOM

### DIFF
--- a/app/assets/javascripts/constants.js.coffee.erb
+++ b/app/assets/javascripts/constants.js.coffee.erb
@@ -4,6 +4,9 @@ Thorax.Models.Patient.templateOidMap = <%= HQMF_TEMPLATE_OID_MAP.to_json.html_sa
 
 Thorax.Models.Measure.logicFields = <%= HQMF::DataCriteria::FIELDS.to_json.html_safe %>
 
-Thorax.Models.Measure.allPopulationCodes = <%= HQMF::PopulationCriteria::ALL_POPULATION_CODES.to_json.html_safe%>
+# DENEX population should come after DENOM population
+<% codes = HQMF::PopulationCriteria::ALL_POPULATION_CODES %>
+<% updatedCodes = codes.insert(codes.index('DENOM')+1, codes.delete_at(codes.index('DENEX'))) %>
+Thorax.Models.Measure.allPopulationCodes = <%= updatedCodes.to_json.html_safe%>
 
 Thorax.Models.PatientDataCriteria.codeSources = <%= Measures::PatientBuilder::CODE_SOURCE.to_json.html_safe %>


### PR DESCRIPTION
#### Story
- https://www.pivotaltracker.com/story/show/67692192
#### Notes
- updated constants to reorder population codes, thereby enforcing application-wide reordering of DENEX to be after DENOM
#### Screenshot

![screen shot 2014-03-20 at 11 08 34 am](https://f.cloud.github.com/assets/456952/2473520/ff4a8662-b041-11e3-8101-681ef9ca50f8.png)
