### PR TITLE
Remove redundant measure title, centered previously off-centered measure title

### DIFF
--- a/app/assets/javascripts/templates/measure.hbs
+++ b/app/assets/javascripts/templates/measure.hbs
@@ -1,7 +1,7 @@
  <div class="main col-sm-8">
   <div class="measure-title">
-    <span class="short-title pull-left"><i class="fa fa-tasks"></i> {{cms_id}}:</span>
-    <span class="full-title">{{title}}</span>
+    <div class="short-title"><i class="fa fa-tasks"></i> {{cms_id}}: </div>
+    <div class="full-title">{{title}}</div>
     <span class="settings-container">
       <div class="measure-settings">
         {{#button "updateMeasure" class="btn btn-default update-measure"}}<i class="fa fa-upload"></i> Update{{/button}}

--- a/app/assets/javascripts/templates/patient_builder/patient_builder.hbs
+++ b/app/assets/javascripts/templates/patient_builder/patient_builder.hbs
@@ -150,7 +150,6 @@
 
 
   <div class="col-right">
-    <h1 class="heading-muted"><i class="fa fa-tasks"></i> Measure</h1>
     {{view populationLogicView}}
   </div>
 

--- a/app/assets/javascripts/templates/patient_builder/population_logic.hbs
+++ b/app/assets/javascripts/templates/patient_builder/population_logic.hbs
@@ -1,3 +1,4 @@
-<h1 class="heading-muted"><i class="fa fa-tasks"></i> Measure <span class="submeasure">{{title}}</span></h1>
+<h1 class="heading-muted"><i class="fa fa-tasks"></i> Measure</h1>
+<h2 class="submeasure">{{title}}</h2>
 
 {{layout-element}}

--- a/app/assets/javascripts/templates/patient_builder/population_logic.hbs
+++ b/app/assets/javascripts/templates/patient_builder/population_logic.hbs
@@ -1,4 +1,3 @@
-<div class="short-title">
-  <i class="fa fa-tasks"></i>MEASURE: <span class="population-title">{{title}}</span>
-</div>
+<h1 class="heading-muted"><i class="fa fa-tasks"></i> Measure <span class="submeasure">{{title}}</span></h1>
+
 {{layout-element}}

--- a/app/assets/stylesheets/builder.less
+++ b/app/assets/stylesheets/builder.less
@@ -128,10 +128,15 @@
     }
   }
 
-
   .heading-muted {
     background-color: @gray-lighter;
     padding-left: 3px;
+    .submeasure {
+      float: right;
+      padding-right: 3px;
+      font-weight: normal;
+      text-transform: lowercase;
+    }
   }
   .heading-primary {
     .time-bar();

--- a/app/assets/stylesheets/builder.less
+++ b/app/assets/stylesheets/builder.less
@@ -131,12 +131,12 @@
   .heading-muted {
     background-color: @gray-lighter;
     padding-left: 3px;
-    .submeasure {
-      float: right;
-      padding-right: 3px;
-      font-weight: normal;
-      text-transform: lowercase;
-    }
+  }
+  .submeasure {
+    text-transform: lowercase;
+    font-weight: normal;
+    background-color: @gray-lighter;
+    padding-left: 30px;
   }
   .heading-primary {
     .time-bar();

--- a/app/assets/stylesheets/measure.less
+++ b/app/assets/stylesheets/measure.less
@@ -103,16 +103,23 @@
   }
 
   .measure-title {
+    display:table;
+    > div {
+      display: table-cell;
+      vertical-align: middle;
+    }
     .make-sm-column(12);
     .title-bar;
     .short-title {
+      white-space: nowrap;
       font-size: 1.8em;
       line-height: 1.75;
-      padding-right: 15px;
+      padding-right: .5em;
     }
     .full-title {
       line-height: 1.6;
-      padding-right: 10px;
+      padding: .25em 0;
+      padding-right: 1.8em;
     }
     .settings-container {
       position: absolute;

--- a/app/assets/stylesheets/rationale.less
+++ b/app/assets/stylesheets/rationale.less
@@ -3,7 +3,7 @@
 .rationale {
   .eval-true, .eval-false, .eval-bad-specifics, .eval-coverage {
     font-weight: 500;
-    padding: 2px;
+    padding: 2px 0px;
   }
   .eval-true {
     background-color: @state-success-bg;


### PR DESCRIPTION
### Stories
- https://www.pivotaltracker.com/story/show/68458794
- https://www.pivotaltracker.com/story/show/68458728
### Notes
- Removed where it had a redundant "Measure" title. 
- Placed submeasure to go in the measure header
- Centered the measure title on the results page vertically relative to the grey bar
### Screens!

![centered](https://cloud.githubusercontent.com/assets/2136286/2917486/aa622906-d6c6-11e3-9722-97894806652f.png)

![headerwithsub](https://cloud.githubusercontent.com/assets/2136286/2917487/aa639278-d6c6-11e3-856b-2f9fece77dcd.png)

My first pull request here! Please forgive the back-and-forth-reverting silliness, I'll keep to my own branch now on. :angel: 
