### PR TITLE
Replace Expected Values form with static display and popover form

### DIFF
--- a/app/assets/javascripts/templates/patient_builder/expected_value.hbs
+++ b/app/assets/javascripts/templates/patient_builder/expected_value.hbs
@@ -48,26 +48,28 @@
 </div>
 </script>
 <div class="tab-pane">
-  {{#each setValues}}
-    {{#ifCond key "==" "OBSERV"}}
-      {{#if value}}
-        <strong>{{displayName}}</strong>: {{value}}{{../../../OBSERV_UNIT}}
-      {{/if}}
-    {{else}}
-      {{#if isEoC}}
-        <Strong>{{displayName}}</strong>: {{value}}
+  <span class="span-expected-values">
+    {{#each setValues}}
+      {{#ifCond key "==" "OBSERV"}}
+        {{#if value}}
+          <strong>{{displayName}}</strong>: {{value}}{{../../../OBSERV_UNIT}}
+        {{/if}}
       {{else}}
-        {{#ifCond key "==" "MSRPOPL"}}
+        {{#if isEoC}}
           <Strong>{{displayName}}</strong>: {{value}}
         {{else}}
-          {{#if value}}
-            <Strong>{{displayName}}</strong>
-          {{/if}}
-        {{/ifCond}}
-      {{/if}}
-    {{/ifCond}}
-  {{else}}
-    None
-  {{/each}}
+          {{#ifCond key "==" "MSRPOPL"}}
+            <Strong>{{displayName}}</strong>: {{value}}
+          {{else}}
+            {{#if value}}
+              <Strong>{{displayName}}</strong>
+            {{/if}}
+          {{/ifCond}}
+        {{/if}}
+      {{/ifCond}}
+    {{else}}
+      None
+    {{/each}}
+  </span>
 </div>
 <button type="button" class="btn-xs btn-default btn-expected-value ev-{{population_index}}" data-toggle="popover" data-placement="bottom" data-html="true"><i class="fa fa-pencil"></i></button>

--- a/app/assets/javascripts/templates/patient_builder/expected_value.hbs
+++ b/app/assets/javascripts/templates/patient_builder/expected_value.hbs
@@ -6,7 +6,13 @@
         {{#ifCond key "==" "OBSERV"}}
           <li class="list-group-item">
             <div class="form-group">
-              <h5>{{displayName}} {{#button "toggleUnits" class="btn btn-xs btn-default"}}{{../../../OBSERV_UNIT}}{{/button}}</h5>
+              <h5>
+                {{displayName}}
+                <div class="btn-group">
+                  {{#button "setPerc" class="btn btn-xs btn-observ-unit-perc"}} % {{/button}}
+                  {{#button "setMins" class="btn btn-xs btn-observ-unit-mins"}} mins {{/button}}
+                </div>
+              </h5>
             </div>
           </li>
           {{#each ../../OBSERV}}

--- a/app/assets/javascripts/templates/patient_builder/expected_value.hbs
+++ b/app/assets/javascripts/templates/patient_builder/expected_value.hbs
@@ -1,5 +1,83 @@
-<h3>Expected Value</h3>
-<div class="form-inline tab-pane">
+<h3>Expected Value</h3> <button type="button" class="btn btn-default pull-right btn-expected-value" data-toggle="popover" data-placement="left" data-html="true"><i class="fa fa-plus"></i></button>
+<script type="text/x-handlebars" class="popover-tmpl">
+  <div class="form-inline">
+    {{#each currentCriteria}}
+      {{#ifCond key "==" "OBSERV"}}
+        <label>
+          {{displayName}}
+          <input type="number" name="{{key}}" min="0" value="{{value}}">
+        </label>
+        <button type="button" class="btn dropdown-toggle" data-toggle="dropdown">{{../../OBSERV_UNIT}}</button>
+        <ul class="dropdown-menu">
+          <li>{{#button "setObservMins" tag="a"}}mins{{/button}}</li>
+          <li>{{#button "setObservPerc" tag="a"}}%{{/button}}</li>
+        </ul>
+      {{else}}
+        {{#if isEoC}}
+          <div class="form-group">
+            <label>
+               <input type="number" name="{{key}}" min="0" value="{{value}}">
+               {{displayName}}
+            </label>
+          </div>
+        {{else}}
+          {{#ifCond key "==" "MSRPOPL"}}
+            <div class="form-group">
+              <label>
+                 <input type="number" name="{{key}}" min="0" value="{{value}}">
+                 {{displayName}}
+              </label>
+            </div>
+          {{else}}
+            <label class="checkbox-inline">
+              <input type="checkbox" name="{{key}}" {{#if value}}checked="{{value}}"{{/if}}>
+              {{displayName}}
+            </label>
+          {{/ifCond}}
+        {{/if}}
+      {{/ifCond}}
+    {{/each}}
+  </div>
+</script>
+<div class="tab-pane">
+  {{#each currentCriteria}}
+    {{#ifCond key "==" "OBSERV"}}
+      <label>
+        {{displayName}}: {{value}} {{../../OBSERV_UNIT}}
+        {{!-- <input type="number" name="{{key}}" min="0"> --}}
+      </label>
+      {{!-- <button type="button" class="btn dropdown-toggle" data-toggle="dropdown">{{../../OBSERV_UNIT}}</button>
+      <ul class="dropdown-menu">
+        <li>{{#button "setObservMins" tag="a"}}mins{{/button}}</li>
+        <li>{{#button "setObservPerc" tag="a"}}%{{/button}}</li>
+      </ul> --}}
+    {{else}}
+      {{#if isEoC}}
+        {{!-- <div class="form-group"> --}}
+          <label>
+             {{!-- <input type="number" name="{{key}}" min="0"> --}}
+             {{displayName}}: {{value}}
+          </label>
+        {{!-- </div> --}}
+      {{else}}
+        {{#ifCond key "==" "MSRPOPL"}}
+          {{!-- <div class="form-group"> --}}
+            <label>
+               {{!-- <input type="number" name="{{key}}" min="0"> --}}
+               {{displayName}}: {{value}}
+            </label>
+          {{!-- </div> --}}
+        {{else}}
+          <label>
+            {{!-- <input type="checkbox" name="{{key}}"> --}}
+            {{displayName}}: {{value}}
+          </label>
+        {{/ifCond}}
+      {{/if}}
+    {{/ifCond}}
+  {{/each}}
+</div>
+{{!-- <div class="form-inline tab-pane">
   {{#each currentCriteria}}
     {{#ifCond key "==" "OBSERV"}}
       <div class="form-group">
@@ -28,4 +106,4 @@
       {{/if}}
     {{/ifCond}}
   {{/each}}
-</div>
+</div> --}}

--- a/app/assets/javascripts/templates/patient_builder/expected_value.hbs
+++ b/app/assets/javascripts/templates/patient_builder/expected_value.hbs
@@ -1,18 +1,25 @@
-<h3>Expected Value</h3> <button type="button" class="btn-xs btn-default pull-right btn-expected-value ev-{{population_index}}" data-toggle="popover" data-placement="left" data-html="true"><i class="fa fa-pencil"></i></button>
+<h3>Expected Value</h3>
 <script type="text/x-handlebars" class="popover-tmpl">
   <div class="form-inline tab-pane">
     <ul class="list-group">
     {{#each currentCriteria}}
-      <li class="list-group-item">
         {{#ifCond key "==" "OBSERV"}}
-          <div class="form-group">
-            <label for="{{key}}_{{@cid}}">{{displayName}}</label>
-            {{#button "toggleUnits" class="btn btn-xs btn-default"}}{{../../../OBSERV_UNIT}}{{/button}}
-            {{#each ../../OBSERV}}
-              <input type="number" id="{{../key}}_{{@index}}" name="{{../key}}" min="0" value="{{this}}">
-            {{/each}}
-          </div>
+          <li class="list-group-item">
+            <div class="form-group">
+              <h5>{{displayName}} {{#button "toggleUnits" class="btn btn-xs btn-default"}}{{../../../OBSERV_UNIT}}{{/button}}</h5>
+            </div>
+          </li>
+          {{#each ../../OBSERV}}
+            <li class="list-group-item">
+              <div class="form-group">
+                <label for="{{../key}}_{{@index}}">
+                  <input type="number" id="{{../key}}_{{@index}}" name="{{../key}}" min="0" value="{{this}}"> {{../displayName}}_{{@index}}
+                </label>
+              </div>
+            </li>
+          {{/each}}
         {{else}}
+          <li class="list-group-item">
           {{#if isEoC}}
             <div class="form-group">
               <label for="{{key}}_{{@cid}}">
@@ -22,8 +29,9 @@
           {{else}}
             {{#ifCond key "==" "MSRPOPL"}}
               <div class="form-group">
-                <label for="{{key}}_{{@cid}}">{{displayName}}</label>
-                <input type="number" id="{{key}}_{{@cid}}" name="{{key}}" min="0">
+                <label for="{{key}}_{{@cid}}">
+                  <input type="number" id="{{key}}_{{@cid}}" name="{{key}}" min="0"> {{displayName}}
+                </label>
               </div>
             {{else}}
               <div class="checkbox">
@@ -33,88 +41,33 @@
               </div>
             {{/ifCond}}
           {{/if}}
+          </li>
         {{/ifCond}}
-      </li>
     {{/each}}
     </ul>
 </div>
 </script>
 <div class="tab-pane">
-  {{#each currentCriteria}}
+  {{#each setValues}}
     {{#ifCond key "==" "OBSERV"}}
-      {{!-- <label> --}}
-        {{displayName}}: {{value}} {{../../OBSERV_UNIT}}
-        {{!-- <input type="number" name="{{key}}" min="0"> --}}
-      {{!-- </label> --}}
-      {{!-- <button type="button" class="btn dropdown-toggle" data-toggle="dropdown">{{../../OBSERV_UNIT}}</button>
-      <ul class="dropdown-menu">
-        <li>{{#button "setObservMins" tag="a"}}mins{{/button}}</li>
-        <li>{{#button "setObservPerc" tag="a"}}%{{/button}}</li>
-      </ul> --}}
+      {{#if value}}
+        <strong>{{displayName}}</strong>: {{value}}{{../../../OBSERV_UNIT}}
+      {{/if}}
     {{else}}
       {{#if isEoC}}
-        {{!-- <div class="form-group"> --}}
-          {{!-- <label> --}}
-             {{!-- <input type="number" name="{{key}}" min="0"> --}}
-             {{displayName}}: {{value}}
-          {{!-- </label> --}}
-        {{!-- </div> --}}
-        {{!-- <div class="form-group">
-          <label for="{{key}}_{{@cid}}">
-            <input type="number" id="{{key}}_{{@cid}}" name="{{key}}" min="0" disabled> {{displayName}}
-          </label>
-        </div> --}}
+        <Strong>{{displayName}}</strong>: {{value}}
       {{else}}
         {{#ifCond key "==" "MSRPOPL"}}
-          {{!-- <div class="form-group"> --}}
-            {{!-- <label> --}}
-               {{!-- <input type="number" name="{{key}}" min="0"> --}}
-               {{displayName}}: {{value}}
-            {{!-- </label> --}}
-          {{!-- </div> --}}
+          <Strong>{{displayName}}</strong>: {{value}}
         {{else}}
-          {{!-- <label>
-            <input type="checkbox" name="{{key}}">
-            {{displayName}}: {{value}}
-          </label> --}}
-          {{!-- <div class="checkbox"> --}}
-            {{!-- <label for="{{key}}_{{@cid}}_display" class="control-label">
-              <input type="checkbox" id="{{key}}_{{@cid}}_display" name="{{key}}" class="expected-value-checkbox display-ev" disabled> {{displayName}}
-            </label> --}}
-          {{!-- </div> --}}
-          {{displayName}}: {{value}}
+          {{#if value}}
+            <Strong>{{displayName}}</strong>
+          {{/if}}
         {{/ifCond}}
       {{/if}}
     {{/ifCond}}
+  {{else}}
+    None
   {{/each}}
 </div>
-{{!-- <div class="form-inline tab-pane">
-  {{#each currentCriteria}}
-    {{#ifCond key "==" "OBSERV"}}
-      <div class="form-group">
-        <label for="{{key}}_{{@cid}}">{{displayName}}</label>
-        {{#button "toggleUnits" class="btn btn-xs btn-default"}}{{../../../OBSERV_UNIT}}{{/button}}
-        {{#each ../../OBSERV}}
-          <input type="number" id="{{../key}}_{{@index}}" name="{{../key}}" min="0" value="{{this}}">
-        {{/each}}
-      </div>
-    {{else}}
-      {{#if isEoC}}
-        <div class="form-group">
-          <label for="{{key}}_{{@cid}}">{{displayName}}</label>
-          <input type="number" id="{{key}}_{{@cid}}" name="{{key}}" min="0">
-        </div>
-      {{else}}
-        {{#ifCond key "==" "MSRPOPL"}}
-          <div class="form-group">
-            <label for="{{key}}_{{@cid}}">{{displayName}}</label>
-            <input type="number" id="{{key}}_{{@cid}}" name="{{key}}" min="0">
-          </div>
-        {{else}}
-          <label for="{{key}}_{{@cid}}" class="checkbox-inline">{{displayName}}</label>
-          <input type="checkbox" id="{{key}}_{{@cid}}" name="{{key}}">
-        {{/ifCond}}
-      {{/if}}
-    {{/ifCond}}
-  {{/each}}
-</div> --}}
+<button type="button" class="btn-xs btn-default btn-expected-value ev-{{population_index}}" data-toggle="popover" data-placement="bottom" data-html="true"><i class="fa fa-pencil"></i></button>

--- a/app/assets/javascripts/templates/patient_builder/expected_value.hbs
+++ b/app/assets/javascripts/templates/patient_builder/expected_value.hbs
@@ -1,4 +1,4 @@
-<h3>Expected Value</h3> <button type="button" class="btn btn-default pull-right btn-expected-value" data-toggle="popover" data-placement="left" data-html="true"><i class="fa fa-plus"></i></button>
+<h3>Expected Value</h3> <button type="button" class="btn-xs btn-default pull-right btn-expected-value ev-{{population_index}}" data-toggle="popover" data-placement="left" data-html="true"><i class="fa fa-pencil"></i></button>
 <script type="text/x-handlebars" class="popover-tmpl">
   <div class="form-inline tab-pane">
     <ul class="list-group">
@@ -15,8 +15,9 @@
         {{else}}
           {{#if isEoC}}
             <div class="form-group">
-              <label for="{{key}}_{{@cid}}">{{displayName}}</label>
-              <input type="number" id="{{key}}_{{@cid}}" name="{{key}}" min="0">
+              <label for="{{key}}_{{@cid}}">
+                <input type="number" id="{{key}}_{{@cid}}" name="{{key}}" min="0"> {{displayName}}
+              </label>
             </div>
           {{else}}
             {{#ifCond key "==" "MSRPOPL"}}
@@ -41,10 +42,10 @@
 <div class="tab-pane">
   {{#each currentCriteria}}
     {{#ifCond key "==" "OBSERV"}}
-      <label>
+      {{!-- <label> --}}
         {{displayName}}: {{value}} {{../../OBSERV_UNIT}}
         {{!-- <input type="number" name="{{key}}" min="0"> --}}
-      </label>
+      {{!-- </label> --}}
       {{!-- <button type="button" class="btn dropdown-toggle" data-toggle="dropdown">{{../../OBSERV_UNIT}}</button>
       <ul class="dropdown-menu">
         <li>{{#button "setObservMins" tag="a"}}mins{{/button}}</li>
@@ -53,18 +54,23 @@
     {{else}}
       {{#if isEoC}}
         {{!-- <div class="form-group"> --}}
-          <label>
+          {{!-- <label> --}}
              {{!-- <input type="number" name="{{key}}" min="0"> --}}
              {{displayName}}: {{value}}
-          </label>
+          {{!-- </label> --}}
         {{!-- </div> --}}
+        {{!-- <div class="form-group">
+          <label for="{{key}}_{{@cid}}">
+            <input type="number" id="{{key}}_{{@cid}}" name="{{key}}" min="0" disabled> {{displayName}}
+          </label>
+        </div> --}}
       {{else}}
         {{#ifCond key "==" "MSRPOPL"}}
           {{!-- <div class="form-group"> --}}
-            <label>
+            {{!-- <label> --}}
                {{!-- <input type="number" name="{{key}}" min="0"> --}}
                {{displayName}}: {{value}}
-            </label>
+            {{!-- </label> --}}
           {{!-- </div> --}}
         {{else}}
           {{!-- <label>
@@ -72,10 +78,11 @@
             {{displayName}}: {{value}}
           </label> --}}
           {{!-- <div class="checkbox"> --}}
-            <label for="{{key}}_{{@cid}}" class="control-label">
-              <input type="checkbox" id="{{key}}_{{@cid}}" name="{{key}}" class="expected-value-checkbox" disabled> {{displayName}}
-            </label>
+            {{!-- <label for="{{key}}_{{@cid}}_display" class="control-label">
+              <input type="checkbox" id="{{key}}_{{@cid}}_display" name="{{key}}" class="expected-value-checkbox display-ev" disabled> {{displayName}}
+            </label> --}}
           {{!-- </div> --}}
+          {{displayName}}: {{value}}
         {{/ifCond}}
       {{/if}}
     {{/ifCond}}

--- a/app/assets/javascripts/templates/patient_builder/expected_value.hbs
+++ b/app/assets/javascripts/templates/patient_builder/expected_value.hbs
@@ -33,19 +33,11 @@
               </label>
             </div>
           {{else}}
-            {{#ifCond key "==" "MSRPOPL"}}
-              <div class="form-group">
-                <label for="{{key}}_{{@cid}}">
-                  <input type="number" id="{{key}}_{{@cid}}" name="{{key}}" min="0"> {{displayName}}
-                </label>
-              </div>
-            {{else}}
-              <div class="checkbox">
-                <label for="{{key}}_{{@cid}}" class="control-label">
-                  <input type="checkbox" id="{{key}}_{{@cid}}" name="{{key}}" class="expected-value-checkbox"> {{displayName}}
-                </label>
-              </div>
-            {{/ifCond}}
+            <div class="checkbox">
+              <label for="{{key}}_{{@cid}}" class="control-label">
+                <input type="checkbox" id="{{key}}_{{@cid}}" name="{{key}}" class="expected-value-checkbox"> {{displayName}}
+              </label>
+            </div>
           {{/if}}
           </li>
         {{/ifCond}}
@@ -64,13 +56,9 @@
         {{#if isEoC}}
           <Strong>{{displayName}}</strong>: {{value}}
         {{else}}
-          {{#ifCond key "==" "MSRPOPL"}}
-            <Strong>{{displayName}}</strong>: {{value}}
-          {{else}}
-            {{#if value}}
-              <Strong>{{displayName}}</strong>
-            {{/if}}
-          {{/ifCond}}
+          {{#if value}}
+            <Strong>{{displayName}}</strong>
+          {{/if}}
         {{/if}}
       {{/ifCond}}
     {{else}}

--- a/app/assets/javascripts/templates/patient_builder/expected_value.hbs
+++ b/app/assets/javascripts/templates/patient_builder/expected_value.hbs
@@ -1,43 +1,42 @@
 <h3>Expected Value</h3> <button type="button" class="btn btn-default pull-right btn-expected-value" data-toggle="popover" data-placement="left" data-html="true"><i class="fa fa-plus"></i></button>
 <script type="text/x-handlebars" class="popover-tmpl">
-  <div class="form-inline">
+  <div class="form-inline tab-pane">
+    <ul class="list-group">
     {{#each currentCriteria}}
-      {{#ifCond key "==" "OBSERV"}}
-        <label>
-          {{displayName}}
-          <input type="number" name="{{key}}" min="0" value="{{value}}">
-        </label>
-        <button type="button" class="btn dropdown-toggle" data-toggle="dropdown">{{../../OBSERV_UNIT}}</button>
-        <ul class="dropdown-menu">
-          <li>{{#button "setObservMins" tag="a"}}mins{{/button}}</li>
-          <li>{{#button "setObservPerc" tag="a"}}%{{/button}}</li>
-        </ul>
-      {{else}}
-        {{#if isEoC}}
+      <li class="list-group-item">
+        {{#ifCond key "==" "OBSERV"}}
           <div class="form-group">
-            <label>
-               <input type="number" name="{{key}}" min="0" value="{{value}}">
-               {{displayName}}
-            </label>
+            <label for="{{key}}_{{@cid}}">{{displayName}}</label>
+            {{#button "toggleUnits" class="btn btn-xs btn-default"}}{{../../../OBSERV_UNIT}}{{/button}}
+            {{#each ../../OBSERV}}
+              <input type="number" id="{{../key}}_{{@index}}" name="{{../key}}" min="0" value="{{this}}">
+            {{/each}}
           </div>
         {{else}}
-          {{#ifCond key "==" "MSRPOPL"}}
+          {{#if isEoC}}
             <div class="form-group">
-              <label>
-                 <input type="number" name="{{key}}" min="0" value="{{value}}">
-                 {{displayName}}
-              </label>
+              <label for="{{key}}_{{@cid}}">{{displayName}}</label>
+              <input type="number" id="{{key}}_{{@cid}}" name="{{key}}" min="0">
             </div>
           {{else}}
-            <label class="checkbox-inline">
-              <input type="checkbox" name="{{key}}" {{#if value}}checked="{{value}}"{{/if}}>
-              {{displayName}}
-            </label>
-          {{/ifCond}}
-        {{/if}}
-      {{/ifCond}}
+            {{#ifCond key "==" "MSRPOPL"}}
+              <div class="form-group">
+                <label for="{{key}}_{{@cid}}">{{displayName}}</label>
+                <input type="number" id="{{key}}_{{@cid}}" name="{{key}}" min="0">
+              </div>
+            {{else}}
+              <div class="checkbox">
+                <label for="{{key}}_{{@cid}}" class="control-label">
+                  <input type="checkbox" id="{{key}}_{{@cid}}" name="{{key}}" class="expected-value-checkbox"> {{displayName}}
+                </label>
+              </div>
+            {{/ifCond}}
+          {{/if}}
+        {{/ifCond}}
+      </li>
     {{/each}}
-  </div>
+    </ul>
+</div>
 </script>
 <div class="tab-pane">
   {{#each currentCriteria}}
@@ -68,10 +67,15 @@
             </label>
           {{!-- </div> --}}
         {{else}}
-          <label>
-            {{!-- <input type="checkbox" name="{{key}}"> --}}
+          {{!-- <label>
+            <input type="checkbox" name="{{key}}">
             {{displayName}}: {{value}}
-          </label>
+          </label> --}}
+          {{!-- <div class="checkbox"> --}}
+            <label for="{{key}}_{{@cid}}" class="control-label">
+              <input type="checkbox" id="{{key}}_{{@cid}}" name="{{key}}" class="expected-value-checkbox" disabled> {{displayName}}
+            </label>
+          {{!-- </div> --}}
         {{/ifCond}}
       {{/if}}
     {{/ifCond}}

--- a/app/assets/javascripts/templates/patient_builder/population_logic.hbs
+++ b/app/assets/javascripts/templates/patient_builder/population_logic.hbs
@@ -1,4 +1,4 @@
 <h1 class="heading-muted"><i class="fa fa-tasks" aria-hidden="true"></i> Measure</h1>
-<p class="submeasure">{{title}}</p>
+{{#if title}}<h2 class="submeasure">{{title}}</h2>{{/if}}
 
 {{layout-element}}

--- a/app/assets/javascripts/templates/population_calculation.hbs
+++ b/app/assets/javascripts/templates/population_calculation.hbs
@@ -82,19 +82,11 @@
                 {{#if ../../episode_of_care}}
                   <span class="default">{{expected}}</span>
                 {{else}}
-                  {{#ifCond name "==" "MSRPOPL"}}
-                    {{#ifCond expected "==" undefined}}
-                      <p class="text-muted" style="margin: auto;">N/A</p>
-                    {{else}}
-                      <span class="default">{{expected}}</span>
-                    {{/ifCond}}
+                  {{#if expected}}
+                    <i class="fa fa-check-square-o default" aria-hidden="true"><span class="sr-only">checked</span></i>
                   {{else}}
-                    {{#if expected}}
-                      <i class="fa fa-check-square-o default" aria-hidden="true"></i><span class="sr-only">checked</span>
-                    {{else}}
-                      <i class="fa fa-square-o default" aria-hidden="true"></i><span class="sr-only">unchecked</span>
-                    {{/if}}
-                  {{/ifCond}}
+                    <i class="fa fa-square-o default" aria-hidden="true"><span class="sr-only">unchecked</span></i>
+                  {{/if}}
                 {{/if}}
               {{/ifCond}}
             </td>
@@ -109,19 +101,11 @@
                 {{#if ../../episode_of_care}}
                   <span class="fail">{{actual}}</span>
                 {{else}}
-                  {{#ifCond name "==" "MSRPOPL"}}
-                    {{#ifCond expected "==" undefined}}
-                      <p class="text-muted" style="margin: auto;">N/A</p>
-                    {{else}}
-                      <span class="default">{{actual}}</span>
-                    {{/ifCond}}
+                  {{#if actual}}
+                    <i class="fa fa-check-square-o default" aria-hidden="true"><span class="sr-only">checked</span></i>
                   {{else}}
-                    {{#if actual}}
-                      <i class="fa fa-check-square-o default" aria-hidden="true"></i><span class="sr-only">checked</span>
-                    {{else}}
-                      <i class="fa fa-square-o default" aria-hidden="true"></i><span class="sr-only">unchecked</span>
-                    {{/if}}
-                  {{/ifCond}}
+                    <i class="fa fa-square-o default" aria-hidden="true"><span class="sr-only">unchecked</span></i>
+                  {{/if}}
                 {{/if}}
               {{/ifCond}}
             </td>

--- a/app/assets/javascripts/views/patient_builder/expected_values.js.coffee
+++ b/app/assets/javascripts/views/patient_builder/expected_values.js.coffee
@@ -77,13 +77,11 @@ class Thorax.Views.ExpectedValueView extends Thorax.Views.BuilderChildView
         @populate()
         @setObservs()
       else
-        # console.log @serialize()
-        # @$('.display-ev').removeAttr('name') #remove name from display to prevent duplicate serialization
         @triggerMaterialize()
         @parseValues()
         @render()
     rendered: -> 
-      @$(".btn-expected-value.ev-#{@index}").popover(content: @$('.popover-tmpl').text())
+      @$(".btn-expected-value.ev-#{@model.get('population_index')}").popover(content: @$('.popover-tmpl').text())
       @setObservs()
 
   context: ->
@@ -103,7 +101,7 @@ class Thorax.Views.ExpectedValueView extends Thorax.Views.BuilderChildView
       DENEX:    'EXCL'
       MSRPOPL:  'MSRPOPL'
       OBSERV:   'OBSERV'
-    @index = @model.get('population_index')
+    @filter = not @measure.get('episode_of_care') and not @measure.get('continuous_variable')
     @popover ?= false
     @parseValues()
 
@@ -118,9 +116,9 @@ class Thorax.Views.ExpectedValueView extends Thorax.Views.BuilderChildView
         isEoC: @measure.get('episode_of_care')
         value: @model.get(pc)
     unless @model.has('OBSERV_UNIT') or not @measure.get('continuous_variable') then @model.set 'OBSERV_UNIT', ' mins', {silent:true}
+    if @filter then @setValues = _(@currentCriteria).filter( (pc) => pc.value ) else @setValues = @currentCriteria
 
   updateObserv: ->
-    debugger
     @model.set @serialize() if @popover
     if @measure.get('continuous_variable') and @model.has('MSRPOPL') and @model.get('MSRPOPL')?
       values = @model.get('MSRPOPL')
@@ -137,7 +135,7 @@ class Thorax.Views.ExpectedValueView extends Thorax.Views.BuilderChildView
       @popover = not @popover
       @triggerMaterialize()
       @parseValues()
-      @render()
+      @render() # if _(@model.changedAttributes()).size()
 
   setObservs: ->
     if @model.get('OBSERV')?.length

--- a/app/assets/javascripts/views/patient_builder/expected_values.js.coffee
+++ b/app/assets/javascripts/views/patient_builder/expected_values.js.coffee
@@ -71,8 +71,8 @@ class Thorax.Views.ExpectedValueView extends Thorax.Views.BuilderChildView
           attr[pc] = if attr[pc] then 1 else 0 # Convert from check-box true/false to 0/1
     'change input[name="MSRPOPL"]': 'updateObserv'
     'click .btn-expected-value': ->
-      @popover = not @popover
-      if @popover
+      @popoverVisible = not @popoverVisible
+      if @popoverVisible
         @$('.popover-title').remove()
         @populate()
         @setObservs()
@@ -102,7 +102,7 @@ class Thorax.Views.ExpectedValueView extends Thorax.Views.BuilderChildView
       MSRPOPL:  'MSRPOPL'
       OBSERV:   'OBSERV'
     @filter = not @measure.get('episode_of_care') and not @measure.get('continuous_variable')
-    @popover ?= false
+    @popoverVisible ?= false
     @parseValues()
 
   parseValues: ->
@@ -119,7 +119,7 @@ class Thorax.Views.ExpectedValueView extends Thorax.Views.BuilderChildView
     if @filter then @setValues = _(@currentCriteria).filter( (pc) => pc.value ) else @setValues = @currentCriteria
 
   updateObserv: ->
-    @model.set @serialize() if @popover
+    @model.set @serialize() if @popoverVisible
     focusIndex = 0
     if @measure.get('continuous_variable') and @model.has('MSRPOPL') and @model.get('MSRPOPL')?
       values = @model.get('MSRPOPL')
@@ -133,8 +133,8 @@ class Thorax.Views.ExpectedValueView extends Thorax.Views.BuilderChildView
       else
         @model.set 'OBSERV', (0 for n in [1..values]) if values
       @setObservs()
-    if @popover
-      @popover = not @popover
+    if @popoverVisible
+      @popoverVisible = not @popoverVisible
       @triggerMaterialize()
       @parseValues()
       @render()

--- a/app/assets/javascripts/views/patient_builder/expected_values.js.coffee
+++ b/app/assets/javascripts/views/patient_builder/expected_values.js.coffee
@@ -69,7 +69,7 @@ class Thorax.Views.ExpectedValueView extends Thorax.Views.BuilderChildView
           else attr[pc] = undefined if pc == 'OBSERV' or pc == 'MSRPOPL'
         else
           attr[pc] = if attr[pc] then 1 else 0 # Convert from check-box true/false to 0/1
-    'blur input[name="MSRPOPL"]': 'updateObserv'
+    'change input[name="MSRPOPL"]': 'updateObserv'
     'click .btn-expected-value': ->
       @popover = not @popover
       if @popover

--- a/app/assets/javascripts/views/patient_builder/expected_values.js.coffee
+++ b/app/assets/javascripts/views/patient_builder/expected_values.js.coffee
@@ -146,11 +146,18 @@ class Thorax.Views.ExpectedValueView extends Thorax.Views.BuilderChildView
     if @model.get('OBSERV')?.length
       for val, index in @model.get('OBSERV')
         @$("#OBSERV_#{index}").val(val)
-
-  toggleUnits: (e) ->
-    if @model.get('OBSERV_UNIT') == ' mins'
-      @model.set 'OBSERV_UNIT', '%'
+    if @model.get('OBSERV_UNIT') == '%'
+      @$('.btn-observ-unit-perc').removeClass('btn-default').addClass('btn-primary').prop('disabled',true)
+      @$('.btn-observ-unit-mins').addClass('btn-default').removeClass('btn-primary').prop('disabled',false)
     else
-      @model.set 'OBSERV_UNIT', ' mins'
+      @$('.btn-observ-unit-mins').removeClass('btn-default').addClass('btn-primary').prop('disabled',true)
+      @$('.btn-observ-unit-perc').addClass('btn-default').removeClass('btn-primary').prop('disabled',false)
+
+  setPerc: (e) ->
+    @model.set 'OBSERV_UNIT', '%'
+    @updateObserv()
+
+  setMins: (e) ->
+    @model.set 'OBSERV_UNIT', ' mins'
     @updateObserv()
 

--- a/app/assets/javascripts/views/patient_builder/expected_values.js.coffee
+++ b/app/assets/javascripts/views/patient_builder/expected_values.js.coffee
@@ -120,12 +120,14 @@ class Thorax.Views.ExpectedValueView extends Thorax.Views.BuilderChildView
 
   updateObserv: ->
     @model.set @serialize() if @popover
+    focusIndex = 0
     if @measure.get('continuous_variable') and @model.has('MSRPOPL') and @model.get('MSRPOPL')?
       values = @model.get('MSRPOPL')
       if @model.get('OBSERV')
         current = @model.get('OBSERV').length
         if values > current
           @model.set 'OBSERV', @model.get('OBSERV').concat(0 for n in [(current+1)..values])
+          focusIndex = current
         else if values < current
           @model.set 'OBSERV', _(@model.get('OBSERV')).first(values)
       else
@@ -135,7 +137,10 @@ class Thorax.Views.ExpectedValueView extends Thorax.Views.BuilderChildView
       @popover = not @popover
       @triggerMaterialize()
       @parseValues()
-      @render() # if _(@model.changedAttributes()).size()
+      @render()
+      # open the popover and re-focus on the correct OBSERV input
+      @$(".btn-expected-value.ev-#{@model.get('population_index')}").click()
+      @$("#OBSERV_#{focusIndex}").focus()
 
   setObservs: ->
     if @model.get('OBSERV')?.length

--- a/app/assets/javascripts/views/patient_builder/expected_values.js.coffee
+++ b/app/assets/javascripts/views/patient_builder/expected_values.js.coffee
@@ -13,7 +13,7 @@ class Thorax.Views.ExpectedValuesView extends Thorax.Views.BonnieView
         id: "expected-#{item.model.get('population_index')}"
 
   serialize: ->
-    childView.serialize() for cid, childView of @expectedValueCollectionView.children
+    console.log(childView.serialize()) for cid, childView of @expectedValueCollectionView.children
     super
 
   hasMultipleTabs: -> @collection.length > 1
@@ -69,8 +69,18 @@ class Thorax.Views.ExpectedValueView extends Thorax.Views.BuilderChildView
           else attr[pc] = undefined if pc == 'OBSERV' or pc == 'MSRPOPL'
         else
           attr[pc] = if attr[pc] then 1 else 0 # Convert from check-box true/false to 0/1
-    'blur input': 'triggerMaterialize'
     'blur input[name="MSRPOPL"]': 'updateObserv'
+    # 'blur input': -> 
+      # @model.set @serialize()
+      # console.log @model.attributes
+    'click .btn-expected-value': ->
+      @popover = not @popover
+      @populate() if @popover
+      unless @popover
+        @initialize()
+        # console.log @currentCriteria
+        @render()
+        @triggerMaterialize()
     rendered: -> 
       @$('.btn-expected-value').popover(content: @$('.popover-tmpl').text())
       @setObservs()
@@ -102,6 +112,7 @@ class Thorax.Views.ExpectedValueView extends Thorax.Views.BuilderChildView
         isEoC: @measure.get('episode_of_care')
         value: @model.get(pc)
     unless @model.has('OBSERV_UNIT') or not @measure.get('continuous_variable') then @model.set 'OBSERV_UNIT', ' mins', {silent:true}
+    @popover ?= false
 
   updateObserv: ->
     if @measure.get('continuous_variable') and @model.has('MSRPOPL') and @model.get('MSRPOPL')?
@@ -118,8 +129,8 @@ class Thorax.Views.ExpectedValueView extends Thorax.Views.BuilderChildView
 
   setObservs: ->
     if @model.get('OBSERV')?.length
-        for val, index in @model.get('OBSERV')
-          @$("#OBSERV_#{index}").val(val)
+      for val, index in @model.get('OBSERV')
+        @$("#OBSERV_#{index}").val(val)
 
   toggleUnits: (e) ->
     if @model.get('OBSERV_UNIT') == ' mins'

--- a/app/assets/javascripts/views/patient_builder/expected_values.js.coffee
+++ b/app/assets/javascripts/views/patient_builder/expected_values.js.coffee
@@ -101,7 +101,6 @@ class Thorax.Views.ExpectedValueView extends Thorax.Views.BuilderChildView
       DENEX:    'EXCL'
       MSRPOPL:  'MSRPOPL'
       OBSERV:   'OBSERV'
-    @filter = not @measure.get('episode_of_care') and not @measure.get('continuous_variable')
     @popoverVisible ?= false
     @parseValues()
 
@@ -116,7 +115,7 @@ class Thorax.Views.ExpectedValueView extends Thorax.Views.BuilderChildView
         isEoC: @measure.get('episode_of_care')
         value: @model.get(pc)
     unless @model.has('OBSERV_UNIT') or not @measure.get('continuous_variable') then @model.set 'OBSERV_UNIT', ' mins', {silent:true}
-    if @filter then @setValues = _(@currentCriteria).filter( (pc) => pc.value ) else @setValues = @currentCriteria
+    if not @measure.get('episode_of_care') then @setValues = _(@currentCriteria).filter( (pc) => pc.value ) else @setValues = @currentCriteria
 
   updateObserv: ->
     @model.set @serialize() if @popoverVisible

--- a/app/assets/javascripts/views/patient_builder/expected_values.js.coffee
+++ b/app/assets/javascripts/views/patient_builder/expected_values.js.coffee
@@ -57,7 +57,7 @@ class Thorax.Views.ExpectedValueView extends Thorax.Views.BuilderChildView
     serialize: (attr) ->
       population = @measure.get('populations').at @model.get('population_index')
       for pc in @measure.populationCriteria() when population.has(pc) and _(attr).size()
-        if @measure.get('episode_of_care') || (@measure.get('continuous_variable') && (pc == 'OBSERV' || pc == 'MSRPOPL'))
+        if @measure.get('episode_of_care') || (@measure.get('continuous_variable') && pc == 'OBSERV')
           # Only parse existing values
           if attr[pc]
             if pc == 'OBSERV'
@@ -87,7 +87,7 @@ class Thorax.Views.ExpectedValueView extends Thorax.Views.BuilderChildView
   context: ->
     context = super
     for pc in @measure.populationCriteria()
-      unless @measure.get('episode_of_care') || (@measure.get('continuous_variable') && (pc == 'OBSERV' || pc == 'MSRPOPL'))
+      unless @measure.get('episode_of_care') || (@measure.get('continuous_variable') && pc == 'OBSERV')
         context[pc] = (context[pc] == 1)
     context
 

--- a/app/assets/javascripts/views/patient_builder/expected_values.js.coffee
+++ b/app/assets/javascripts/views/patient_builder/expected_values.js.coffee
@@ -71,7 +71,9 @@ class Thorax.Views.ExpectedValueView extends Thorax.Views.BuilderChildView
           attr[pc] = if attr[pc] then 1 else 0 # Convert from check-box true/false to 0/1
     'blur input': 'triggerMaterialize'
     'blur input[name="MSRPOPL"]': 'updateObserv'
-    'rendered': 'setObservs'
+    rendered: -> 
+      @$('.btn-expected-value').popover(content: @$('.popover-tmpl').text())
+      @setObservs()
 
   context: ->
     context = super
@@ -98,6 +100,7 @@ class Thorax.Views.ExpectedValueView extends Thorax.Views.BuilderChildView
         key: pc
         displayName: criteriaMap[pc]
         isEoC: @measure.get('episode_of_care')
+        value: @model.get(pc)
     unless @model.has('OBSERV_UNIT') or not @measure.get('continuous_variable') then @model.set 'OBSERV_UNIT', ' mins', {silent:true}
 
   updateObserv: ->

--- a/app/assets/stylesheets/builder.less
+++ b/app/assets/stylesheets/builder.less
@@ -104,6 +104,7 @@
       background-color: @gray-lighter;
     }
     .tab-content {
+      padding-left: 10px;
       padding-bottom: 10px;
       h2, h3 {
         &:extend(h2);

--- a/app/assets/stylesheets/builder.less
+++ b/app/assets/stylesheets/builder.less
@@ -111,7 +111,9 @@
         margin-top: 0;
         padding-top: 6px;
       }
-
+      .span-expected-values {
+        word-wrap: break-word;
+      }
       .form-inline {
         .form-group {
           padding-right: 10px;

--- a/app/assets/stylesheets/builder.less
+++ b/app/assets/stylesheets/builder.less
@@ -127,6 +127,9 @@
           input[name=OBSERV] {
             width: 45px;
           }
+          .btn-observ-unit-perc, .btn-observ-unit-mins {
+            opacity: 1.0;
+          }
         }
         .list-group {
           margin-bottom: 0;

--- a/app/assets/stylesheets/builder.less
+++ b/app/assets/stylesheets/builder.less
@@ -125,6 +125,16 @@
             width: 45px;
           }
         }
+        .list-group {
+          margin-bottom: 0;
+          .list-group-item {
+            padding: 5px 5px;
+            border: none;
+            .expected-value-checkbox {
+              vertical-align: top;
+            }
+          }
+        }
       }
     }
   }

--- a/spec/javascripts/views/patient_builder_spec.js.coffee
+++ b/spec/javascripts/views/patient_builder_spec.js.coffee
@@ -257,6 +257,7 @@ describe 'PatientBuilderView', ->
   describe "setting expected values", ->
     beforeEach ->
       @patientBuilder.appendTo 'body'
+      @patientBuilder.$(".btn-expected-value").click() #open the popover before setting the expected value
       @patientBuilder.$('input[type=checkbox][name=DENOM]:first').click()
       @patientBuilder.$("button[data-call-method=save]").click()
 


### PR DESCRIPTION
### Story
- https://www.pivotaltracker.com/story/show/63991566
- https://www.pivotaltracker.com/story/show/65923976 (included fix for MSRPOPL as checkbox for patient-based CV measures)
### Notes
- replaced expected values section in patient builder with static display with the following features:
  - for checkboxes, only the checked populations appear, otherwise <code>None</code> is displayed
  - for EoC measures, all populations are displayed with numerical expected values displayed
  - for CV measures, the IPP behaves like checkboxes, the MSRPOPL behaves like EoC populations, and OBSERV has special behavior where updating MSRPOPL re-renders the popover with the changed value of OBSERV fields
- removed empty population title header from patient builder population logic view template
### Screenshots
- checkboxes, not filled
  - ![checkboxempty](https://cloud.githubusercontent.com/assets/456952/3028872/b8d448c6-e02f-11e3-8fc2-29d73e846ea7.png)
- checkboxes, filled
  - ![checkboxfilled](https://cloud.githubusercontent.com/assets/456952/3028870/b8d40d48-e02f-11e3-84d3-4e18749eb122.png)
- EoC, filled
  - ![eocfilled](https://cloud.githubusercontent.com/assets/456952/3028871/b8d4150e-e02f-11e3-8f25-0db90b1b10fa.png)
- CV, not filled
  - ![screen shot 2014-05-20 at 11 04 18 am](https://cloud.githubusercontent.com/assets/456952/3028905/10ec3f3c-e030-11e3-8aef-d94479d948f6.png)
- CV, filled
  - ![cvfilled](https://cloud.githubusercontent.com/assets/456952/3028869/b8d3b6a4-e02f-11e3-95b8-816be0181c5c.png)
- CV, filled & units toggled
  - ![cvfilledtoggled](https://cloud.githubusercontent.com/assets/456952/3028867/b8d35222-e02f-11e3-952e-80c6df6149d3.png)
