### PR TITLE
Switch NQF ids to CMS ids

### DIFF
--- a/app/assets/javascripts/templates/measure.hbs
+++ b/app/assets/javascripts/templates/measure.hbs
@@ -1,6 +1,6 @@
  <div class="main">
   <div class="measure-title">
-    <span class="short-title pull-left"><i class="fa fa-tasks"></i> {{measure_id}}:</span>
+    <span class="short-title pull-left"><i class="fa fa-tasks"></i> {{cms_id}}:</span>
     <span class="full-title">{{title}}</span>
     <span class="settings-container">
       <div class="measure-settings">

--- a/app/assets/javascripts/templates/measures.hbs
+++ b/app/assets/javascripts/templates/measures.hbs
@@ -27,8 +27,8 @@
       </div>
       <div class="measure-title">
          <span class="nqf-listing pull-right">
-          <span class="sr-only">NQF ID: </span>
-          {{measure_id}}
+          <span class="sr-only">CMS ID: </span>
+          {{cms_id}}
         </span>
         {{#link "measures/{{hqmf_set_id}}" expand-tokens=true}}{{title}}{{/link}}
       </div>

--- a/spec/javascripts/views/measures_view_spec.js.coffee
+++ b/spec/javascripts/views/measures_view_spec.js.coffee
@@ -9,5 +9,5 @@ describe 'MeasuresView', ->
     # expect(@measuresView.$el).toContainText "Total measures: #{@measures.length}"
     expect(@measuresView.$('.measure').length).toBe @measures.length
     measure = @measures.first()
-    expect(@measuresView.$el).toContainText measure.get('measure_id')
+    expect(@measuresView.$el).toContainText measure.get('cms_id')
     expect(@measuresView.$el).toContainText measure.get('title')


### PR DESCRIPTION
#### Story
- https://www.pivotaltracker.com/story/show/67921654
#### Note
- searched for usages of nqf and measure_id, updated relevant measure templates to render <code>cms_id</code> values instead of <code>measure_id</code> (NQF ids)
