### PR TITLE
Added script allowing the required fields icons to show error

### DIFF
--- a/app/assets/stylesheets/bootstrap3.less
+++ b/app/assets/stylesheets/bootstrap3.less
@@ -139,3 +139,10 @@ h2 {
 .popover {
   box-shadow: none;
 }
+
+//hack that Twitter uses to fix input field widths in IE9
+.input-group {
+  .form-control {
+    float:left;
+  }
+}

--- a/app/assets/stylesheets/login.less
+++ b/app/assets/stylesheets/login.less
@@ -2,7 +2,7 @@
   .login {
     // center horizontally, give it some breathing room across the top
     margin-top: 200px;
-    .make-sm-column-offset(4);
+
     width: @form-width;
 
     header h1 {

--- a/app/assets/stylesheets/login.less
+++ b/app/assets/stylesheets/login.less
@@ -3,6 +3,8 @@
     // center horizontally, give it some breathing room across the top
     margin-top: 200px;
 
+    .center-block;
+
     width: @form-width;
 
     header h1 {

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -25,5 +25,9 @@
   <% end %>
 </div>
 
-
+<script>
+  $(function() {
+    $('.field_with_errors').parent().removeClass('required').addClass('has-error'); //allows icon to change color appropriately for validation
+  });
+</script>
 

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -96,3 +96,9 @@
   <a href="/#value_sets/edit" class="btn btn-primary btn-lg" >Edit</a>
   <span class="help-block">Search loaded value sets, correlate codes across value sets via filters, and modify current white/black list value set entries.</span>
 <% end %>
+
+<script>
+  $(function() {
+    $('.field_with_errors').parent().removeClass('required').addClass('has-error'); //allows icon to change color appropriately for validation
+  });
+</script>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -99,8 +99,6 @@
       $submit.prop('disabled', !$checkbox.is(':checked'));
     });
 
-    $('.field_with_errors').each(function() {
-      $(this).parent().removeClass('required').addClass('has-error');
-    }); //allows icon to change color appropriately for validation
+    $('.field_with_errors').parent().removeClass('required').addClass('has-error'); //allows icon to change color appropriately for validation
   });
 </script>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -98,5 +98,9 @@
           $submit = $form.find(':submit');
       $submit.prop('disabled', !$checkbox.is(':checked'));
     });
+
+    $('.field_with_errors').each(function() {
+      $(this).parent().removeClass('required').addClass('has-error');
+    }); //allows icon to change color appropriately for validation
   });
 </script>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,4 +1,4 @@
-<div class="login">
+<div class="login center-block">
   <header>
     <h1>Bonnie</h1>
     <h2>A Testing Tool for eCQMs</h2>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,4 +1,4 @@
-<div class="login center-block">
+<div class="login">
   <header>
     <h1>Bonnie</h1>
     <h2>A Testing Tool for eCQMs</h2>


### PR DESCRIPTION
### Story
- https://www.pivotaltracker.com/story/show/68443700
### Notes
- It only acts when there's a `field_with_errors` on the page. 
- I love jQuery!
- One thing I noticed: The last field (confirm password) never shows as having an error, which strikes me as strange, but I guess that's an artifact of devise?
### Screenshot

![iconvalidation](https://cloud.githubusercontent.com/assets/2136286/2961588/61de87d2-dac8-11e3-9799-1cb2b3d6818a.png)
