### PR TITLE
Fix coverage calculation for empty patient populations

### DIFF
--- a/app/assets/javascripts/models/population.js.coffee
+++ b/app/assets/javascripts/models/population.js.coffee
@@ -50,7 +50,7 @@ class Thorax.Models.Population extends Thorax.Model
           occurrences = occurrences.concat @getDataCriteriaKeys(dataCriteria,specificsOnly)
       else
         if child.specific_occurrence || !specificsOnly
-          occurrences.push child.key
+          occurrences.push child.key if child.key
       if (child.temporal_references?.length > 0)
         for temporal_reference in child.temporal_references
           dataCriteria = @measure().get('data_criteria')[temporal_reference.reference]


### PR DESCRIPTION
#### Story
- https://www.pivotaltracker.com/story/show/69113542
#### Notes
- if a patient population has "None" or no logic elements, the coverage calculation does not compute up to 100% because the population in question does not have a <code>key</code> attribute
- verified with CMS52v2, where a patient can meet all logic element criteria and not achieve 100% without this fix
