### PR TITLE
Update admin users view with totals and expanded sorting options

### DIFF
--- a/app/assets/javascripts/models/user.js.coffee
+++ b/app/assets/javascripts/models/user.js.coffee
@@ -6,4 +6,15 @@ class Thorax.Models.User extends Thorax.Model
 class Thorax.Collections.Users extends Thorax.Collection
   url: '/admin/users'
   model: Thorax.Models.User
-  comparator: (u) -> [ u.get('approved'), u.get('email') ]
+  comparators:
+    'approved': (u) -> [ u.get('approved'), u.get('email') ]
+    'email': 'email'
+    'measure_count': (u) -> [ u.get('measure_count') ]
+    'patient_count': (u) -> [ u.get('patient_count') ]
+
+  initialize: ->
+    @setComparator('approved')
+
+  setComparator: (key) ->
+    @comparator = @comparators[key]
+    @

--- a/app/assets/javascripts/templates/users/users.hbs
+++ b/app/assets/javascripts/templates/users/users.hbs
@@ -1,5 +1,12 @@
 <h1><i class="fa fa-users"></i> Users ({{collection.length}})</h1>
 
+Sort by: <select name="users_sort_list" class="users-sort-list">
+  <option value="approved">Approval Status</option>
+  <option value="email">Email Address</option>
+  <option value="measure_count">Measure Count</option>
+  <option value="patient_count">Patient Count</option>
+</select>
+
 <table class="table table-striped table-hover">
   <thead>
     <tr>

--- a/app/assets/javascripts/templates/users/users.hbs
+++ b/app/assets/javascripts/templates/users/users.hbs
@@ -1,12 +1,12 @@
-<h1><i class="glyphicon glyphicon-user"></i> Users</h1>
+<h1><i class="fa fa-users"></i> Users ({{collection.length}})</h1>
 
 <table class="table table-striped table-hover">
   <thead>
     <tr>
       <th width="200px">Email Address</th>
       <th width="70px">Bundle</th>
-      <th width="75px" class="centered">Measures</th>
-      <th width="75px" class="centered">Patients</th>
+      <th width="75px" class="centered">Measures ({{totalMeasures}})</th>
+      <th width="75px" class="centered">Patients ({{totalPatients}})</th>
       <th width="75px" class="centered">Admin?</th>
       <th width="75px" class="centered">Portfolio?</th>
       <th width="75px" class="centered">Approved?</th>

--- a/app/assets/javascripts/views/users_view.js.coffee
+++ b/app/assets/javascripts/views/users_view.js.coffee
@@ -2,6 +2,9 @@ class Thorax.Views.Users extends Thorax.Views.BonnieView
   className: 'user-management'
   template: JST['users/users']
 
+  events:
+    'change .users-sort-list': 'sortUsers'
+
   initialize: ->
     @totalMeasures = 0
     @totalPatients = 0
@@ -11,6 +14,12 @@ class Thorax.Views.Users extends Thorax.Views.BonnieView
     @totalMeasures = @collection.reduce(((sum, user) -> sum + user.get('measure_count')), 0)
     @totalPatients = @collection.reduce(((sum, user) -> sum + user.get('patient_count')), 0)
     @render()
+
+  sortUsers: (e) ->
+    attr = $(e.target).val()
+    @collection.setComparator(attr).sort()
+    # need to reverse the models for descending order on measure/patient counts
+    if attr is 'measure_count' or attr is 'patient_count' then @collection.reset(@collection.models.reverse(), {sort: false})
 
 class Thorax.Views.User extends Thorax.Views.BonnieView
   template: JST['users/user']

--- a/app/assets/javascripts/views/users_view.js.coffee
+++ b/app/assets/javascripts/views/users_view.js.coffee
@@ -2,6 +2,16 @@ class Thorax.Views.Users extends Thorax.Views.BonnieView
   className: 'user-management'
   template: JST['users/users']
 
+  initialize: ->
+    @totalMeasures = 0
+    @totalPatients = 0
+    @collection.on 'change add reset destroy remove', @updateSummary, this
+
+  updateSummary: ->
+    @totalMeasures = @collection.reduce(((sum, user) -> sum + user.get('measure_count')), 0)
+    @totalPatients = @collection.reduce(((sum, user) -> sum + user.get('patient_count')), 0)
+    @render()
+
 class Thorax.Views.User extends Thorax.Views.BonnieView
   template: JST['users/user']
   editTemplate: JST['users/edit_user']


### PR DESCRIPTION
#### Stories
- https://www.pivotaltracker.com/story/show/70293314
- https://www.pivotaltracker.com/story/show/70293156
#### Notes
- add totals to admin users view: total # of users, total # of measures, total # of patients
- add select for modifying users view sorting: approval status, email address, measure count, patient count
