### PR TITLE
Disable transfer patients button based on user's measures/patients

### DIFF
--- a/app/assets/javascripts/templates/measure.hbs
+++ b/app/assets/javascripts/templates/measure.hbs
@@ -41,7 +41,15 @@
     <span class="settings-container">
       <div class="patients-settings">
         {{#button "exportPatients" class="btn btn-default export-patients"}}<i class="fa fa-download"></i> Export{{/button}}
-        {{#button "toggleMeasureListing" class="btn btn-default btn-measure-listing toggle-measure-listing"}}<i class="fa fa-users"></i> <i class="fa fa-arrow-right"></i> <i class="fa fa-tasks"></i>{{/button}}
+        {{#empty patients}}
+          {{#button "toggleMeasureListing" class="btn btn-default btn-measure-listing toggle-measure-listing" disabled="disabled"}}<i class="fa fa-users"></i> <i class="fa fa-arrow-right"></i> <i class="fa fa-tasks"></i>{{/button}}
+        {{else}}
+          {{#ifCond measures.length "<=" "1"}}
+            {{#button "toggleMeasureListing" class="btn btn-default btn-measure-listing toggle-measure-listing" disabled="disabled"}}<i class="fa fa-users"></i> <i class="fa fa-arrow-right"></i> <i class="fa fa-tasks"></i>{{/button}}
+          {{else}}
+            {{#button "toggleMeasureListing" class="btn btn-default btn-measure-listing toggle-measure-listing"}}<i class="fa fa-users"></i> <i class="fa fa-arrow-right"></i> <i class="fa fa-tasks"></i>{{/button}}
+          {{/ifCond}}
+        {{/empty}}
       </div>
       {{#button "patientsSettings" tag="a" class="btn-settings" href=""}}<i class="fa fa-cog"></i> <span class="sr-only">Patient Options</span>{{/button}}
     </span>

--- a/app/assets/javascripts/views/measure_view.js.coffee
+++ b/app/assets/javascripts/views/measure_view.js.coffee
@@ -5,6 +5,7 @@ class Thorax.Views.Measure extends Thorax.Views.BonnieView
     rendered: ->
       @exportPatientsView = new Thorax.Views.ExportPatientsView() # Modal dialogs for exporting
       @exportPatientsView.appendTo(@$el)
+      @$('.toggle-measure-listing').prop('disabled', @measures.length <= 1)
     'click .measure-listing': 'selectMeasureListing'
 
   initialize: ->

--- a/app/assets/javascripts/views/measure_view.js.coffee
+++ b/app/assets/javascripts/views/measure_view.js.coffee
@@ -5,7 +5,6 @@ class Thorax.Views.Measure extends Thorax.Views.BonnieView
     rendered: ->
       @exportPatientsView = new Thorax.Views.ExportPatientsView() # Modal dialogs for exporting
       @exportPatientsView.appendTo(@$el)
-      @$('.toggle-measure-listing').prop('disabled', @measures.length <= 1)
     'click .measure-listing': 'selectMeasureListing'
 
   initialize: ->


### PR DESCRIPTION
#### Story
- https://www.pivotaltracker.com/story/show/68464574
#### Note
- ~~disabled transfer patients settings button on rendered event after checking collection size~~
- originally used `@$('.toggle-measure-listing').prop('disabled', @measures.length <= 1 || @model.get('patients').length < 1)`, but decided to move toward template-based approach for cleaner UI updating
