### PR TITLE
Support multiple episodes of care (EoC) for continuous variable (CV) measures

### DIFF
--- a/app/assets/javascripts/models/expected_value.js.coffee
+++ b/app/assets/javascripts/models/expected_value.js.coffee
@@ -27,16 +27,15 @@ class Thorax.Models.ExpectedValue extends Thorax.Model
       result.set 'values', _(result.get('values')).sortBy( (v) -> v)
 
     for popCrit in @populationCriteria()
-      key = popCrit
       if popCrit.indexOf('OBSERV') != -1
         expected = if popCrit == 'OBSERV' then @get('OBSERV')?[0] else @get('OBSERV')?[@observIndex(popCrit)]
         actual = if popCrit == 'OBSERV' then result.get('values')?[0] else result.get('values')?[@observIndex(popCrit)]
         unit = @get('OBSERV_UNIT')
         key = 'OBSERV'
-        # console.log "#{popCrit} exp: #{expected} act: #{actual}"
       else
         expected = @get(popCrit)
         actual = result.get(popCrit)
+        key = popCrit
       # Here's the hash we return:
       name: popCrit
       key: key

--- a/app/assets/javascripts/models/expected_value.js.coffee
+++ b/app/assets/javascripts/models/expected_value.js.coffee
@@ -21,8 +21,8 @@ class Thorax.Models.ExpectedValue extends Thorax.Model
     for popCrit in @populationCriteria()
       key = popCrit
       if popCrit.indexOf('OBSERV') != -1
-        expected = @get('OBSERV')?[popCrit.split('_')[1]]
-        actual = result.get('values')?[popCrit.split('_')[1]]
+        expected = if popCrit == 'OBSERV' then @get('OBSERV') else @get('OBSERV')?[popCrit.split('_')[1]]
+        actual = if popCrit == 'OBSERV' then result.get('values')?[0] else result.get('values')?[popCrit.split('_')[1]]
         unit = @get('OBSERV_UNIT')
         key = 'OBSERV'
         # console.log "#{popCrit} exp: #{expected} act: #{actual}"

--- a/app/assets/javascripts/models/expected_value.js.coffee
+++ b/app/assets/javascripts/models/expected_value.js.coffee
@@ -1,28 +1,41 @@
 class Thorax.Models.ExpectedValue extends Thorax.Model
 
   populationCriteria: ->
-    _(@pick(Thorax.Models.Measure.allPopulationCodes)).keys()
+    defaults = _(@pick(Thorax.Models.Measure.allPopulationCodes)).keys()
+    if @has('OBSERV') and @get('OBSERV')?.length > 1
+      defaults = _(defaults).without('OBSERV')
+      for val, index in @get('OBSERV')
+        defaults.push "OBSERV_#{index}"
+    defaults
 
   isMatch: (result) ->
     # account for OBSERV if an actual value exists
     unless @has 'OBSERV' then if result.get('values')?[0]? then @set 'OBSERV', undefined
 
     for popCrit in @populationCriteria()
-      if popCrit is 'OBSERV' then return false unless @get(popCrit) == result.get('values')?[0]
+      if popCrit.indexOf('OBSERV') != -1 then return false unless @get('OBSERV')[popCrit.split('_')[1]] == result.get('values')?[popCrit.split('_')[1]]
       else return false unless @get(popCrit) == result.get(popCrit)
     return true
 
   comparison: (result) ->
     for popCrit in @populationCriteria()
-      expected = @get(popCrit)
-      actual = if popCrit == 'OBSERV' then result.get('values')?[0] else result.get(popCrit)
+      key = popCrit
+      if popCrit.indexOf('OBSERV') != -1
+        expected = @get('OBSERV')?[popCrit.split('_')[1]]
+        actual = result.get('values')?[popCrit.split('_')[1]]
+        unit = @get('OBSERV_UNIT')
+        key = 'OBSERV'
+        # console.log "#{popCrit} exp: #{expected} act: #{actual}"
+      else
+        expected = @get(popCrit)
+        actual = result.get(popCrit)
       # Here's the hash we return:
       name: popCrit
+      key: key
       expected: expected
       actual: actual
       match: expected == actual
-      unit: if popCrit == 'OBSERV' then @get('OBSERV_UNIT')
-
+      unit: unit
 
 class Thorax.Collections.ExpectedValues extends Thorax.Collection
   model: Thorax.Models.ExpectedValue

--- a/app/assets/javascripts/models/expected_value.js.coffee
+++ b/app/assets/javascripts/models/expected_value.js.coffee
@@ -2,27 +2,35 @@ class Thorax.Models.ExpectedValue extends Thorax.Model
 
   populationCriteria: ->
     defaults = _(@pick(Thorax.Models.Measure.allPopulationCodes)).keys()
-    if @has('OBSERV') and @get('OBSERV')?.length > 1
+
+    # create OBSERV_index keys for multiple OBSERV values
+    if @has('OBSERV') and @get('OBSERV')?.length
       defaults = _(defaults).without('OBSERV')
       for val, index in @get('OBSERV')
-        defaults.push "OBSERV_#{index}"
+        defaults.push "OBSERV_#{index+1}"
     defaults
 
   isMatch: (result) ->
     # account for OBSERV if an actual value exists
-    unless @has 'OBSERV' then if result.get('values')?[0]? then @set 'OBSERV', undefined
+    unless @has 'OBSERV' then if result.get('values')?.length then @set 'OBSERV', (undefined for val in result.get('values'))
 
     for popCrit in @populationCriteria()
-      if popCrit.indexOf('OBSERV') != -1 then return false unless @get('OBSERV')[popCrit.split('_')[1]] == result.get('values')?[popCrit.split('_')[1]]
+      if popCrit.indexOf('OBSERV') != -1 then return false unless @get('OBSERV')[@observIndex(popCrit)] == result.get('values')?[@observIndex(popCrit)]
       else return false unless @get(popCrit) == result.get(popCrit)
     return true
 
   comparison: (result) ->
+    # sort OBSERV and results before comparing
+    if @has('OBSERV') and @get('OBSERV').length
+      @set 'OBSERV', _(@get('OBSERV')).sortBy( (v) -> v)
+    if result.get('values')?
+      result.set 'values', _(result.get('values')).sortBy( (v) -> v)
+
     for popCrit in @populationCriteria()
       key = popCrit
       if popCrit.indexOf('OBSERV') != -1
-        expected = if popCrit == 'OBSERV' then @get('OBSERV') else @get('OBSERV')?[popCrit.split('_')[1]]
-        actual = if popCrit == 'OBSERV' then result.get('values')?[0] else result.get('values')?[popCrit.split('_')[1]]
+        expected = if popCrit == 'OBSERV' then @get('OBSERV')?[0] else @get('OBSERV')?[@observIndex(popCrit)]
+        actual = if popCrit == 'OBSERV' then result.get('values')?[0] else result.get('values')?[@observIndex(popCrit)]
         unit = @get('OBSERV_UNIT')
         key = 'OBSERV'
         # console.log "#{popCrit} exp: #{expected} act: #{actual}"
@@ -36,6 +44,9 @@ class Thorax.Models.ExpectedValue extends Thorax.Model
       actual: actual
       match: expected == actual
       unit: unit
+
+  observIndex: (observKey) ->
+    observKey.split('_')[1] - 1
 
 class Thorax.Collections.ExpectedValues extends Thorax.Collection
   model: Thorax.Models.ExpectedValue

--- a/app/assets/javascripts/models/expected_value.js.coffee
+++ b/app/assets/javascripts/models/expected_value.js.coffee
@@ -12,7 +12,13 @@ class Thorax.Models.ExpectedValue extends Thorax.Model
 
   isMatch: (result) ->
     # account for OBSERV if an actual value exists
-    unless @has 'OBSERV' then if result.get('values')?.length then @set 'OBSERV', (undefined for val in result.get('values'))
+    unless @has 'OBSERV'
+      if result.get('values')?.length
+        @set 'OBSERV', (undefined for val in result.get('values'))
+    else
+      if result.get('values')?.length
+        if @get('OBSERV').length - result.get('values').length < 0
+          @get('OBSERV').push(undefined) for n in [(@get('OBSERV').length + 1)..result.get('values').length]
 
     for popCrit in @populationCriteria()
       if popCrit.indexOf('OBSERV') != -1 then return false unless @get('OBSERV')[@observIndex(popCrit)] == result.get('values')?[@observIndex(popCrit)]

--- a/app/assets/javascripts/templates/measures.hbs
+++ b/app/assets/javascripts/templates/measures.hbs
@@ -24,7 +24,6 @@
     <div class="measure-col">
       <div class="measure-title">
         {{#link "measures/{{hqmf_set_id}}" expand-tokens=true}}<span class="sr-only">{{cms_id}}, Measure Title: </span>{{title}}{{/link}}
-        {{#if continuous_variable}}[ CV ]{{/if}}{{#if episode_of_care}}[ EoC ]{{/if}}
         <span class="nqf-listing">
           <span class="sr-only">CMS ID: </span>
           {{cms_id}}

--- a/app/assets/javascripts/templates/measures.hbs
+++ b/app/assets/javascripts/templates/measures.hbs
@@ -24,6 +24,7 @@
     <div class="measure-col">
       <div class="measure-title">
         {{#link "measures/{{hqmf_set_id}}" expand-tokens=true}}<span class="sr-only">{{cms_id}}, Measure Title: </span>{{title}}{{/link}}
+        {{#if continuous_variable}}[ CV ]{{/if}}{{#if episode_of_care}}[ EoC ]{{/if}}
         <span class="nqf-listing">
           <span class="sr-only">CMS ID: </span>
           {{cms_id}}

--- a/app/assets/javascripts/templates/patient_builder/expected_value.hbs
+++ b/app/assets/javascripts/templates/patient_builder/expected_value.hbs
@@ -6,8 +6,7 @@
         <label for="{{key}}_{{@cid}}">{{displayName}}</label>
         {{#button "toggleUnits" class="btn btn-xs btn-default"}}{{../../../OBSERV_UNIT}}{{/button}}
         {{#each ../../OBSERV}}
-          {{#log this}}{{/log}}
-          <input type="number" id="{{../key}}_{{@index}}_{{@cid}}" name="{{../key}}" min="0" value="{{this}}">
+          <input type="number" id="{{../key}}_{{@index}}" name="{{../key}}" min="0" value="{{this}}">
         {{/each}}
       </div>
     {{else}}

--- a/app/assets/javascripts/templates/patient_builder/expected_value.hbs
+++ b/app/assets/javascripts/templates/patient_builder/expected_value.hbs
@@ -2,15 +2,14 @@
 <div class="form-inline tab-pane">
   {{#each currentCriteria}}
     {{#ifCond key "==" "OBSERV"}}
-      <label>
-        {{displayName}}
-        <input type="number" name="{{key}}" min="0">
-      </label>
-      <button type="button" class="btn dropdown-toggle" data-toggle="dropdown">{{../../OBSERV_UNIT}}</button>
-      <ul class="dropdown-menu">
-        <li>{{#button "setObservMins" tag="a"}}mins{{/button}}</li>
-        <li>{{#button "setObservPerc" tag="a"}}%{{/button}}</li>
-      </ul>
+      <div class="form-group">
+        <label for="{{key}}_{{@cid}}">{{displayName}}</label>
+        {{#button "toggleUnits" class="btn btn-xs btn-default"}}{{../../../OBSERV_UNIT}}{{/button}}
+        {{#each ../../OBSERV}}
+          {{#log this}}{{/log}}
+          <input type="number" id="{{../key}}_{{@index}}_{{@cid}}" name="{{../key}}" min="0" value="{{this}}">
+        {{/each}}
+      </div>
     {{else}}
       {{#if isEoC}}
         <div class="form-group">

--- a/app/assets/javascripts/templates/population_calculation.hbs
+++ b/app/assets/javascripts/templates/population_calculation.hbs
@@ -74,7 +74,7 @@
             <td style="text-align: center;">
               {{#ifCond key "==" "OBSERV"}}
                 {{#ifCond expected "==" undefined}}
-                  <p class="text-muted">N/A</p>
+                  <p class="text-muted" style="margin: auto;">N/A</p>
                 {{else}}
                   {{expected}}{{unit}}
                 {{/ifCond}}
@@ -84,7 +84,7 @@
                 {{else}}
                   {{#ifCond name "==" "MSRPOPL"}}
                     {{#ifCond expected "==" undefined}}
-                      <p class="text-muted">N/A</p>
+                      <p class="text-muted" style="margin: auto;">N/A</p>
                     {{else}}
                       <span class="default">{{expected}}</span>
                     {{/ifCond}}
@@ -101,7 +101,7 @@
             <td style="text-align: center;">
               {{#ifCond key "==" "OBSERV"}}
                 {{#ifCond actual "==" undefined}}
-                  <p class="text-muted">N/A</p>
+                  <p class="text-muted" style="margin: auto;">N/A</p>
                 {{else}}
                   <span class="fail">{{actual}}{{unit}}</span>
                 {{/ifCond}}
@@ -111,7 +111,7 @@
                 {{else}}
                   {{#ifCond name "==" "MSRPOPL"}}
                     {{#ifCond expected "==" undefined}}
-                      <p class="text-muted">N/A</p>
+                      <p class="text-muted" style="margin: auto;">N/A</p>
                     {{else}}
                       <span class="default">{{actual}}</span>
                     {{/ifCond}}

--- a/app/assets/javascripts/templates/population_calculation.hbs
+++ b/app/assets/javascripts/templates/population_calculation.hbs
@@ -72,7 +72,7 @@
             </td>
             <td>{{name}}</td>
             <td style="text-align: center;">
-              {{#ifCond name "==" "OBSERV"}}
+              {{#ifCond key "==" "OBSERV"}}
                 {{#ifCond expected "==" undefined}}
                   <p class="text-muted">N/A</p>
                 {{else}}
@@ -99,7 +99,7 @@
               {{/ifCond}}
             </td>
             <td style="text-align: center;">
-              {{#ifCond name "==" "OBSERV"}}
+              {{#ifCond key "==" "OBSERV"}}
                 {{#ifCond actual "==" undefined}}
                   <p class="text-muted">N/A</p>
                 {{else}}

--- a/app/assets/javascripts/views/patient_builder/expected_values.js.coffee
+++ b/app/assets/javascripts/views/patient_builder/expected_values.js.coffee
@@ -69,6 +69,7 @@ class Thorax.Views.ExpectedValueView extends Thorax.Views.BuilderChildView
           attr[pc] = if attr[pc] then 1 else 0 # Convert from check-box true/false to 0/1
     'blur input': 'triggerMaterialize'
     'blur input[name="MSRPOPL"]': -> @updateObserv()
+    rendered: -> @updateObserv()
 
   context: ->
     context = super
@@ -102,21 +103,19 @@ class Thorax.Views.ExpectedValueView extends Thorax.Views.BuilderChildView
       if @model.get('OBSERV')
         current = @model.get('OBSERV').length
         if values > current
-          @model.set 'OBSERV', _(@model.get('OBSERV')).first(values)
+          @model.set 'OBSERV', @model.get('OBSERV').concat(0 for n in [(current+1)..values])
         else if values < current
-          @model.get('OBSERV').push(0) for n in [current..values]
+          @model.set 'OBSERV', _(@model.get('OBSERV')).first(values)
       else
         @model.set 'OBSERV', (0 for n in [1..values])
-    console.log @model.get('OBSERV')
+      console.log @model.get('OBSERV')
+      for val, index in @model.get('OBSERV')
+        @$("#OBSERV_#{index}").val(val)
+        console.log "OBSERV_#{index} #{val}"
 
   toggleUnits: (e) ->
     if @model.get('OBSERV_UNIT') == ' mins'
       @model.set 'OBSERV_UNIT', '%'
     else
       @model.set 'OBSERV_UNIT', ' mins'
-
-  setObservMins: ->
-    @model.set 'OBSERV_UNIT', ' mins'
-
-  setObservPerc: ->
-    @model.set 'OBSERV_UNIT', '%'
+    @updateObserv()

--- a/app/assets/javascripts/views/patient_builder/expected_values.js.coffee
+++ b/app/assets/javascripts/views/patient_builder/expected_values.js.coffee
@@ -68,8 +68,8 @@ class Thorax.Views.ExpectedValueView extends Thorax.Views.BuilderChildView
         else
           attr[pc] = if attr[pc] then 1 else 0 # Convert from check-box true/false to 0/1
     'blur input': 'triggerMaterialize'
-    'blur input[name="MSRPOPL"]': -> @updateObserv()
-    rendered: -> @setObservs()
+    'blur input[name="MSRPOPL"]': 'updateObserv'
+    'rendered': 'setObservs'
 
   context: ->
     context = super
@@ -95,7 +95,6 @@ class Thorax.Views.ExpectedValueView extends Thorax.Views.BuilderChildView
         displayName: criteriaMap[pc]
         isEoC: @measure.get('episode_of_care')
     unless @model.has('OBSERV_UNIT') then @model.set 'OBSERV_UNIT', ' mins'
-    console.log @model.get('OBSERV')
 
   updateObserv: ->
     if @measure.get('continuous_variable') and @model.has('MSRPOPL') and @model.get('MSRPOPL')?
@@ -108,14 +107,12 @@ class Thorax.Views.ExpectedValueView extends Thorax.Views.BuilderChildView
           @model.set 'OBSERV', _(@model.get('OBSERV')).first(values)
       else
         @model.set 'OBSERV', (0 for n in [1..values]) if values
-      console.log @model.get('OBSERV')
       @setObservs()
 
   setObservs: ->
     if @model.get('OBSERV')?.length
         for val, index in @model.get('OBSERV')
           @$("#OBSERV_#{index}").val(val)
-          console.log "OBSERV_#{index} #{val}"
 
   toggleUnits: (e) ->
     if @model.get('OBSERV_UNIT') == ' mins'

--- a/app/assets/javascripts/views/patient_builder/expected_values.js.coffee
+++ b/app/assets/javascripts/views/patient_builder/expected_values.js.coffee
@@ -69,7 +69,7 @@ class Thorax.Views.ExpectedValueView extends Thorax.Views.BuilderChildView
           attr[pc] = if attr[pc] then 1 else 0 # Convert from check-box true/false to 0/1
     'blur input': 'triggerMaterialize'
     'blur input[name="MSRPOPL"]': -> @updateObserv()
-    rendered: -> @updateObserv()
+    rendered: -> @setObservs()
 
   context: ->
     context = super
@@ -98,7 +98,7 @@ class Thorax.Views.ExpectedValueView extends Thorax.Views.BuilderChildView
     console.log @model.get('OBSERV')
 
   updateObserv: ->
-    if @measure.get('continuous_variable') and @model.has('MSRPOPL') and @model.get('MSRPOPL')
+    if @measure.get('continuous_variable') and @model.has('MSRPOPL') and @model.get('MSRPOPL')?
       values = @model.get('MSRPOPL')
       if @model.get('OBSERV')
         current = @model.get('OBSERV').length
@@ -107,11 +107,15 @@ class Thorax.Views.ExpectedValueView extends Thorax.Views.BuilderChildView
         else if values < current
           @model.set 'OBSERV', _(@model.get('OBSERV')).first(values)
       else
-        @model.set 'OBSERV', (0 for n in [1..values])
+        @model.set 'OBSERV', (0 for n in [1..values]) if values
       console.log @model.get('OBSERV')
-      for val, index in @model.get('OBSERV')
-        @$("#OBSERV_#{index}").val(val)
-        console.log "OBSERV_#{index} #{val}"
+      @setObservs()
+
+  setObservs: ->
+    if @model.get('OBSERV')?.length
+        for val, index in @model.get('OBSERV')
+          @$("#OBSERV_#{index}").val(val)
+          console.log "OBSERV_#{index} #{val}"
 
   toggleUnits: (e) ->
     if @model.get('OBSERV_UNIT') == ' mins'

--- a/app/assets/javascripts/views/patient_builder/expected_values.js.coffee
+++ b/app/assets/javascripts/views/patient_builder/expected_values.js.coffee
@@ -60,6 +60,7 @@ class Thorax.Views.ExpectedValueView extends Thorax.Views.BuilderChildView
           # Only parse existing values
           if attr[pc]
             if pc == 'OBSERV'
+              attr[pc] = [].concat(attr[pc])
               attr[pc] = (parseFloat(o) for o in attr[pc])
             else
               attr[pc] = parseFloat(attr[pc])

--- a/app/assets/stylesheets/builder.less
+++ b/app/assets/stylesheets/builder.less
@@ -120,6 +120,9 @@
             display: inline-block;
             width: 40px;
           }
+          input[name=OBSERV] {
+            width: 45px;
+          }
         }
       }
     }

--- a/lib/tasks/bonnie.rake
+++ b/lib/tasks/bonnie.rake
@@ -210,6 +210,15 @@ namespace :bonnie do
     end
   end
 
+  namespace :test do
+    desc 'Delete all non-CV measures after importing from bonnie-production-eh'
+    task :clean_up => :environment do
+      puts "Reducing imported measures"
+      some_measure_ids = Measure.in(cms_id: ['CMS112v2', 'CMS55v2', 'CMS32v3']).pluck('hqmf_set_id')
+      Measure.nin(hqmf_set_id: some_measure_ids).delete
+    end
+  end
+
   namespace :measures do
     desc 'Pre-generate measure JavaScript and cache in the DB'
     task :pregenerate_js => :environment do


### PR DESCRIPTION
#### Story
- https://www.pivotaltracker.com/story/show/65923976
#### Notes
- <code>OBSERV</code> values are now stored as an array of values (minutes or percentages), and <code>result</code> values are properly read when comparing expectations against results
- the values for <code>OBSERV</code> and <code>result</code> are sorted before comparison
- the number of <code>OBSERV</code> values one can enter in the expected values section is dependent on the value entered for <code>MSRPOPL</code>, which updates the inputs via a <code>blur</code> event
- <code>rake bonnie:db:reset</code> and <code>rake bonnie:test:clean_up</code> were updated for expedited testing
- proposed testing strategy
  - <code>rake bonnie:db:reset DB=bonnie-production-eh</code>
  - <code>rake bonnie:test:clean_up</code>
  - login with <code>bonnie@example.com:bonnie</code>
  - create a test patient for <code>CMS55v2</code> that produces >= 1 <code>MSRPOPL</code> and >= 1 <code>OBSERV</code> results
    - last name, first name, dob = 03/06/1937, 10:30 AM
    - Encounter: Emergency Department Visit
      - start = 04/01/2012, 11:00 AM
      - end = 04/01/2012, 12:30 PM
      - field values
        - Facility Arrival Time = 04/01/2012, 11:00 AM
        - Facility Departure Time = 04/01/2012, 12:00 PM
    - Encounter: Encounter Inpatient
      - start = 04/01/2012, 1:00 PM
      - end = 04/04/2012, 2:00 PM
      - field values
        - Discharge datetime = 04/04/2012, 2:00 PM
    - Encounter: Emergency Department Visit
      - start = 04/02/2012, 11:00 AM
      - end = 04/02/2012, 12:30 PM
      - field values
        - Facility Arrival Time = 04/02/2012, 11:00 AM
        - Facility Departure Time = 04/02/2012, 12:30 PM
    - Encounter: Encounter Inpatient
      - start = 04/02/2012, 1:00 PM
      - end = 04/05/2012, 2:00 PM
      - field values
        - Discharge datetime = 04/05/2012, 2:00 PM
#### Screenshots
- results now show all actuals, even if no <code>OBSERV</code> expectations are present
  - ![defaultpatient](https://cloud.githubusercontent.com/assets/456952/2781890/2b3b553e-cb19-11e3-9b30-3c7b14e5af49.png)
- results for test patient following strategy above
  - ![default_testpatient](https://cloud.githubusercontent.com/assets/456952/2781891/2b3b715e-cb19-11e3-8c88-0d68b6867c04.png)
- updated expected values section provides multiple <code>OBSERV</code> inputs, with no order necessary
  - ![updatedexpectedvalues](https://cloud.githubusercontent.com/assets/456952/2781933/8fc6f71a-cb19-11e3-8634-0fb7b51babc9.png)
- results for test patient with expected values
  - ![updatedtestpatientresults](https://cloud.githubusercontent.com/assets/456952/2781892/2b3c0006-cb19-11e3-8c40-342e4a3db773.png)
