### PR TITLE
Sort user listings in admin view by approved status

### DIFF
--- a/app/assets/javascripts/models/user.js.coffee
+++ b/app/assets/javascripts/models/user.js.coffee
@@ -6,4 +6,4 @@ class Thorax.Models.User extends Thorax.Model
 class Thorax.Collections.Users extends Thorax.Collection
   url: '/admin/users'
   model: Thorax.Models.User
-  comparator: (u) -> u.get('approved')
+  comparator: (u) -> [ u.get('approved'), u.get('email') ]

--- a/app/assets/javascripts/models/user.js.coffee
+++ b/app/assets/javascripts/models/user.js.coffee
@@ -6,3 +6,4 @@ class Thorax.Models.User extends Thorax.Model
 class Thorax.Collections.Users extends Thorax.Collection
   url: '/admin/users'
   model: Thorax.Models.User
+  comparator: (u) -> u.get('approved')


### PR DESCRIPTION
#### Note
- sorts user listings by <code>approved</code>, such that unapproved users are at the top, and then sorts the respective groups alphabetically based on email address (original sorting criteria)
#### Screenshot

![screen shot 2014-04-03 at 4 19 28 pm](https://cloud.githubusercontent.com/assets/456952/2608661/4c7ae716-bb6d-11e3-844b-e9e8b474b6b3.png)
