### PR TITLE
Enable date shifting a user's patient records via rake task

### DIFF
--- a/app/assets/javascripts/models/data_criteria.js.coffee
+++ b/app/assets/javascripts/models/data_criteria.js.coffee
@@ -12,7 +12,7 @@ class Thorax.Models.MeasureDataCriteria extends Thorax.Model
     new Thorax.Models.PatientDataCriteria attr
 
   getDefaultTime: ->
-    parseInt(moment.utc().set('year', 2012).set('hour',8).set('minute',0).set('second',0).format('X'))*1000
+    parseInt(moment.utc().set('year', bonnie.measurePeriod).set('hour',8).set('minute',0).set('second',0).format('X'))*1000
 
 class Thorax.Collections.MeasureDataCriteria extends Thorax.Collection
   model: Thorax.Models.MeasureDataCriteria

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -52,7 +52,7 @@ class Admin::UsersController < ApplicationController
 
   def bundle
     user = User.find(params[:id])
-    exporter = Measures::Exporter::BundleExporter.new(user, version: '1.0', hqmfjs_libraries_version: APP_CONFIG['hqmfjs_libraries_version'], effective_date: ( Time.at(APP_CONFIG['measure_period_start']).utc + 1.year - 1.day + 23.hours + 59.minutes ).to_i)
+    exporter = Measures::Exporter::BundleExporter.new(user, version: '1.0', hqmfjs_libraries_version: APP_CONFIG['hqmfjs_libraries_version'], effective_date: ( Time.at(APP_CONFIG['measure_period_start']).utc + 1.year - 1.minute ).to_i)
     zip_data = exporter.export_zip
 
     cookies[:fileDownload] = "true" # We need to set this cookie for jquery.fileDownload

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -52,7 +52,7 @@ class Admin::UsersController < ApplicationController
 
   def bundle
     user = User.find(params[:id])
-    exporter = Measures::Exporter::BundleExporter.new(user, version: '1.0', hqmfjs_libraries_version: APP_CONFIG['hqmfjs_libraries_version'])
+    exporter = Measures::Exporter::BundleExporter.new(user, version: '1.0', hqmfjs_libraries_version: APP_CONFIG['hqmfjs_libraries_version'], effective_date: ( Time.at(APP_CONFIG['measure_period_start']).utc + 1.year - 1.day + 23.hours + 59.minutes ).to_i)
     zip_data = exporter.export_zip
 
     cookies[:fileDownload] = "true" # We need to set this cookie for jquery.fileDownload

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -38,8 +38,8 @@ class PatientsController < ApplicationController
     html_exporter = HealthDataStandards::Export::HTML.new
 
     measure = Measure.by_user(current_user).where({:hqmf_set_id => params[:hqmf_set_id]}).map(&:as_hqmf_model)
-    start_time = Time.new(2012, 1, 1)
-    end_time = Time.new(2012, 12, 31)
+    start_time = Time.new(Time.zone.at(APP_CONFIG['measure_period_start']).year, 1, 1)
+    end_time = Time.new(Time.zone.at(APP_CONFIG['measure_period_start']).year, 12, 31)
 
     # if we have results we want to write a summary
     summary_content = get_summary_content(measure, records, params[:results].values) if (params[:results])

--- a/lib/bonnie_measure_javascript.erb
+++ b/lib/bonnie_measure_javascript.erb
@@ -9,7 +9,7 @@
     var enable_logging = false;
     var enable_rationale = true;
     var short_circuit = false;
-    <% if APP_CONFIG['measure_period_start']%>var effective_date = <%= ( Time.at(APP_CONFIG['measure_period_start']).utc + 1.year - 1.day + 23.hours + 59.minutes ).to_i%>;<% end %>
+    <% if APP_CONFIG['measure_period_start']%>var effective_date = <%= ( Time.at(APP_CONFIG['measure_period_start']).utc + 1.year - 1.minute ).to_i%>;<% end %>
 
     ObjectId = function() { return 1; };
     var result = null; // Calls to emit() set this local variable

--- a/lib/bonnie_measure_javascript.erb
+++ b/lib/bonnie_measure_javascript.erb
@@ -9,6 +9,7 @@
     var enable_logging = false;
     var enable_rationale = true;
     var short_circuit = false;
+    <% if APP_CONFIG['measure_period_start']%>var effective_date = <%= ( Time.at(APP_CONFIG['measure_period_start']).utc + 1.year - 1.day + 23.hours + 59.minutes ).to_i%>;<% end %>
 
     ObjectId = function() { return 1; };
     var result = null; // Calls to emit() set this local variable

--- a/lib/tasks/bonnie.rake
+++ b/lib/tasks/bonnie.rake
@@ -308,17 +308,24 @@ namespace :bonnie do
       direction = 'forward' if !direction.downcase == 'backward'
       puts "Shifting dates #{direction} [ #{years}ys, #{months}mos, #{weeks}wks, #{days}d, #{hours}hrs, #{minutes}mins, #{seconds}s ] for source_data_criteria start/stop dates and birth/death dates on all associated patient records for #{user.email}"
       direction.downcase == 'backward' ? dir = -1 : dir = 1
+      timestamps = ['FACILITY_LOCATION_ARRIVAL_DATETIME','FACILITY_LOCATION_DEPARTURE_DATETIME','DISCHARGE_DATETIME','ADMISSION_DATETIME','START_DATETIME','STOP_DATETIME','INCISION_DATETIME','REMOVAL_DATETIME']
       Record.by_user(user).each do |patient|
-        patient.birthdate = ( Time.at(patient.birthdate ).utc + dir * ( years.to_i.years + months.to_i.months + weeks.to_i.weeks + days.to_i.days + hours.to_i.hours + minutes.to_i.minutes + seconds.to_i.seconds ) ).to_i
+        patient.birthdate = ( Time.at( patient.birthdate ).utc + dir * ( years.to_i.years + months.to_i.months + weeks.to_i.weeks + days.to_i.days + hours.to_i.hours + minutes.to_i.minutes + seconds.to_i.seconds ) ).to_i
         if patient.expired
-          patient.deathdate = ( Time.at(patient.deathdate ).utc + dir * ( years.to_i.years + months.to_i.months + weeks.to_i.weeks + days.to_i.days + hours.to_i.hours + minutes.to_i.minutes + seconds.to_i.seconds ) ).to_i
+          patient.deathdate = ( Time.at( patient.deathdate ).utc + dir * ( years.to_i.years + months.to_i.months + weeks.to_i.weeks + days.to_i.days + hours.to_i.hours + minutes.to_i.minutes + seconds.to_i.seconds ) ).to_i
         end
         patient.source_data_criteria.each do |sdc|
           unless sdc["start_date"].blank?
-            sdc["start_date"] = ( Time.at(sdc["start_date"] / 1000 ).utc + dir * ( years.to_i.years + months.to_i.months + weeks.to_i.weeks + days.to_i.days + hours.to_i.hours + minutes.to_i.minutes + seconds.to_i.seconds ) ).to_i * 1000
+            sdc["start_date"] = ( Time.at( sdc["start_date"] / 1000 ).utc + dir * ( years.to_i.years + months.to_i.months + weeks.to_i.weeks + days.to_i.days + hours.to_i.hours + minutes.to_i.minutes + seconds.to_i.seconds ) ).to_i * 1000
           end
           unless sdc["end_date"].blank?
-            sdc["end_date"] = ( Time.at(sdc["end_date"] / 1000 ).utc + dir * ( years.to_i.years + months.to_i.months + weeks.to_i.weeks + days.to_i.days + hours.to_i.hours + minutes.to_i.minutes + seconds.to_i.seconds ) ).to_i * 1000
+            sdc["end_date"] = ( Time.at( sdc["end_date"] / 1000 ).utc + dir * ( years.to_i.years + months.to_i.months + weeks.to_i.weeks + days.to_i.days + hours.to_i.hours + minutes.to_i.minutes + seconds.to_i.seconds ) ).to_i * 1000
+          end
+          unless sdc['field_values'].blank?
+            sdc_timestamps = timestamps & sdc['field_values'].keys
+            sdc_timestamps.each do |sdc_timestamp|
+              sdc['field_values'][sdc_timestamp]['value'] = ( Time.at( sdc['field_values'][sdc_timestamp]['value'] / 1000 ).utc + dir * ( years.to_i.years + months.to_i.months + weeks.to_i.weeks + days.to_i.days + hours.to_i.hours + minutes.to_i.minutes + seconds.to_i.seconds ) ).to_i * 1000
+            end
           end
         end
         Measures::PatientBuilder.rebuild_patient(patient)

--- a/lib/tasks/bonnie.rake
+++ b/lib/tasks/bonnie.rake
@@ -303,14 +303,8 @@ namespace :bonnie do
     task :date_shift => :environment do
       user_email = ENV['EMAIL'] || User.first.email
       user = User.where(email: user_email).first
+      seconds, minutes, hours, days, weeks, months, years = ENV['SECONDS'] || 0, ENV['MINUTES'] || 0, ENV['HOURS'] || 0, ENV['DAYS'] || 0, ENV['WEEKS'] || 0, ENV['MONTHS'] || 0, ENV['YEARS'] || 0
       direction = ENV['DIR'] || 'forward'
-      seconds = ENV['SECONDS'] || 0
-      minutes = ENV['MINUTES'] || 0
-      hours = ENV['HOURS'] || 0
-      days = ENV['DAYS'] || 0
-      weeks = ENV['WEEKS'] || 0
-      months = ENV['MONTHS'] || 0
-      years = ENV['YEARS'] || 0
       direction = 'forward' if !direction.downcase == 'backward'
       puts "Shifting dates #{direction} [ #{years}ys, #{months}mos, #{weeks}wks, #{days}d, #{hours}hrs, #{minutes}mins, #{seconds}s ] for source_data_criteria on all associated patient records for #{user.email}"
       direction.downcase == 'backward' ? dir = -1 : dir = 1

--- a/lib/tasks/bonnie.rake
+++ b/lib/tasks/bonnie.rake
@@ -303,28 +303,29 @@ namespace :bonnie do
     task :date_shift => :environment do
       user_email = ENV['EMAIL'] || User.first.email
       user = User.where(email: user_email).first
-      seconds, minutes, hours, days, weeks, months, years = ENV['SECONDS'] || 0, ENV['MINUTES'] || 0, ENV['HOURS'] || 0, ENV['DAYS'] || 0, ENV['WEEKS'] || 0, ENV['MONTHS'] || 0, ENV['YEARS'] || 0
       direction = ENV['DIR'] || 'forward'
       direction = 'forward' if !direction.downcase == 'backward'
+      seconds, minutes, hours, days, weeks, months, years = ENV['SECONDS'] || 0, ENV['MINUTES'] || 0, ENV['HOURS'] || 0, ENV['DAYS'] || 0, ENV['WEEKS'] || 0, ENV['MONTHS'] || 0, ENV['YEARS'] || 0
       puts "Shifting dates #{direction} [ #{years}ys, #{months}mos, #{weeks}wks, #{days}d, #{hours}hrs, #{minutes}mins, #{seconds}s ] for source_data_criteria start/stop dates and birth/death dates on all associated patient records for #{user.email}"
       direction.downcase == 'backward' ? dir = -1 : dir = 1
+      seconds, minutes, hours, days, weeks, months, years = dir * seconds.to_i, dir * minutes.to_i, dir * hours.to_i, dir * days.to_i, dir * weeks.to_i, dir * months.to_i, dir * years.to_i
       timestamps = ['FACILITY_LOCATION_ARRIVAL_DATETIME','FACILITY_LOCATION_DEPARTURE_DATETIME','DISCHARGE_DATETIME','ADMISSION_DATETIME','START_DATETIME','STOP_DATETIME','INCISION_DATETIME','REMOVAL_DATETIME']
       Record.by_user(user).each do |patient|
-        patient.birthdate = ( Time.at( patient.birthdate ).utc + dir * ( years.to_i.years + months.to_i.months + weeks.to_i.weeks + days.to_i.days + hours.to_i.hours + minutes.to_i.minutes + seconds.to_i.seconds ) ).to_i
+        patient.birthdate = ( Time.at( patient.birthdate ).utc.advance( :years => years, :months => months, :weeks => weeks, :days => days, :hours => hours, :minutes => minutes, :seconds => seconds ) ).to_i
         if patient.expired
-          patient.deathdate = ( Time.at( patient.deathdate ).utc + dir * ( years.to_i.years + months.to_i.months + weeks.to_i.weeks + days.to_i.days + hours.to_i.hours + minutes.to_i.minutes + seconds.to_i.seconds ) ).to_i
+          patient.deathdate = ( Time.at( patient.deathdate ).utc.advance( :years => years, :months => months, :weeks => weeks, :days => days, :hours => hours, :minutes => minutes, :seconds => seconds ) ).to_i
         end
         patient.source_data_criteria.each do |sdc|
           unless sdc["start_date"].blank?
-            sdc["start_date"] = ( Time.at( sdc["start_date"] / 1000 ).utc + dir * ( years.to_i.years + months.to_i.months + weeks.to_i.weeks + days.to_i.days + hours.to_i.hours + minutes.to_i.minutes + seconds.to_i.seconds ) ).to_i * 1000
+            sdc["start_date"] = ( Time.at( sdc["start_date"] / 1000 ).utc.advance( :years => years, :months => months, :weeks => weeks, :days => days, :hours => hours, :minutes => minutes, :seconds => seconds ) ).to_i * 1000
           end
           unless sdc["end_date"].blank?
-            sdc["end_date"] = ( Time.at( sdc["end_date"] / 1000 ).utc + dir * ( years.to_i.years + months.to_i.months + weeks.to_i.weeks + days.to_i.days + hours.to_i.hours + minutes.to_i.minutes + seconds.to_i.seconds ) ).to_i * 1000
+            sdc["end_date"] = ( Time.at( sdc["end_date"] / 1000 ).utc.advance( :years => years, :months => months, :weeks => weeks, :days => days, :hours => hours, :minutes => minutes, :seconds => seconds ) ).to_i * 1000
           end
           unless sdc['field_values'].blank?
             sdc_timestamps = timestamps & sdc['field_values'].keys
             sdc_timestamps.each do |sdc_timestamp|
-              sdc['field_values'][sdc_timestamp]['value'] = ( Time.at( sdc['field_values'][sdc_timestamp]['value'] / 1000 ).utc + dir * ( years.to_i.years + months.to_i.months + weeks.to_i.weeks + days.to_i.days + hours.to_i.hours + minutes.to_i.minutes + seconds.to_i.seconds ) ).to_i * 1000
+              sdc['field_values'][sdc_timestamp]['value'] = ( Time.at( sdc['field_values'][sdc_timestamp]['value'] / 1000 ).utc.advance( :years => years, :months => months, :weeks => weeks, :days => days, :hours => hours, :minutes => minutes, :seconds => seconds ) ).to_i * 1000
             end
           end
         end


### PR DESCRIPTION
### Story
- https://www.pivotaltracker.com/story/show/63411726
### Notes
- added `rake bonnie:patients:date_shift` rake task with `EMAIL, DIR, SECONDS, MINUTES, HOURS, DAYS, WEEKS, MONTHS, YEARS` arguments
  - Use `EMAIL` to denote the user to scope the date_shift for all associated patients' source data criteria; first user by default.
  - Use `DIR` to denote direction [forward, backward]; direction is forward by default.
  - Use `SECONDS, MINUTES, HOURS, DAYS, WEEKS, MONTHS, YEARS` to denote time offset [###]; offsets are 0 by default.
- updated Patient Data Criteria model to use `bonnie.measurePeriod` when specifying the default dates for a dropped data criteria in the patient builder
- passed in bonnie.yml's `measure_start_period` into export action for the users_controller when exporting a user bundle within the admin users view
- specified an `effective_date` variable in the measure javascript containing bonnie.yml's `measure_start_period` (with computation for the end date)
