### PR TITLE
remove the template from the timepicker plugin

### DIFF
--- a/app/assets/javascripts/views/patient_builder/data_criteria.js.coffee
+++ b/app/assets/javascripts/views/patient_builder/data_criteria.js.coffee
@@ -91,7 +91,7 @@ class Thorax.Views.EditCriteriaView extends Thorax.Views.BuilderChildView
     rendered: ->
       @$('.criteria-data.droppable').droppable greedy: true, accept: '.ui-draggable', hoverClass: 'drop-target-highlight', drop: _.bind(@dropCriteria, this)
       @$('.date-picker').datepicker().on 'changeDate', _.bind(@triggerMaterialize, this)
-      @$('.time-picker').timepicker().on 'changeTime.timepicker', _.bind(@triggerMaterialize, this)
+      @$('.time-picker').timepicker(template: false).on 'changeTime.timepicker', _.bind(@triggerMaterialize, this)
       @$el.toggleClass 'during-measurement-period', @model.isDuringMeasurePeriod()
     'change .negation-select':                    'toggleNegationSelect'
     'change :input[name=end_date_is_undefined]':  'toggleEndDateDefinition'
@@ -212,7 +212,7 @@ class Thorax.Views.EditCriteriaValueView extends Thorax.Views.BuilderChildView
     rendered: ->
       @$("select[name=type]").selectBoxIt()
       @$('.date-picker').datepicker().on 'changeDate', _.bind(@validateForAddition, this)
-      @$('.time-picker').timepicker().on 'changeTime.timepicker', _.bind(@validateForAddition, this)
+      @$('.time-picker').timepicker(template: false).on 'changeTime.timepicker', _.bind(@validateForAddition, this)
     'change select[name=type]': (e) ->
       @model.set type: $(e.target).val()
       @validateForAddition()

--- a/app/assets/javascripts/views/patient_builder/patient_builder.js.coffee
+++ b/app/assets/javascripts/views/patient_builder/patient_builder.js.coffee
@@ -63,7 +63,7 @@ class Thorax.Views.PatientBuilder extends Thorax.Views.BonnieView
       @$('.criteria-container.droppable').droppable greedy: true, accept: '.ui-draggable', drop: _.bind(@drop, this)
 
       @$('.date-picker').datepicker().on 'changeDate', _.bind(@materialize, this)
-      @$('.time-picker').timepicker().on 'changeTime.timepicker', _.bind(@materialize, this)
+      @$('.time-picker').timepicker(template: false).on 'changeTime.timepicker', _.bind(@materialize, this)
     serialize: (attr) ->
       birthdate = attr.birthdate if attr.birthdate
       birthdate += " #{attr.birthtime}" if attr.birthdate && attr.birthtime


### PR DESCRIPTION
This keeps the popup from interfering with tabbing through the app, without altogether disabling the timepicker.

For a quick demo, go to http://jdewit.github.io/bootstrap-timepicker/ and scroll down to the "Without a template" example.
