### PR TITLE
Display episode_ids for episode of care measures in measure view

### DIFF
--- a/app/assets/javascripts/templates/measure.hbs
+++ b/app/assets/javascripts/templates/measure.hbs
@@ -12,6 +12,17 @@
     </span>
   </div>
   <div class="measure-dsp">
+    {{#if episode_of_care}}
+      <div class="measure-dsp-title">
+        Episode(s) of Care:
+      </div>
+        {{#each episodesOfCare tag="ul"}}
+          {{#with attributes}}
+            <li>{{description}}</li>
+          {{/with}}
+        {{/each}}
+      <p></p>
+    {{/if}}
     <div class="measure-dsp-title">
       Description:
     </div>

--- a/app/assets/javascripts/views/measure_view.js.coffee
+++ b/app/assets/javascripts/views/measure_view.js.coffee
@@ -27,6 +27,9 @@ class Thorax.Views.Measure extends Thorax.View
     @logicView.listenTo @populationCalculation, 'rationale:clear', -> @clearRationale()
     @logicView.listenTo @populationCalculation, 'rationale:show', (result) -> @showRationale(result)
 
+  episodesOfCare: ->
+    @model.get('source_data_criteria').filter((sdc) => sdc.get('source_data_criteria') in @model.get('episode_ids'))
+
   updateMeasure: (e) ->
     importMeasureView = new Thorax.Views.ImportMeasure(model: @model)
     importMeasureView.appendTo(@$el)


### PR DESCRIPTION
#### Story
- https://www.pivotaltracker.com/story/show/67679384
#### Notes
- added method to measure view for retrieving episode of care measure data criteria models from <code>source_data_criteria</code> using <code>episode_ids</code>
- only render episode(s) of care above measure description if measure has <code>episode_of_care</code> as <code>true</code>; if so, render the selected values (defined on initial measure upload or subsequent measure updates)
#### Screenshot

![screen shot 2014-03-20 at 11 49 48 am](https://f.cloud.github.com/assets/456952/2474075/a79130e6-b047-11e3-898e-3ad26395885b.png)
