### PR TITLE
Fix duplicate Expected Value inputs in Patient Builder view

### DIFF
--- a/app/assets/javascripts/views/patient_builder/expected_values.js.coffee
+++ b/app/assets/javascripts/views/patient_builder/expected_values.js.coffee
@@ -95,7 +95,7 @@ class Thorax.Views.ExpectedValueView extends Thorax.Views.BuilderChildView
         key: pc
         displayName: criteriaMap[pc]
         isEoC: @measure.get('episode_of_care')
-    unless @model.has('OBSERV_UNIT') then @model.set 'OBSERV_UNIT', ' mins'
+    unless @model.has('OBSERV_UNIT') or not @measure.get('continuous_variable') then @model.set 'OBSERV_UNIT', ' mins', {silent:true}
 
   updateObserv: ->
     if @measure.get('continuous_variable') and @model.has('MSRPOPL') and @model.get('MSRPOPL')?


### PR DESCRIPTION
#### Story
- https://www.pivotaltracker.com/story/show/69469804
#### Notes
- expected values were updated to support <code>OBSERV_UNIT</code> for CV measures, but remained erroneous
- the fix involved only setting an <code>OBSERV_UNIT</code> for CV measures, and passing a <code>{silent:true}</code> when doing so ( taken from the response to this familiar issue: https://github.com/walmartlabs/thorax/issues/300 )
#### Screenshot
- duplicate expected values in patient builder elements (expected-0, expected-1)
  - ![screen shot 2014-05-12 at 10 54 23 am](https://cloud.githubusercontent.com/assets/456952/2946848/e723785a-d9ef-11e3-9678-3f62e9439cc8.png)
