### PR TITLE
place tabs in logical order

### DIFF
--- a/app/assets/javascripts/templates/measures.hbs
+++ b/app/assets/javascripts/templates/measures.hbs
@@ -22,15 +22,15 @@
 
   <div class="measure row">
     <div class="measure-col">
-      <div class="btn-wrapper pull-right">
-        {{#button "updateMeasure" class="btn btn-primary"}}<i class="fa fa-refresh fa-fw"></i><span class="sr-only">{{cms_id}}, </span> Update <span class="sr-only">existing measure</span>{{/button}}
-      </div>
       <div class="measure-title">
-        <span class="nqf-listing pull-right">
+        {{#link "measures/{{hqmf_set_id}}" expand-tokens=true}}<span class="sr-only">{{cms_id}}, Measure Title: </span>{{title}}{{/link}}
+        <span class="nqf-listing">
           <span class="sr-only">CMS ID: </span>
           {{cms_id}}
         </span>
-        {{#link "measures/{{hqmf_set_id}}" expand-tokens=true}}<span class="sr-only">{{cms_id}}, Measure Title: </span>{{title}}{{/link}}
+      </div>
+      <div class="btn-wrapper">
+        {{#button "updateMeasure" class="btn btn-primary"}}<i class="fa fa-refresh fa-fw"></i><span class="sr-only">{{cms_id}}, </span> Update <span class="sr-only">existing measure</span>{{/button}}
       </div>
     </div>
     <div class="expected-col">
@@ -44,16 +44,16 @@
       {{/unless}}
     </div>
     <div class="patient-listing-col">
-      <a href="#measures/{{hqmf_set_id}}/patients/new" class="btn {{#unless patients.length}}btn-primary{{else}}btn-default{{/unless}} pull-right">
-        <i class="fa fa-user"></i>
-        <i class="fa fa-plus"></i>
-        <span class="sr-only">{{cms_id}}, add new patient to measure</span>
-      </a>
       {{#if multiplePopulations}}
         <span class="sr-only">{{cms_id}} has </span><span class="patient-listing">{{patients.length}}</span><span class="sr-only"> test patients</span>
       {{else}}
         {{view "MeasureFractionView" model=differences.summary cms_id=cms_id}}
       {{/if}}
+      <a href="#measures/{{hqmf_set_id}}/patients/new" class="btn {{#unless patients.length}}btn-primary{{else}}btn-default{{/unless}}">
+        <i class="fa fa-user"></i>
+        <i class="fa fa-plus"></i>
+        <span class="sr-only">{{cms_id}}, add new patient to measure</span>
+      </a>
     </div>
   </div>
 

--- a/app/assets/javascripts/templates/patient_builder/edit_criteria.hbs
+++ b/app/assets/javascripts/templates/patient_builder/edit_criteria.hbs
@@ -11,13 +11,15 @@
         </div>
 
         <div class="col-md-6">
+          <div class="pull-left">
+            <h2>Date</h2>
+            <div>{{start_date}}{{#if end_date}} &ndash; {{end_date}}{{/if}}</div>
+          </div>
           {{#button "toggleDetails" class="close"}}
             <i class="fa fa-lg fa-angle-right"></i>
             <span class="sr-only">Expand Data Criteria, {{definition}}, {{description}} </span>
             <span class="highlight-indicator sr-only"></span>
           {{/button}}
-          <h2>Date</h2>
-          <div>{{start_date}}{{#if end_date}} &ndash; {{end_date}}{{/if}}</div>
         </div>
       </div>
       {{#ifPortfolio}}
@@ -27,13 +29,17 @@
       {{/ifPortfolio}}
     </div>
     <form class="hide" role="form">
-      {{#button "toggleDetails" class="close"}}
-        <i class="fa fa-lg fa-angle-down"></i>
-        <span class="sr-only">Collapse Data Criteria, {{definition}}, {{description}}</span>
-      {{/button}}
-      <span class="highlight-indicator sr-only"></span>
+      <div class="clearfix">
+        <div class="pull-left">
+          <span class="highlight-indicator sr-only"></span>
 
-      <p><strong>{{definition}}:</strong> {{description}}</p>
+          <p><strong>{{definition}}:</strong> {{description}}</p>
+        </div>
+        {{#button "toggleDetails" class="close"}}
+          <i class="fa fa-lg fa-angle-down"></i>
+          <span class="sr-only">Collapse Data Criteria, {{definition}}, {{description}}</span>
+        {{/button}}
+      </div>
 
       <div class="row">
         <div class="form-group col-md-6">

--- a/app/assets/javascripts/templates/patient_builder/edit_criteria.hbs
+++ b/app/assets/javascripts/templates/patient_builder/edit_criteria.hbs
@@ -134,14 +134,13 @@
         </select>
       </div>
 
-      <div class="clearfix">
+      <div class="criteria-delete">
         <div class="pull-right">
-          &nbsp; {{! If we take this out, say goodbye to space between the buttons. Why, Chrome? Firefox and Safari don't have this problem. }}
-          {{#button "removeCriteria" class="btn btn-danger hide"}}Delete{{/button}}
-          {{#button "showDelete" class="btn btn-danger-inverse"}}
+          {{#button "showDelete" class="btn btn-danger-inverse criteria-delete-check"}}
             <i class="fa fa-minus-circle"></i>
             <span class="sr-only">show delete</span>
           {{/button}}
+          {{#button "removeCriteria" class="btn btn-danger hide"}}Delete{{/button}}
         </div>
       </div>
     </form>

--- a/app/assets/javascripts/views/patient_builder/data_criteria.js.coffee
+++ b/app/assets/javascripts/views/patient_builder/data_criteria.js.coffee
@@ -120,7 +120,7 @@ class Thorax.Views.EditCriteriaView extends Thorax.Views.BuilderChildView
   showDelete: (e) ->
     e.preventDefault()
     $btn = $(e.currentTarget)
-    $btn.toggleClass('btn-danger btn-danger-inverse').prev().toggleClass('hide')
+    $btn.toggleClass('btn-danger btn-danger-inverse').next().toggleClass('hide')
 
   toggleEndDateDefinition: (e) ->
     $cb = $(e.target)

--- a/app/assets/stylesheets/application.css.less
+++ b/app/assets/stylesheets/application.css.less
@@ -21,4 +21,3 @@
 @import "builder";
 @import "vsbuilder";
 @import "users";
-

--- a/app/assets/stylesheets/builder.less
+++ b/app/assets/stylesheets/builder.less
@@ -283,6 +283,13 @@
             }
           }
         }
+        .criteria-delete {
+          .clearfix;
+          .criteria-delete-check {
+            .pull-right;
+            margin-left: 5px;
+          }
+        }
       }
     }
   }

--- a/app/assets/stylesheets/measures.less
+++ b/app/assets/stylesheets/measures.less
@@ -3,10 +3,22 @@
 // For entire page
 .measure-col {
   .make-xs-column(7);
+  position: relative;
+  .measure-title {
+    .clearfix;
+    a {
+      .make-md-column(10; 0);
+    }
+    .nqf-listing {
+      .make-md-column(2; 0);
+    }
+  }
   .btn-wrapper {
-    line-height: 1;
     border-left: 5px white solid;
     border-right: 5px white solid;
+    line-height: 1;
+    position: absolute;
+    top: 0; right: 15px;
   }
 }
 
@@ -21,6 +33,12 @@
 
 .patient-listing-col {
   .make-xs-column(2);
+  position: relative;
+  .btn {
+    position: absolute;
+    right: 0;
+    top: 0;
+  }
 }
 
 // Just the heading


### PR DESCRIPTION
As a person using a screen reader, when I tab through the page, I should be presented with objects in a logical order, so that I can make sense of the site.

These changes were based on feedback from users of screen readers during a 508 compliance review.
