### PR TITLE
Remove embedded finalize view from dashboard template

### DIFF
--- a/app/assets/javascripts/templates/measures.hbs
+++ b/app/assets/javascripts/templates/measures.hbs
@@ -79,6 +79,3 @@
     {{/collection}}
   {{/if}}
 {{/collection}}
-
-{{! FIXME view creation/removal should happen as necessary in view, not in handlebars }}
-{{view finalizeMeasuresView}}

--- a/app/assets/javascripts/views/measures_view.js.coffee
+++ b/app/assets/javascripts/views/measures_view.js.coffee
@@ -14,7 +14,9 @@ class Thorax.Views.Measures extends Thorax.Views.BonnieView
   events:
     rendered: ->
       if @collection.isEmpty() then @importMeasure()
-
+      else if @finalizeMeasuresView.measures.length
+        @finalizeMeasuresView.appendTo(@$el)
+        @finalizeMeasuresView.display()
 
 class Thorax.Views.MeasureRowView extends Thorax.Views.BonnieView
 


### PR DESCRIPTION
#### Story
- https://www.pivotaltracker.com/story/show/68369804
#### Note
- instead of embedding the finalize dialog view, check to see if any measures need to be finalized after rendering the dashboard view; if so, then add it to the dashboard view and render it
