### PR TITLE
Fix rendering issue on error in forgot password page

### DIFF
--- a/app/assets/stylesheets/login.less
+++ b/app/assets/stylesheets/login.less
@@ -18,9 +18,6 @@
       .btn-lg;
       margin: 30px 0;
     }
-    .field_with_errors{
-      .devise_error;
-    }
   }
   .input-group-lg > .input-group-addon {
     padding-left: 6px;
@@ -42,8 +39,15 @@
     .required {
       .form-control-validation(@brand-primary; @brand-primary; @input-bg);
     }
-    .field_with_errors{
-      .devise_error;
+    .field_with_errors {
+      .has-error;
     }
+  }
+}
+
+.field_with_errors {
+  .has-error;
+  input {
+    .input-lg;
   }
 }

--- a/app/assets/stylesheets/login.less
+++ b/app/assets/stylesheets/login.less
@@ -18,6 +18,9 @@
       .btn-lg;
       margin: 30px 0;
     }
+    .field_with_errors{
+      .devise_error;
+    }
   }
   .input-group-lg > .input-group-addon {
     padding-left: 6px;
@@ -39,11 +42,8 @@
     .required {
       .form-control-validation(@brand-primary; @brand-primary; @input-bg);
     }
-    .field_with_errors {
-      .has-error;
-      input {
-        .input-lg;
-      }
+    .field_with_errors{
+      .devise_error;
     }
   }
 }

--- a/app/assets/stylesheets/login.less
+++ b/app/assets/stylesheets/login.less
@@ -39,6 +39,7 @@
     .required {
       .form-control-validation(@brand-primary; @brand-primary; @input-bg);
     }
+    // override brand-primary styling on input fields with errors
     .field_with_errors {
       .has-error;
     }

--- a/app/assets/stylesheets/mixins.less
+++ b/app/assets/stylesheets/mixins.less
@@ -52,11 +52,3 @@
 .btn-danger-inverse {
   .button-variant(@btn-danger-bg; @btn-danger-color; @btn-danger-border);
 }
-
-// Set the conditional formatting and size for input errors on devise pages
-.devise_error {
-  .has-error;
-  input {
-    .input-lg;
-  }
-}

--- a/app/assets/stylesheets/mixins.less
+++ b/app/assets/stylesheets/mixins.less
@@ -52,3 +52,11 @@
 .btn-danger-inverse {
   .button-variant(@btn-danger-bg; @btn-danger-color; @btn-danger-border);
 }
+
+// Set the conditional formatting and size for input errors on devise pages
+.devise_error {
+  .has-error;
+  input {
+    .input-lg;
+  }
+}


### PR DESCRIPTION
#### Story
- https://www.pivotaltracker.com/story/show/68935910
#### Note
- ~~moved previous style fix for account registration and edit pages into <code>mixins.less</code>~~
- ~~added new <code>devise_error</code> mixin to login and registration classes, resolving the rendering issues on input errors~~
- added <code>field_with_errors</code> outside login.less' namespace
- left origin usage of <code>has-error</code> in registration styles to overwrite <code>required</code> style
