### PR TITLE
Add user information to email generated on exception

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,7 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery
   before_filter :authenticate_user!
+  before_filter :log_additional_data
   layout :layout_by_resource
 
   def layout_by_resource
@@ -11,4 +12,10 @@ class ApplicationController < ActionController::Base
     end
   end
 
+  protected
+    def log_additional_data
+      request.env["exception_notifier.exception_data"] = {
+        :current_user => current_user
+      }
+    end
 end

--- a/app/views/exception_notifier/_user_info.text.erb
+++ b/app/views/exception_notifier/_user_info.text.erb
@@ -1,0 +1,6 @@
+<% if @current_user.nil? %>
+No logged in user.
+<% else %>
+User name: <%= @current_user.first_name %> <%= @current_user.last_name %>
+User email: <%= @current_user.email %>
+<% end %>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -73,7 +73,8 @@ Bonnie::Application.configure do
   config.middleware.use ExceptionNotification::Rack, email: {
     email_prefix: "[Bonnie] ",
     sender_address: %{"Bonnie" <bonnie@#{HOSTNAME}>},
-    exception_recipients: %w{bonnie-feedback-list@lists.mitre.org}
+    exception_recipients: %w{bonnie-feedback-list@lists.mitre.org},
+    sections: %w{request session user_info environment backtrace}
   }
 
 end


### PR DESCRIPTION
This adds information about who the current user is to the exception email generated by the exception_notification gem.
