### PR TITLE
Quick fix for rationale highlighting in patient builder logic view

### DIFF
--- a/app/assets/javascripts/views/patient_builder/patient_builder.js.coffee
+++ b/app/assets/javascripts/views/patient_builder/patient_builder.js.coffee
@@ -28,6 +28,7 @@ class Thorax.Views.PatientBuilder extends Thorax.View
     @expectedValuesView.on 'population:select', (population_index) =>
       @populationLogicView.setPopulation @measure.get('populations').at(population_index)
       @materialize()
+      @populationLogicView.showRationale @model
     @model.on 'materialize', =>
       @populationLogicView.showRationale @model
     @model.on 'clearHighlight', =>

--- a/app/assets/javascripts/views/patient_builder/patient_builder.js.coffee
+++ b/app/assets/javascripts/views/patient_builder/patient_builder.js.coffee
@@ -28,7 +28,7 @@ class Thorax.Views.PatientBuilder extends Thorax.View
     @expectedValuesView.on 'population:select', (population_index) =>
       @populationLogicView.setPopulation @measure.get('populations').at(population_index)
       @materialize()
-      @populationLogicView.showRationale @model
+      @populationLogicView.showRationale @model # Materialize event may not trigger if model hasn't changed
     @model.on 'materialize', =>
       @populationLogicView.showRationale @model
     @model.on 'clearHighlight', =>

--- a/app/assets/javascripts/views/patient_builder/patient_builder.js.coffee
+++ b/app/assets/javascripts/views/patient_builder/patient_builder.js.coffee
@@ -27,8 +27,7 @@ class Thorax.Views.PatientBuilder extends Thorax.View
     @populationLogicView.showRationale @model
     @expectedValuesView.on 'population:select', (population_index) =>
       @populationLogicView.setPopulation @measure.get('populations').at(population_index)
-      @materialize()
-      @populationLogicView.showRationale @model # Materialize event may not trigger if model hasn't changed
+      @populationLogicView.showRationale @model
     @model.on 'materialize', =>
       @populationLogicView.showRationale @model
     @model.on 'clearHighlight', =>


### PR DESCRIPTION
#### Story
- https://www.pivotaltracker.com/story/show/67942242
#### Note
- the main issue is that if you just switch between populations, the patient model does not change, and therefore does not actually materialize, so the event handler doesn't fire to update the rationale highlighting in-between tab switching
- all other patient model interactions (ones that actually modify the patient model's json) behave and fire materialize events accordingly
