### PR TITLE
support logic highlighting for screen-readers

### DIFF
--- a/app/assets/javascripts/templates/logic/data_criteria.hbs
+++ b/app/assets/javascripts/templates/logic/data_criteria.hbs
@@ -1,4 +1,10 @@
-<span class="{{dataCriteria.key}} rationale-target{{#ifCond dataCriteria.type '!=' 'derived'}} highlight-target{{/ifCond}}">
+<label class="{{dataCriteria.key}} rationale-target{{#ifCond dataCriteria.type '!=' 'derived'}} highlight-target{{/ifCond}}">
+{{#ifCond dataCriteria.type '!=' 'derived'}}
+  <span class="sr-only">
+    <input type="radio" name="toggleHighlight" class="toggle-highlight-target">
+  </span>
+{{/ifCond}}
+
 {{#each dataCriteria.subset_operators}}
   {{view "SubsetOperatorLogic" subsetOperator=this tag="span"}}
 {{/each}}
@@ -46,6 +52,4 @@
   {{/if}}
 
 {{/ifCond}}
-</span>
-
-
+</label>

--- a/app/assets/javascripts/templates/patient_builder/edit_criteria.hbs
+++ b/app/assets/javascripts/templates/patient_builder/edit_criteria.hbs
@@ -15,6 +15,7 @@
             <i class="fa fa-lg fa-angle-right"></i>
             <span class="sr-only">Expand Data Criteria</span>
           {{/button}}
+          <span class="highlight-indicator sr-only"></span>
           <label>Date</label>
           <div>{{start_date}}{{#if end_date}} &ndash; {{end_date}}{{/if}}</div>
         </div>
@@ -30,6 +31,7 @@
         <i class="fa fa-lg fa-angle-down"></i>
         <span class="sr-only">Collapse Data Criteria</span>
       {{/button}}
+      <span class="highlight-indicator sr-only"></span>
 
       <p><strong>{{definition}}:</strong> {{description}}</p>
 

--- a/app/assets/javascripts/views/logic/data_criteria_logic_view.js.coffee
+++ b/app/assets/javascripts/views/logic/data_criteria_logic_view.js.coffee
@@ -11,7 +11,6 @@ class Thorax.Views.DataCriteriaLogic extends Thorax.View
     'click .toggle-highlight-target': 'toggleHighlightEntry'
 
   initialize: ->
-    # @populationCode =
     @dataCriteria = @measure.get('data_criteria')[@reference]
     # we need to do this because the view helper doesn't seem to be available in an #each.
     if @dataCriteria.field_values
@@ -42,7 +41,8 @@ class Thorax.Views.DataCriteriaLogic extends Thorax.View
     @populationCriteriaView().parent.clearHighlightPatientData()
 
   toggleHighlightEntry: (e) ->
-    if $(e.target).is(':checked') then @highlightEntry() else @clearHighlightEntry()
+    @clearHighlightEntry()
+    if $(e.target).is(':checked') then @highlightEntry()
 
   populationCriteriaView: ->
     parent = @parent

--- a/app/assets/javascripts/views/logic/data_criteria_logic_view.js.coffee
+++ b/app/assets/javascripts/views/logic/data_criteria_logic_view.js.coffee
@@ -1,15 +1,17 @@
 class Thorax.Views.DataCriteriaLogic extends Thorax.View
-  
+
   template: JST['logic/data_criteria']
-  operator_map: 
+  operator_map:
     'XPRODUCT':'AND'
     'UNION':'OR'
 
   events:
     'mouseover .highlight-target': 'highlightEntry'
     'mouseout .highlight-target': 'clearHighlightEntry'
+    'click .toggle-highlight-target': 'toggleHighlightEntry'
 
   initialize: ->
+    # @populationCode =
     @dataCriteria = @measure.get('data_criteria')[@reference]
     # we need to do this because the view helper doesn't seem to be available in an #each.
     if @dataCriteria.field_values
@@ -38,6 +40,9 @@ class Thorax.Views.DataCriteriaLogic extends Thorax.View
 
   clearHighlightEntry: (e) ->
     @populationCriteriaView().parent.clearHighlightPatientData()
+
+  toggleHighlightEntry: (e) ->
+    if $(e.target).is(':checked') then @highlightEntry() else @clearHighlightEntry()
 
   populationCriteriaView: ->
     parent = @parent

--- a/app/assets/javascripts/views/logic/population_logic_view.js.coffee
+++ b/app/assets/javascripts/views/logic/population_logic_view.js.coffee
@@ -93,6 +93,7 @@ class Thorax.Views.PopulationLogic extends Thorax.View
   coverageScreenReaderStatus: ->
     @$('.rationale .rationale-target').find('.sr-highlight-status').html('(status: not covered)')
     @$('.eval-coverage').children('.sr-highlight-status').html('(status: covered)')
+    @$('.eval-coverage').children('.criteria-title').children('.sr-highlight-status').html('(status: covered)')
     @$('.conjunction').children('.sr-highlight-status').empty()
     @$('.population-label').children('.sr-highlight-status').empty()
 

--- a/app/assets/javascripts/views/logic/population_logic_view.js.coffee
+++ b/app/assets/javascripts/views/logic/population_logic_view.js.coffee
@@ -9,7 +9,7 @@ class Thorax.Views.PopulationsLogic extends Thorax.LayoutView
   showCoverage: -> @getView().showCoverage()
   clearCoverage: -> @getView().clearCoverage()
   populationContext: (population) ->
-    _(population.toJSON()).extend 
+    _(population.toJSON()).extend
       isActive: population is @collection.first()
       populationTitle: population.get('title') || population.get('sub_id')
 
@@ -71,9 +71,9 @@ class Thorax.Views.PopulationLogic extends Thorax.View
         for codedEntry in matchingCodedEntries
           type = (if goodElements?.indexOf(codedEntry.id) < 0 then partial else valid)
           # picked up by EditCriteriaView
-          for sourceDataCriterium in @latestResult.patient.get('source_data_criteria').models 
+          for sourceDataCriterium in @latestResult.patient.get('source_data_criteria').models
             if sourceDataCriterium.get('coded_entry_id') == codedEntry.id
-              sourceDataCriterium.trigger 'highlight', type 
+              sourceDataCriterium.trigger 'highlight', type
 
   clearHighlightPatientData: ->
     # picked up by PatientBuilder
@@ -82,24 +82,24 @@ class Thorax.Views.PopulationLogic extends Thorax.View
   clearRationale: ->
     @$('.rationale .rationale-target').removeClass('eval-false eval-true eval-bad-specifics')
     @$('.rationale .panel-heading').removeClass('eval-panel-false eval-panel-true eval-panel-bad-specifics')
-    @$('.sr-highlight-status').html('')
+    @$('.sr-highlight-status').empty()
 
   showCoverage: ->
     @clearRationale()
     for criteria in @model.coverage().rationaleCriteria
-      @$(".#{criteria}").addClass('eval-coverage') 
+      @$(".#{criteria}").addClass('eval-coverage')
     @coverageScreenReaderStatus()
 
   coverageScreenReaderStatus: ->
     @$('.rationale .rationale-target').find('.sr-highlight-status').html('(status: not covered)')
     @$('.eval-coverage').children('.sr-highlight-status').html('(status: covered)')
-    @$('.conjunction').children('.sr-highlight-status').html('')
-    @$('.population-label').children('.sr-highlight-status').html('')
+    @$('.conjunction').children('.sr-highlight-status').empty()
+    @$('.population-label').children('.sr-highlight-status').empty()
 
   clearCoverage: ->
     if @$('.eval-coverage').length > 0
       @$('.rationale .rationale-target').removeClass('eval-coverage')
-      @$('.sr-highlight-status').html('')
+      @$('.sr-highlight-status').empty()
 
   expandPopulations: ->
     @$('.panel-population > a[data-toggle="collapse"]').removeClass('collapsed')

--- a/app/assets/javascripts/views/patient_builder/data_criteria.js.coffee
+++ b/app/assets/javascripts/views/patient_builder/data_criteria.js.coffee
@@ -47,7 +47,9 @@ class Thorax.Views.EditCriteriaView extends Thorax.Views.BuilderChildView
       criteriaType: @model.get('type')
     @editCodeSelectionView = new Thorax.Views.CodeSelectionView criteria: @model
 
-    @model.on 'highlight', (type) => @$('.criteria-data').addClass(type)
+    @model.on 'highlight', (type) =>
+      # add highlight
+      @$('.criteria-data').addClass(type)
 
   valueWithDateContext: (model) ->
     _(model.toJSON()).extend

--- a/app/assets/javascripts/views/patient_builder/data_criteria.js.coffee
+++ b/app/assets/javascripts/views/patient_builder/data_criteria.js.coffee
@@ -48,8 +48,8 @@ class Thorax.Views.EditCriteriaView extends Thorax.Views.BuilderChildView
     @editCodeSelectionView = new Thorax.Views.CodeSelectionView criteria: @model
 
     @model.on 'highlight', (type) =>
-      # add highlight
       @$('.criteria-data').addClass(type)
+      @$('.highlight-indicator').attr('tabindex', 0).text 'matches selected logic, '
 
   valueWithDateContext: (model) ->
     _(model.toJSON()).extend

--- a/app/assets/javascripts/views/patient_builder/patient_builder.js.coffee
+++ b/app/assets/javascripts/views/patient_builder/patient_builder.js.coffee
@@ -32,7 +32,7 @@ class Thorax.Views.PatientBuilder extends Thorax.View
       @populationLogicView.showRationale @model
     @model.on 'clearHighlight', =>
       @$('.criteria-data').removeClass("#{Thorax.Views.EditCriteriaView.highlight.valid} #{Thorax.Views.EditCriteriaView.highlight.partial}")
-      # remove highlight
+      @$('.highlight-indicator').removeAttr('tabindex').empty()
 
   dataCriteriaCategories: ->
     categories = {}

--- a/app/assets/javascripts/views/patient_builder/patient_builder.js.coffee
+++ b/app/assets/javascripts/views/patient_builder/patient_builder.js.coffee
@@ -32,6 +32,7 @@ class Thorax.Views.PatientBuilder extends Thorax.View
       @populationLogicView.showRationale @model
     @model.on 'clearHighlight', =>
       @$('.criteria-data').removeClass("#{Thorax.Views.EditCriteriaView.highlight.valid} #{Thorax.Views.EditCriteriaView.highlight.partial}")
+      # remove highlight
 
   dataCriteriaCategories: ->
     categories = {}

--- a/app/assets/stylesheets/builder.less
+++ b/app/assets/stylesheets/builder.less
@@ -287,17 +287,8 @@
     }
   }
   .measure-viz {
-    .conjunction {
-      font-weight: bold;
-    }
-    ul {
-      padding-left: 20px;
-      list-style-type: none;
-      margin-bottom: 0px;
-      .multi-temporal {
-        list-style-type: circle; 
-        padding-left: 40px;
-      }
+    label {
+      text-transform: inherit;
     }
   }
 

--- a/app/assets/stylesheets/measure.less
+++ b/app/assets/stylesheets/measure.less
@@ -153,17 +153,5 @@
     .make-sm-column(12);
     padding-top: 15px;
     padding-left: 0px;
-    .conjunction {
-      font-weight: bold;
-    }
-    ul {
-      padding-left: 20px;
-      list-style-type: none;
-      margin-bottom: 0px;
-      .multi-temporal {
-        list-style-type: circle; 
-        padding-left: 40px;
-      }
-    }
   }
 }

--- a/app/assets/stylesheets/mixins.less
+++ b/app/assets/stylesheets/mixins.less
@@ -34,6 +34,24 @@
   }
 }
 
+.measure-viz {
+  .conjunction {
+    font-weight: bold;
+  }
+  ul {
+    padding-left: 20px;
+    list-style-type: none;
+    margin-bottom: 0px;
+    .multi-temporal {
+      list-style-type: circle;
+      padding-left: 40px;
+    }
+  }
+  label {
+    display: inline;
+  }
+}
+
 .btn-danger-inverse {
   .button-variant(@btn-danger-bg; @btn-danger-color; @btn-danger-border);
 }


### PR DESCRIPTION
A user with a screen reader, when passing over the logic, can select a piece of the logic (via a radio button) and have the associated data criteria "highlighted" in the patient builder.
