### PR TITLE
Add support for Ends Concurrent with Start / Starts Concurrent with End

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/projectcypress/health-data-standards.git
-  revision: 1992aa22c47b8e9a8a5e53150de70dfd9322a1e9
+  revision: 3dccdd2d93da67bfecd0fd93caaca57635f4d02c
   branch: master
   specs:
-    health-data-standards (3.4.5)
+    health-data-standards (3.4.6)
       activesupport (~> 3.2.14)
       builder (~> 3.0.0)
       erubis (~> 2.7.0)
@@ -143,7 +143,7 @@ GEM
     mail (2.5.4)
       mime-types (~> 1.16)
       treetop (~> 1.4.8)
-    memoist (0.9.1)
+    memoist (0.9.2)
     method_source (0.8.2)
     mime-types (1.25.1)
     mini_portile (0.5.3)
@@ -156,7 +156,7 @@ GEM
     mongoid-tree (1.0.4)
       mongoid (>= 3.0, <= 4.0)
     moped (1.5.2)
-    multi_json (1.9.2)
+    multi_json (1.10.1)
     net-scp (1.1.2)
       net-ssh (>= 2.6.5)
     net-ssh (2.7.0)

--- a/app/assets/javascripts/views/logic/temporal_reference_view.js.coffee
+++ b/app/assets/javascripts/views/logic/temporal_reference_view.js.coffee
@@ -8,13 +8,15 @@ class Thorax.Views.TemporalReferenceLogic extends Thorax.Views.BonnieView
     'SBE':'Starts Before or During'
     'SAE':'Starts After End of'
     'EBS':'Ends Before Start of'
-    'EAS':'Ends After Start'
+    'EAS':'Ends After Start of'
     'EBE':'Ends Before or During'
     'EAE':'Ends After End of'
     'SDU':'Starts During'
     'EDU':'Ends During'
     'ECW':'Ends Concurrent with'
+    'ECWS':'Ends Concurrent with Start of'
     'SCW':'Starts Concurrent with'
+    'SCWE':'Starts Concurrent with End of'
     'CONCURRENT':'Concurrent with'
 
   initialize: ->


### PR DESCRIPTION
When rendering a measure, correctly expand ECWS and SCWE into the appropriate readable text
