### PR TITLE
hide icons from screen readers 

### DIFF
--- a/app/assets/javascripts/templates/import/import_measure.hbs
+++ b/app/assets/javascripts/templates/import/import_measure.hbs
@@ -41,7 +41,7 @@
               <div class="col-lg-{{dataSize}}">
                 <input type="password" class="form-control" id="vsacPassword" name="vsac_password" placeholder="password">
               </div>
-              <div class="col-lg-offset-{{titleSize}} vsac-registration"><a href="https://uts.nlm.nih.gov/license.html" target="_blank"><i class="fa fa-plus-circle"></i> Register for VSAC</a></div>
+              <div class="col-lg-offset-{{titleSize}} vsac-registration"><a href="https://uts.nlm.nih.gov/license.html" target="_blank"><i class="fa fa-plus-circle" aria-hidden="true"></i> Register for VSAC</a></div>
             </div>
           </div>
           <div class="form-group">

--- a/app/assets/javascripts/templates/logic/population_criteria.hbs
+++ b/app/assets/javascripts/templates/logic/population_criteria.hbs
@@ -5,7 +5,7 @@
         <div>
           <span class="population-label {{population.type}} rationale-target"><b>{{translate_population population.type}}: </b><span class="sr-only sr-highlight-status"></span></span>
           <div class="pull-right">
-            <i class="fa fa-lg fa-angle-down toggle-icon"></i>
+            <i class="fa fa-lg fa-angle-down toggle-icon" aria-hidden="true"></i>
             <span class="sr-only">toggle {{translate_population population.type}}</span>
           </div>
         </div>

--- a/app/assets/javascripts/templates/measure.hbs
+++ b/app/assets/javascripts/templates/measure.hbs
@@ -1,14 +1,14 @@
  <div class="main col-sm-8">
   <div class="measure-title">
-    <div class="short-title"><i class="fa fa-tasks"></i> {{cms_id}}: </div>
+    <div class="short-title"><i class="fa fa-tasks" aria-hidden="true"></i> {{cms_id}}: </div>
     <div class="full-title">{{title}}</div>
     <span class="settings-container">
       <div class="measure-settings">
-        {{#button "updateMeasure" class="btn btn-default update-measure"}}<i class="fa fa-upload"></i> Update{{/button}}
-        {{#button "deleteMeasure" class="btn btn-danger delete-measure hide"}}<i class="fa fa-times"></i> Delete{{/button}}
-        {{#button "showDelete" class="btn btn-danger-inverse delete-icon"}}<i class="fa fa-minus-circle"></i> <span class="sr-only">Show Delete</span>{{/button}}
+        {{#button "updateMeasure" class="btn btn-default update-measure"}}<i class="fa fa-upload" aria-hidden="true"></i> Update{{/button}}
+        {{#button "deleteMeasure" class="btn btn-danger delete-measure hide"}}<i class="fa fa-times" aria-hidden="true"></i> Delete{{/button}}
+        {{#button "showDelete" class="btn btn-danger-inverse delete-icon"}}<i class="fa fa-minus-circle" aria-hidden="true"></i> <span class="sr-only">Show Delete</span>{{/button}}
       </div>
-      {{#button "measureSettings" tag="a" class="btn-settings" href=""}}<i class="fa fa-cog"></i> <span class="sr-only">Measure Settings</span>{{/button}}
+      {{#button "measureSettings" tag="a" class="btn-settings" href=""}}<i class="fa fa-cog" aria-hidden="true"></i> <span class="sr-only">Measure Settings</span>{{/button}}
     </span>
   </div>
   <div class="measure-dsp">
@@ -37,21 +37,21 @@
 
 <div class="right-sidebar">
   <div class="patients-title">
-    <span class="short-title pull-left"><i class="fa fa-user fa-fw"></i>Test Patients</span>
+    <span class="short-title pull-left"><i class="fa fa-user fa-fw" aria-hidden="true"></i>Test Patients</span>
     <span class="settings-container">
       <div class="patients-settings">
-        {{#button "exportPatients" class="btn btn-default export-patients"}}<i class="fa fa-download"></i> Export{{/button}}
+        {{#button "exportPatients" class="btn btn-default export-patients"}}<i class="fa fa-download" aria-hidden="true"></i> Export{{/button}}
         {{#empty patients}}
-          {{#button "toggleMeasureListing" class="btn btn-default btn-measure-listing toggle-measure-listing" disabled="disabled"}}<i class="fa fa-users"></i> <i class="fa fa-arrow-right"></i> <i class="fa fa-tasks"></i>{{/button}}
+          {{#button "toggleMeasureListing" class="btn btn-default btn-measure-listing toggle-measure-listing" disabled="disabled"}}<i class="fa fa-users" aria-hidden="true"></i> <i class="fa fa-arrow-right" aria-hidden="true"></i> <i class="fa fa-tasks" aria-hidden="true"></i>{{/button}}
         {{else}}
           {{#ifCond measures.length "<=" "1"}}
-            {{#button "toggleMeasureListing" class="btn btn-default btn-measure-listing toggle-measure-listing" disabled="disabled"}}<i class="fa fa-users"></i> <i class="fa fa-arrow-right"></i> <i class="fa fa-tasks"></i>{{/button}}
+            {{#button "toggleMeasureListing" class="btn btn-default btn-measure-listing toggle-measure-listing" disabled="disabled"}}<i class="fa fa-users" aria-hidden="true"></i> <i class="fa fa-arrow-right" aria-hidden="true"></i> <i class="fa fa-tasks" aria-hidden="true"></i>{{/button}}
           {{else}}
-            {{#button "toggleMeasureListing" class="btn btn-default btn-measure-listing toggle-measure-listing"}}<i class="fa fa-users"></i> <i class="fa fa-arrow-right"></i> <i class="fa fa-tasks"></i>{{/button}}
+            {{#button "toggleMeasureListing" class="btn btn-default btn-measure-listing toggle-measure-listing"}}<i class="fa fa-users" aria-hidden="true"></i> <i class="fa fa-arrow-right" aria-hidden="true"></i> <i class="fa fa-tasks" aria-hidden="true"></i>{{/button}}
           {{/ifCond}}
         {{/empty}}
       </div>
-      {{#button "patientsSettings" tag="a" class="btn-settings" href=""}}<i class="fa fa-cog"></i> <span class="sr-only">Patient Options</span>{{/button}}
+      {{#button "patientsSettings" tag="a" class="btn-settings" href=""}}<i class="fa fa-cog" aria-hidden="true"></i> <span class="sr-only">Patient Options</span>{{/button}}
     </span>
   </div>
   <span class="patients-listing-header" style="display:none;">Select Patients to Clone:</span>

--- a/app/assets/javascripts/templates/measure.hbs
+++ b/app/assets/javascripts/templates/measure.hbs
@@ -42,12 +42,12 @@
       <div class="patients-settings">
         {{#button "exportPatients" class="btn btn-default export-patients"}}<i class="fa fa-download" aria-hidden="true"></i> Export{{/button}}
         {{#empty patients}}
-          {{#button "toggleMeasureListing" class="btn btn-default btn-measure-listing toggle-measure-listing" disabled="disabled"}}<i class="fa fa-users" aria-hidden="true"></i> <i class="fa fa-arrow-right" aria-hidden="true"></i> <i class="fa fa-tasks" aria-hidden="true"></i>{{/button}}
+          {{#button "toggleMeasureListing" class="btn btn-default btn-measure-listing toggle-measure-listing" disabled="disabled"}}<i class="fa fa-users" aria-hidden="true"></i> <i class="fa fa-arrow-right" aria-hidden="true"></i> <i class="fa fa-tasks" aria-hidden="true"></i><span class="sr-only">Toggle measure listing</span>{{/button}}
         {{else}}
           {{#ifCond measures.length "<=" "1"}}
-            {{#button "toggleMeasureListing" class="btn btn-default btn-measure-listing toggle-measure-listing" disabled="disabled"}}<i class="fa fa-users" aria-hidden="true"></i> <i class="fa fa-arrow-right" aria-hidden="true"></i> <i class="fa fa-tasks" aria-hidden="true"></i>{{/button}}
+            {{#button "toggleMeasureListing" class="btn btn-default btn-measure-listing toggle-measure-listing" disabled="disabled"}}<i class="fa fa-users" aria-hidden="true"></i> <i class="fa fa-arrow-right" aria-hidden="true"></i> <i class="fa fa-tasks" aria-hidden="true"></i><span class="sr-only">Toggle measure listing</span>{{/button}}
           {{else}}
-            {{#button "toggleMeasureListing" class="btn btn-default btn-measure-listing toggle-measure-listing"}}<i class="fa fa-users" aria-hidden="true"></i> <i class="fa fa-arrow-right" aria-hidden="true"></i> <i class="fa fa-tasks" aria-hidden="true"></i>{{/button}}
+            {{#button "toggleMeasureListing" class="btn btn-default btn-measure-listing toggle-measure-listing"}}<i class="fa fa-users" aria-hidden="true"></i> <i class="fa fa-arrow-right" aria-hidden="true"></i> <i class="fa fa-tasks" aria-hidden="true"></i><span class="sr-only">Toggle measure listing</span>{{/button}}
           {{/ifCond}}
         {{/empty}}
       </div>

--- a/app/assets/javascripts/templates/measure/coverage.hbs
+++ b/app/assets/javascripts/templates/measure/coverage.hbs
@@ -10,7 +10,7 @@
       <span class="status status-coverage">% COVERAGE</span>
     </div>
     <div class="coverage-data">
-      {{#button "identifyCoverage" class="btn btn-default btn-show-coverage"}}<i class="fa fa-bar-chart-o"></i> Show{{/button}}
+      {{#button "identifyCoverage" class="btn btn-default btn-show-coverage"}}<i class="fa fa-bar-chart-o" aria-hidden="true"></i> Show{{/button}}
     </div>
   {{/ifCond}}
 </div>

--- a/app/assets/javascripts/templates/measure_debug.hbs
+++ b/app/assets/javascripts/templates/measure_debug.hbs
@@ -9,7 +9,7 @@
 <div data-toggle="buttons-checkbox">
   {{#collection patients item-context="patientContext"}}
     {{#button 'togglePatient' class='btn btn-primary toggle-patient' style='width: 180px; margin: 5px 5px 0px 0px;'}}
-      {{last}}, {{first}} {{#if inMeasure}}<i class="fa fa-tag" style="padding-left: 10px;"></i>{{/if}}
+      {{last}}, {{first}} {{#if inMeasure}}<i class="fa fa-tag" style="padding-left: 10px;" aria-hidden="true"></i>{{/if}}
     {{/button}}
   {{/collection}}
 </div>
@@ -37,11 +37,11 @@
   {{#collection results tag="tbody"}}
     <tr>
       <td>{{last}}, {{first}}</td>
-      <td style="text-align: center;">{{#if IPP}}<i class="fa fa-check"></i>{{/if}}</td>
-      <td style="text-align: center;">{{#if DENOM}}<i class="fa fa-check"></i>{{/if}}</td>
-      <td style="text-align: center;">{{#if NUMER}}<i class="fa fa-check"></i>{{/if}}</td>
-      <td style="text-align: center;">{{#if DENEX}}<i class="fa fa-check"></i>{{/if}}</td>
-      <td style="text-align: center;">{{#if DENEXCEP}}<i class="fa fa-check"></i>{{/if}}</td>
+      <td style="text-align: center;">{{#if IPP}}<i class="fa fa-check" aria-hidden="true"></i>{{/if}}</td>
+      <td style="text-align: center;">{{#if DENOM}}<i class="fa fa-check" aria-hidden="true"></i>{{/if}}</td>
+      <td style="text-align: center;">{{#if NUMER}}<i class="fa fa-check" aria-hidden="true"></i>{{/if}}</td>
+      <td style="text-align: center;">{{#if DENEX}}<i class="fa fa-check" aria-hidden="true"></i>{{/if}}</td>
+      <td style="text-align: center;">{{#if DENEXCEP}}<i class="fa fa-check" aria-hidden="true"></i>{{/if}}</td>
     </tr>
   {{/collection}}
 </table>

--- a/app/assets/javascripts/templates/measure_debug.hbs
+++ b/app/assets/javascripts/templates/measure_debug.hbs
@@ -9,7 +9,7 @@
 <div data-toggle="buttons-checkbox">
   {{#collection patients item-context="patientContext"}}
     {{#button 'togglePatient' class='btn btn-primary toggle-patient' style='width: 180px; margin: 5px 5px 0px 0px;'}}
-      {{last}}, {{first}} {{#if inMeasure}}<i class="fa fa-tag" style="padding-left: 10px;" aria-hidden="true"></i>{{/if}}
+      {{last}}, {{first}} {{#if inMeasure}}<i class="fa fa-tag" style="padding-left: 10px;" aria-hidden="true"></i><span class="sr-only">in measure</span>{{/if}}
     {{/button}}
   {{/collection}}
 </div>
@@ -37,11 +37,11 @@
   {{#collection results tag="tbody"}}
     <tr>
       <td>{{last}}, {{first}}</td>
-      <td style="text-align: center;">{{#if IPP}}<i class="fa fa-check" aria-hidden="true"></i>{{/if}}</td>
-      <td style="text-align: center;">{{#if DENOM}}<i class="fa fa-check" aria-hidden="true"></i>{{/if}}</td>
-      <td style="text-align: center;">{{#if NUMER}}<i class="fa fa-check" aria-hidden="true"></i>{{/if}}</td>
-      <td style="text-align: center;">{{#if DENEX}}<i class="fa fa-check" aria-hidden="true"></i>{{/if}}</td>
-      <td style="text-align: center;">{{#if DENEXCEP}}<i class="fa fa-check" aria-hidden="true"></i>{{/if}}</td>
+      <td style="text-align: center;">{{#if IPP}}<i class="fa fa-check" aria-hidden="true"></i><span class="sr-only">IPP</span>{{/if}}</td>
+      <td style="text-align: center;">{{#if DENOM}}<i class="fa fa-check" aria-hidden="true"></i><span class="sr-only">DENOM</span>{{/if}}</td>
+      <td style="text-align: center;">{{#if NUMER}}<i class="fa fa-check" aria-hidden="true"></i><span class="sr-only">NUMER</span>{{/if}}</td>
+      <td style="text-align: center;">{{#if DENEX}}<i class="fa fa-check" aria-hidden="true"></i><span class="sr-only">DENEX</span>{{/if}}</td>
+      <td style="text-align: center;">{{#if DENEXCEP}}<i class="fa fa-check" aria-hidden="true"></i><span class="sr-only">DENEXCEP</span>{{/if}}</td>
     </tr>
   {{/collection}}
 </table>

--- a/app/assets/javascripts/templates/measures.hbs
+++ b/app/assets/javascripts/templates/measures.hbs
@@ -5,7 +5,7 @@
     <div class="btn-wrapper pull-right">
       {{#button "importMeasure" class="btn btn-primary"}}<i class="fa fa-upload"></i> Upload <span class="sr-only">new measure</span>{{/button}}
     </div>
-    <h1><i class="glyphicon glyphicon-tasks"></i> Measures</h1>
+    <h1><i class="fa fa-tasks"></i> Measures</h1>
   </div>
   <div class="expected-col">
     <h2 aria-hidden="true">Expected</h2>

--- a/app/assets/javascripts/templates/measures.hbs
+++ b/app/assets/javascripts/templates/measures.hbs
@@ -3,9 +3,9 @@
 <div class="dashboard-heading row">
   <div class="measure-col">
     <div class="btn-wrapper pull-right">
-      {{#button "importMeasure" class="btn btn-primary"}}<i class="fa fa-upload"></i> Upload <span class="sr-only">new measure</span>{{/button}}
+      {{#button "importMeasure" class="btn btn-primary"}}<i class="fa fa-upload" aria-hidden="true"></i> Upload <span class="sr-only">new measure</span>{{/button}}
     </div>
-    <h1><i class="fa fa-tasks"></i> Measures</h1>
+    <h1><i class="fa fa-tasks" aria-hidden="true"></i> Measures</h1>
   </div>
   <div class="expected-col">
     <h2 aria-hidden="true">Expected</h2>
@@ -30,7 +30,7 @@
         </span>
       </div>
       <div class="btn-wrapper">
-        {{#button "updateMeasure" class="btn btn-primary"}}<i class="fa fa-refresh fa-fw"></i><span class="sr-only">{{cms_id}}, </span> Update <span class="sr-only">existing measure</span>{{/button}}
+        {{#button "updateMeasure" class="btn btn-primary"}}<i class="fa fa-refresh fa-fw" aria-hidden="true"></i><span class="sr-only">{{cms_id}}, </span> Update <span class="sr-only">existing measure</span>{{/button}}
       </div>
     </div>
     <div class="expected-col">
@@ -50,8 +50,8 @@
         {{view "MeasureFractionView" model=differences.summary cms_id=cms_id}}
       {{/if}}
       <a href="#measures/{{hqmf_set_id}}/patients/new" class="btn {{#unless patients.length}}btn-primary{{else}}btn-default{{/unless}}">
-        <i class="fa fa-user"></i>
-        <i class="fa fa-plus"></i>
+        <i class="fa fa-user" aria-hidden="true"></i>
+        <i class="fa fa-plus" aria-hidden="true"></i>
         <span class="sr-only">{{cms_id}}, add new patient to measure</span>
       </a>
     </div>

--- a/app/assets/javascripts/templates/patient_builder/edit_codes.hbs
+++ b/app/assets/javascripts/templates/patient_builder/edit_codes.hbs
@@ -19,7 +19,7 @@
 
   <div class="col-md-1">
     {{#button "addCode" class="btn btn-primary pull-right" disabled="disabled"}}
-      <i class="fa fa-plus"></i>
+      <i class="fa fa-plus" aria-hidden="true"></i>
       <span class="sr-only">add code</span>
     {{/button}}
   </div>

--- a/app/assets/javascripts/templates/patient_builder/edit_criteria.hbs
+++ b/app/assets/javascripts/templates/patient_builder/edit_criteria.hbs
@@ -1,5 +1,5 @@
 <div class="criteria-type-marker">
-  <i class="fa fa-fw fa-lg {{faIcon}}"></i>
+  <i class="fa fa-fw fa-lg {{faIcon}}" aria-hidden="true"></i>
 </div>
 <div class="criteria-body">
   <div class="criteria-data droppable">
@@ -16,7 +16,7 @@
             <div>{{start_date}}{{#if end_date}} &ndash; {{end_date}}{{/if}}</div>
           </div>
           {{#button "toggleDetails" class="close"}}
-            <i class="fa fa-lg fa-angle-right"></i>
+            <i class="fa fa-lg fa-angle-right" aria-hidden="true"></i>
             <span class="sr-only">Expand Data Criteria, {{definition}}, {{description}} </span>
             <span class="highlight-indicator sr-only"></span>
           {{/button}}
@@ -36,14 +36,14 @@
           <p><strong>{{definition}}:</strong> {{description}}</p>
         </div>
         {{#button "toggleDetails" class="close"}}
-          <i class="fa fa-lg fa-angle-down"></i>
+          <i class="fa fa-lg fa-angle-down" aria-hidden="true"></i>
           <span class="sr-only">Collapse Data Criteria, {{definition}}, {{description}}</span>
         {{/button}}
       </div>
 
       <div class="row">
         <div class="form-group col-md-6">
-          <label for="start_date_{{@cid}}" class="control-label"><i class="fa fa-clock-o"></i> Start<span class="sr-only">date month/day/year</span></label></label>
+          <label for="start_date_{{@cid}}" class="control-label"><i class="fa fa-clock-o" aria-hidden="true"></i> Start<span class="sr-only"> start date month/day/year</span></label></label>
           <div class="datetime-control">
             <div>
               <input type="text" name="start_date" id="start_date_{{@cid}}" class="date-picker form-control" placeholder="mm/dd/yyyy" data-date-format="mm/dd/yyyy" data-date-keyboard-navigation="false" data-date-autoclose="true">
@@ -57,7 +57,7 @@
         </div>
 
         <div class="form-group col-md-6">
-          <label for="end_date_{{@cid}}" class="control-label"><i class="fa fa-clock-o"></i> Stop<span class="sr-only"> date month/day/year</span></label>
+          <label for="end_date_{{@cid}}" class="control-label"><i class="fa fa-clock-o" aria-hidden="true"></i> Stop<span class="sr-only"> end date month/day/year</span></label>
           <div class="datetime-control">
             <div>
               <input type="text" name="end_date" id="end_date_{{@cid}}" class="date-picker form-control" placeholder="mm/dd/yyyy" data-date-format="mm/dd/yyyy" data-date-keyboard-navigation="false" data-date-autoclose="true"{{#if end_date_is_undefined}} disabled{{/if}}>
@@ -78,7 +78,7 @@
       </div>
 
       <div class="form-group">
-        <label class="control-label"><i class="fa fa-code"></i> Codes<input class="sr-only" disabled></label>
+        <label class="control-label"><i class="fa fa-code" aria-hidden="true"></i> Codes<input class="sr-only" disabled></label>
 
         {{#collection codes class="existing-values"}}
         <span>
@@ -92,7 +92,7 @@
       </div>
 
       <div class="form-group">
-        <label class="control-label"><i class="fa fa-bar-chart-o"></i> Value<input class="sr-only" disabled></label>
+        <label class="control-label"><i class="fa fa-bar-chart-o" aria-hidden="true"></i> Value<input class="sr-only" disabled></label>
 
         {{#collection value class="existing-values"}}
           <span>
@@ -106,7 +106,7 @@
       </div>
 
       <div class="form-group">
-        <label class="control-label"><i class="fa fa-bar-chart-o"></i> Field Value<input class="sr-only" disabled></label>
+        <label class="control-label"><i class="fa fa-bar-chart-o" aria-hidden="true"></i> Field Value<input class="sr-only" disabled></label>
 
         {{#collection field_values class="existing-values" item-context=valueWithDateContext}}
           <span>
@@ -143,7 +143,7 @@
       <div class="criteria-delete">
         <div class="pull-right">
           {{#button "showDelete" class="btn btn-danger-inverse criteria-delete-check"}}
-            <i class="fa fa-minus-circle"></i>
+            <i class="fa fa-minus-circle" aria-hidden="true"></i>
             <span class="sr-only">show delete</span>
           {{/button}}
           {{#button "removeCriteria" class="btn btn-danger hide"}}Delete{{/button}}

--- a/app/assets/javascripts/templates/patient_builder/edit_value.hbs
+++ b/app/assets/javascripts/templates/patient_builder/edit_value.hbs
@@ -58,7 +58,7 @@
 
   <div class="col-md-1">
     {{#button "addValue" class="btn btn-primary pull-right" disabled="disabled"}}
-      <i class="fa fa-plus"></i>
+      <i class="fa fa-plus" aria-hidden="true"></i>
       <span class="sr-only">add {{#if fieldValue}}field {{/if}}value</span>
     {{/button}}
   </div>

--- a/app/assets/javascripts/templates/patient_builder/patient_builder.hbs
+++ b/app/assets/javascripts/templates/patient_builder/patient_builder.hbs
@@ -12,7 +12,7 @@
   </div>
 
   <div class="col-md-6">
-    <div class="timeline-icon pull-left"><i class="fa fa-user fa-fw fa-4x"></i></div>
+    <div class="timeline-icon pull-left"><i class="fa fa-user fa-fw fa-4x" aria-hidden="true"></i></div>
     <div class="validation-alerts"><div class="alert alert-danger hidden"></div></div>
   </div>
 
@@ -99,7 +99,7 @@
                 <input type="text" id="deathtime" name="deathtime" class="time-picker form-control" placeholder="--:-- --" data-show-inputs="false" data-default-time="8:00 AM">
               </div>
               {{#button "removeDeathDate" class="btn btn-link remove-death-date"}}
-                <i class="fa fa-times-circle"></i>
+                <i class="fa fa-times-circle" aria-hidden="true"></i>
                 <span class="sr-only">remove date of death</span>
               {{/button}}
             </div>

--- a/app/assets/javascripts/templates/patient_builder/population_logic.hbs
+++ b/app/assets/javascripts/templates/patient_builder/population_logic.hbs
@@ -1,4 +1,4 @@
-<h1 class="heading-muted"><i class="fa fa-tasks"></i> Measure</h1>
+<h1 class="heading-muted"><i class="fa fa-tasks" aria-hidden="true"></i> Measure</h1>
 <h2 class="submeasure">{{title}}</h2>
 
 {{layout-element}}

--- a/app/assets/javascripts/templates/patient_builder/select_criteria.hbs
+++ b/app/assets/javascripts/templates/patient_builder/select_criteria.hbs
@@ -1,14 +1,14 @@
 <div class="panel">
   <a class="panel-title collapsed" data-toggle="collapse" data-parent="#criteriaElements" href="#collapse-{{cid}}">
-    <i class="fa fa-angle-right fa-2x panel-expander"></i>
-    <i class="fa {{faIcon}} fa-3x panel-icon"></i>
+    <i class="fa fa-angle-right fa-2x panel-expander" aria-hidden="true"></i>
+    <i class="fa {{faIcon}} fa-3x panel-icon" aria-hidden="true"></i>
     {{title}}
   </a>
 
   <div id="collapse-{{cid}}" class="collapse">
     {{#collection item-view="SelectCriteriaItemView"}}
       <div class="draggable">
-        <div class="pull-right" style="margin: 0 0 3px 3px"><i class="fa fa-arrows"></i></div>
+        <div class="pull-right" style="margin: 0 0 3px 3px"><i class="fa fa-arrows" aria-hidden="true"></i></div>
         <strong class="ui-draggable">{{description}}</strong>
         <span class="sr-only">{{#button "addCriteriaToPatient"}}add criteria to patient: {{description}}{{/button}}</span>
       </div>

--- a/app/assets/javascripts/templates/patients/patients.hbs
+++ b/app/assets/javascripts/templates/patients/patients.hbs
@@ -8,7 +8,7 @@
   </thead>
   {{#collection patients tag="tbody"}}
     <tr class="tr patient-listing">
-      <td width="5%" class="td delete-icon">{{#button "delStart" class="btn btn-danger"}}<i class="fa fa-minus-circle" aria-hidden="true"></i>{{/button}}</td>
+      <td width="5%" class="td delete-icon">{{#button "delStart" class="btn btn-danger"}}<i class="fa fa-minus-circle" aria-hidden="true"></i><span class="sr-only">Delete</span>{{/button}}</td>
       <td>{{last}}, {{first}}</td>
       <td width="24%">
         {{#link "patients/{{_id}}" class="btn btn-primary" expand-tokens=true}}View{{/link}}

--- a/app/assets/javascripts/templates/patients/patients.hbs
+++ b/app/assets/javascripts/templates/patients/patients.hbs
@@ -8,7 +8,7 @@
   </thead>
   {{#collection patients tag="tbody"}}
     <tr class="tr patient-listing">
-      <td width="5%" class="td delete-icon">{{#button "delStart" class="btn btn-danger"}}<i class="glyphicon glyphicon-minus-sign"></i>{{/button}}</td>
+      <td width="5%" class="td delete-icon">{{#button "delStart" class="btn btn-danger"}}<i class="fa fa-minus-circle"></i>{{/button}}</td>
       <td>{{last}}, {{first}}</td>
       <td width="24%">
         {{#link "patients/{{_id}}" class="btn btn-primary" expand-tokens=true}}View{{/link}}

--- a/app/assets/javascripts/templates/patients/patients.hbs
+++ b/app/assets/javascripts/templates/patients/patients.hbs
@@ -8,7 +8,7 @@
   </thead>
   {{#collection patients tag="tbody"}}
     <tr class="tr patient-listing">
-      <td width="5%" class="td delete-icon">{{#button "delStart" class="btn btn-danger"}}<i class="fa fa-minus-circle"></i>{{/button}}</td>
+      <td width="5%" class="td delete-icon">{{#button "delStart" class="btn btn-danger"}}<i class="fa fa-minus-circle" aria-hidden="true"></i>{{/button}}</td>
       <td>{{last}}, {{first}}</td>
       <td width="24%">
         {{#link "patients/{{_id}}" class="btn btn-primary" expand-tokens=true}}View{{/link}}

--- a/app/assets/javascripts/templates/patients/record.hbs
+++ b/app/assets/javascripts/templates/patients/record.hbs
@@ -18,4 +18,4 @@
   </div><hr>
 {{/if}}
 <br/>
-{{#link "patients" class="btn btn-primary"}}<i class="glyphicon glyphicon-circle-arrow-left"></i> back to patients listing{{/link}}
+{{#link "patients" class="btn btn-primary"}}<i class="fa fa-arrow-circle-left"></i> back to patients listing{{/link}}

--- a/app/assets/javascripts/templates/patients/record.hbs
+++ b/app/assets/javascripts/templates/patients/record.hbs
@@ -18,4 +18,4 @@
   </div><hr>
 {{/if}}
 <br/>
-{{#link "patients" class="btn btn-primary"}}<i class="fa fa-arrow-circle-left"></i> back to patients listing{{/link}}
+{{#link "patients" class="btn btn-primary"}}<i class="fa fa-arrow-circle-left" aria-hidden="true"></i> back to patients listing{{/link}}

--- a/app/assets/javascripts/templates/population_calculation.hbs
+++ b/app/assets/javascripts/templates/population_calculation.hbs
@@ -30,15 +30,15 @@
             {{else}}
               {{#if done}}
                 {{#if match}}
-                  <i class="fa fa-check"><span class="sr-only">{{patient.last}} {{patient.first}}, patient passing</span></i>
+                  <i class="fa fa-check" aria-hidden="true"></i><span class="sr-only">{{patient.last}} {{patient.first}}, patient passing</span>
                 {{else}}
-                  <i class="fa fa-times"><span class="sr-only">{{patient.last}} {{patient.first}}, patient failing</span></i>
+                  <i class="fa fa-times" aria-hidden="true"></i><span class="sr-only">{{patient.last}} {{patient.first}}, patient failing</span>
                 {{/if}}
               {{/if}}
             {{/if}}
           </div>
           <div class="patient-user-icon-col">
-            <i class="fa fa-user"><span class="sr-only">{{patient.last}} {{patient.first}}, patient result</span></i>
+            <i class="fa fa-user" aria-hidden="true"></i><span class="sr-only">{{patient.last}} {{patient.first}}, patient result</span>
           </div>
           <div class="patient-name-col">
             <span class="sr-only">patient name: </span>{{patient.last}} {{patient.first}}
@@ -65,9 +65,9 @@
           <tr>
             <td style="text-align: center;">
               {{#if match}}
-                <i class="fa fa-check pass"><span class="sr-only">passed</span></i>
+                <i class="fa fa-check pass" aria-hidden="true"></i><span class="sr-only">passed</span>
               {{else}}
-                <i class="fa fa-times fail"><span class="sr-only">failed</span></i>
+                <i class="fa fa-times fail" aria-hidden="true"></i><span class="sr-only">failed</span>
               {{/if}}
             </td>
             <td>{{name}}</td>
@@ -90,9 +90,9 @@
                     {{/ifCond}}
                   {{else}}
                     {{#if expected}}
-                      <i class="fa fa-check-square-o default"><span class="sr-only">checked</span></i>
+                      <i class="fa fa-check-square-o default" aria-hidden="true"></i><span class="sr-only">checked</span>
                     {{else}}
-                      <i class="fa fa-square-o default"><span class="sr-only">unchecked</span></i>
+                      <i class="fa fa-square-o default" aria-hidden="true"></i><span class="sr-only">unchecked</span>
                     {{/if}}
                   {{/ifCond}}
                 {{/if}}
@@ -117,9 +117,9 @@
                     {{/ifCond}}
                   {{else}}
                     {{#if actual}}
-                      <i class="fa fa-check-square-o default"><span class="sr-only">checked</span></i>
+                      <i class="fa fa-check-square-o default" aria-hidden="true"></i><span class="sr-only">checked</span>
                     {{else}}
-                      <i class="fa fa-square-o default"><span class="sr-only">unchecked</span></i>
+                      <i class="fa fa-square-o default" aria-hidden="true"></i><span class="sr-only">unchecked</span>
                     {{/if}}
                   {{/ifCond}}
                 {{/if}}

--- a/app/assets/javascripts/templates/population_calculation.hbs
+++ b/app/assets/javascripts/templates/population_calculation.hbs
@@ -9,8 +9,8 @@
     <div class="patient-data-col">
       {{view "MeasureFractionView" model=differences.summary tag="span"}}
       <a href="#measures/{{measure_id}}/patients/new" class="btn {{#unless patients.length}}btn-primary{{else}}btn-default{{/unless}} pull-right">
-        <i class="fa fa-user"></i>
-        <i class="fa fa-plus"></i>
+        <i class="fa fa-user" aria-hidden="true"></i>
+        <i class="fa fa-plus" aria-hidden="true"></i>
         <span class="sr-only">add new patient</span>
       </a>
     </div>
@@ -47,7 +47,7 @@
             <span class="sr-only">{{patient.last}} {{patient.first}}, status </span>{{status}}
           </div>
           <div class="patient-btn-col">
-            {{#button "expandResult" class="close"}}<i class="fa fa-lg fa-angle-right expand-result-icon expand-result-icon-{{patient._id}}"></i> <span class="sr-only">{{patient.last}} {{patient.first}}, Toggle Logic Pass/Fail</span>{{/button}}
+            {{#button "expandResult" class="close"}}<i class="fa fa-lg fa-angle-right expand-result-icon expand-result-icon-{{patient._id}}" aria-hidden="true"></i> <span class="sr-only">{{patient.last}} {{patient.first}}, Toggle Logic Pass/Fail</span>{{/button}}
           </div>
         </div>
       </div>
@@ -131,7 +131,7 @@
       {{#link "measures/{{measure_id}}/patients/{{patient._id}}/edit" class="btn btn-primary" expand-tokens=true}}EDIT<span class="sr-only"> patient {{patient.last}} {{patient.first}}</span>{{/link}}
       {{#button "clonePatient" class="btn btn-primary"}}CLONE<span class="sr-only"> patient {{patient.last}} {{patient.first}}</span>{{/button}}
       {{#button "showDelete" class="btn btn-danger-inverse"}}
-        <i class="fa fa-minus-circle"></i>
+        <i class="fa fa-minus-circle" aria-hidden="true"></i>
         <span class="sr-only">{{patient.last}} {{patient.first}}, Show Delete</span>
       {{/button}}
       {{#button "deletePatient" class="btn btn-danger delete-{{patient._id}}" style="display: none;" expand-tokens=true}}Delete<span class="sr-only"> patient {{patient.last}} {{patient.first}}</span>{{/button}}

--- a/app/assets/javascripts/templates/users/edit_user.hbs
+++ b/app/assets/javascripts/templates/users/edit_user.hbs
@@ -4,7 +4,7 @@
 <td class="centered">{{patient_count}}</td>
 <td class="centered"><input type="checkbox" name="admin"></td>
 <td class="centered"><input type="checkbox" name="portfolio"></td>
-<td class="centered check">{{#if approved}}<i class="fa fa-check"></i>{{/if}}</td>
+<td class="centered check">{{#if approved}}<i class="fa fa-check" aria-hidden="true"></i>{{/if}}</td>
 <td></td>
 <td>{{#button "cancel" class="btn btn-default"}}Cancel{{/button}}</td>
 <td>{{#button "save" class="btn btn-primary"}}Save{{/button}}</td>

--- a/app/assets/javascripts/templates/users/edit_user.hbs
+++ b/app/assets/javascripts/templates/users/edit_user.hbs
@@ -4,7 +4,7 @@
 <td class="centered">{{patient_count}}</td>
 <td class="centered"><input type="checkbox" name="admin"></td>
 <td class="centered"><input type="checkbox" name="portfolio"></td>
-<td class="centered check">{{#if approved}}<i class="fa fa-check" aria-hidden="true"></i>{{/if}}</td>
+<td class="centered check">{{#if approved}}<i class="fa fa-check" aria-hidden="true"></i><span class="sr-only">Approved</span>{{/if}}</td>
 <td></td>
 <td>{{#button "cancel" class="btn btn-default"}}Cancel{{/button}}</td>
 <td>{{#button "save" class="btn btn-primary"}}Save{{/button}}</td>

--- a/app/assets/javascripts/templates/users/user.hbs
+++ b/app/assets/javascripts/templates/users/user.hbs
@@ -1,10 +1,10 @@
 <td>{{email}}</td>
-<td>{{#button "bundle" class="btn btn-primary"}}<i class="fa fa-download"></i>{{/button}}</td>
+<td>{{#button "bundle" class="btn btn-primary"}}<i class="fa fa-download" aria-hidden="true"></i>{{/button}}</td>
 <td class="centered"><a href="admin/users/{{_id}}/measures">{{measure_count}}</a></td>
 <td class="centered"><a href="admin/users/{{_id}}/patients">{{patient_count}}</a></td>
-<td class="centered check">{{#if admin}}<i class="fa fa-check"></i>{{/if}}</td>
-<td class="centered check">{{#if portfolio}}<i class="fa fa-check"></i>{{/if}}</td>
-<td class="centered check">{{#if approved}}<i class="fa fa-check"></i>{{/if}}</td>
+<td class="centered check">{{#if admin}}<i class="fa fa-check" aria-hidden="true"></i>{{/if}}</td>
+<td class="centered check">{{#if portfolio}}<i class="fa fa-check" aria-hidden="true"></i>{{/if}}</td>
+<td class="centered check">{{#if approved}}<i class="fa fa-check" aria-hidden="true"></i>{{/if}}</td>
 {{#unless isCurrentUser}}
   <td>
     {{#if approved}}
@@ -15,8 +15,8 @@
   </td>
   <td>{{#button "edit" class="btn btn-primary"}}Edit{{/button}}</td>
   <td>
-    {{#button "showDelete" class="btn btn-danger-inverse"}}<i class="fa fa-minus-circle"></i>{{/button}}
-    {{#button "delete" class="btn btn-danger delete-user hide"}}<i class="fa fa-times"></i> Delete{{/button}}
+    {{#button "showDelete" class="btn btn-danger-inverse"}}<i class="fa fa-minus-circle" aria-hidden="true"></i>{{/button}}
+    {{#button "delete" class="btn btn-danger delete-user hide"}}<i class="fa fa-times" aria-hidden="true"></i> Delete{{/button}}
   </td>
   <td>
     <form action="/admin/users/{{_id}}/log_in_as" method="POST">

--- a/app/assets/javascripts/templates/users/user.hbs
+++ b/app/assets/javascripts/templates/users/user.hbs
@@ -1,10 +1,10 @@
 <td>{{email}}</td>
-<td>{{#button "bundle" class="btn btn-primary"}}<i class="fa fa-download" aria-hidden="true"></i>{{/button}}</td>
+<td>{{#button "bundle" class="btn btn-primary"}}<i class="fa fa-download" aria-hidden="true"></i><span class="sr-only">Download</span>{{/button}}</td>
 <td class="centered"><a href="admin/users/{{_id}}/measures">{{measure_count}}</a></td>
 <td class="centered"><a href="admin/users/{{_id}}/patients">{{patient_count}}</a></td>
-<td class="centered check">{{#if admin}}<i class="fa fa-check" aria-hidden="true"></i>{{/if}}</td>
-<td class="centered check">{{#if portfolio}}<i class="fa fa-check" aria-hidden="true"></i>{{/if}}</td>
-<td class="centered check">{{#if approved}}<i class="fa fa-check" aria-hidden="true"></i>{{/if}}</td>
+<td class="centered check">{{#if admin}}<i class="fa fa-check" aria-hidden="true"></i><span class="sr-only">checked</span>{{/if}}</td>
+<td class="centered check">{{#if portfolio}}<i class="fa fa-check" aria-hidden="true"></i><span class="sr-only">checked</span>{{/if}}</td>
+<td class="centered check">{{#if approved}}<i class="fa fa-check" aria-hidden="true"></i><span class="sr-only">checked</span>{{/if}}</td>
 {{#unless isCurrentUser}}
   <td>
     {{#if approved}}

--- a/app/assets/javascripts/templates/users/users.hbs
+++ b/app/assets/javascripts/templates/users/users.hbs
@@ -1,4 +1,4 @@
-<h1><i class="fa fa-users"></i> Users ({{collection.length}})</h1>
+<h1><i class="fa fa-users" aria-hidden="true"></i> Users ({{collection.length}})</h1>
 
 Sort by: <select name="users_sort_list" class="users-sort-list">
   <option value="approved">Approval Status</option>

--- a/app/assets/javascripts/templates/value_sets_builder/value_set.hbs
+++ b/app/assets/javascripts/templates/value_sets_builder/value_set.hbs
@@ -1,13 +1,13 @@
 <div class="value-set-entry">
   <div class="criteria-details">
       {{#button "toggleDetails" class="close"}}
-        {{#if isWhiteList}}<i class="fa fa-fw fa-search"></i>{{else}}{{#if isBlackList}}<i class="fa fa-fw fa-search"></i>{{else}}<i class="fa fa-lg fa-fw fa-angle-right"></i>{{/if}}{{/if}}
+        {{#if isWhiteList}}<i class="fa fa-fw fa-search" aria-hidden="true"></i>{{else}}{{#if isBlackList}}<i class="fa fa-fw fa-search" aria-hidden="true"></i>{{else}}<i class="fa fa-lg fa-fw fa-angle-right" aria-hidden="true"></i>{{/if}}{{/if}}
         <span class="sr-only">toggle details</span>
       {{/button}}
-        <h4 class="{{#if isEmpty}}empty{{/if}}"><i class="fa fa-fw fa-lg {{#if isWhiteList}}fa-check-circle success{{else}}{{#if isBlackList}}fa-times-circle danger{{else}}fa-list-alt{{/if}}{{/if}}"></i> {{display_name}}
+        <h4 class="{{#if isEmpty}}empty{{/if}}"><i class="fa fa-fw fa-lg {{#if isWhiteList}}fa-check-circle success{{else}}{{#if isBlackList}}fa-times-circle danger{{else}}fa-list-alt{{/if}}{{/if}}" aria-hidden="true"></i>  {{display_name}}
         {{#if filters}}
           {{#button "addFilter" class="btn btn-xs btn-default value-set-filter pull-right"}}
-            <i class="fa fa-plus"></i>
+            <i class="fa fa-plus" aria-hidden="true"></i>
             <span class="sr-only">add</span>
             FILTER
           {{/button}}
@@ -16,20 +16,20 @@
   </div>
   <form class="hide" role="form">
       {{#button "toggleDetails" class="close"}}
-        <i class="fa fa-lg fa-fw fa-angle-down"></i>
+        <i class="fa fa-lg fa-fw fa-angle-down" aria-hidden="true"></i>
         <span class="sr-only">toggle details</span>
       {{/button}}
 
-      <h4><i class="fa fa-fw fa-lg fa-list-alt"></i> {{display_name}}
+      <h4><i class="fa fa-fw fa-lg fa-list-alt" aria-hidden="true"></i> {{display_name}}
         {{#if filters}}
-          {{#button "addFilter" class="btn btn-xs btn-default value-set-filter pull-right"}} <i class="fa fa-plus"></i> FILTER {{/button}}
+          {{#button "addFilter" class="btn btn-xs btn-default value-set-filter pull-right"}} <i class="fa fa-plus" aria-hidden="true"></i> FILTER {{/button}}
         {{/if}}
       </h4>
 
       <div class="panel panel-default value-set-listing">
         <div class="panel-body">
           <label class="pull-right"><small>{{oid}}</small></label>
-          <i class="fa fa-list"></i> <label>Codes</label>
+          <i class="fa fa-list" aria-hidden="true"></i> <label>Codes</label>
           <ul class="nav nav-pills">
             {{#each codeSystems}}
               <li{{#unless index}} class="active"{{/unless}}><a href="#{{../cid}}-{{index}}" data-toggle="tab">{{code_system}} <span class="badge">{{count}}</span></a></li>
@@ -42,7 +42,7 @@
                   <li class="list-group-item">
                     <div class="row">
                       <div class="col-xs-1">
-                        {{#if white_list}}<i class="fa fa-fw fa-lg fa-check-circle success"></i>{{else}}{{#if black_list}}<i class="fa fa-fw fa-lg fa-times-circle danger"></i>{{else}}{{/if}}{{/if}}
+                        {{#if white_list}}<i class="fa fa-fw fa-lg fa-check" aria-hidden="true"></i>{{else}}{{#if black_list}}<i class="fa fa-fw fa-lg fa-times" aria-hidden="true"></i>{{else}}{{/if}}{{/if}}
                       </div>
                       <div class="col-xs-8">
                         <strong><small>{{code}}</small></strong> {{display_name}} <span class="label label-{{#if white_list}}success{{else}}{{#if black_list}}danger{{else}}info{{/if}}{{/if}}">{{code_system_name}}</span>
@@ -64,7 +64,7 @@
         {{#empty associatedMeasures}}
         {{else}}
           <div class="well">
-            <i class="fa fa-tasks"></i> <label>Associated Measures</label>
+            <i class="fa fa-tasks" aria-hidden="true"></i> <label>Associated Measures</label>
             {{#collection associatedMeasures}}
               {{#link "measures/{{hqmf_set_id}}" class="btn btn-default" expand-tokens=true}}{{cms_id}} ({{measure_id}}){{/link}}
             {{/collection}}
@@ -73,7 +73,7 @@
         {{#empty associatedPatients}}
         {{else}}
           <div class="well">
-            <i class="fa fa-users"></i> <label>Associated Patients</label>
+            <i class="fa fa-users" aria-hidden="true"></i> <label>Associated Patients</label>
             {{#collection associatedPatients item-context="patientContext" class="list-group" tag="ul"}}
               <li class="list-group-item">
               {{#link "measures/{{measureId}}/patients/{{_id}}/edit" class="btn btn-default" expand-tokens=true}}{{last}}, {{first}}{{/link}}
@@ -90,7 +90,7 @@
           </div>
         {{/empty}}
         <div class="panel-footer">
-          {{#button "save" class="btn btn-default value-set-save"}}<i class="fa fa-save"></i> Save{{/button}}
+          {{#button "save" class="btn btn-default value-set-save"}}<i class="fa fa-save" aria-hidden="true"></i> Save{{/button}}
         </div>
       </div>
   </form>

--- a/app/assets/javascripts/templates/value_sets_builder/value_sets_builder.hbs
+++ b/app/assets/javascripts/templates/value_sets_builder/value_sets_builder.hbs
@@ -19,7 +19,7 @@
       {{#collection filters item-context="filterContext" tag="div" class=" panel panel-default value-set-filters"}}
         <tr>
           <th>
-            {{#button 'removeFilter' class="btn btn-xs btn-close"}}<i class="fa fa-times" aria-hidden="true"></i>{{/button}}
+            {{#button 'removeFilter' class="btn btn-xs btn-close"}}<i class="fa fa-times" aria-hidden="true"></i><span class="sr-only">Remove filter</span>{{/button}}
           </th>
           <th class="filter-cell">
             {{display_name}}

--- a/app/assets/javascripts/templates/value_sets_builder/value_sets_builder.hbs
+++ b/app/assets/javascripts/templates/value_sets_builder/value_sets_builder.hbs
@@ -19,7 +19,7 @@
       {{#collection filters item-context="filterContext" tag="div" class=" panel panel-default value-set-filters"}}
         <tr>
           <th>
-            {{#button 'removeFilter' class="btn btn-xs btn-close"}}<i class="fa fa-times"></i>{{/button}}
+            {{#button 'removeFilter' class="btn btn-xs btn-close"}}<i class="fa fa-times" aria-hidden="true"></i>{{/button}}
           </th>
           <th class="filter-cell">
             {{display_name}}
@@ -48,16 +48,16 @@
         <div class="input-group">
           <input type="text" class="form-control" id="searchByNameOrOID" placeholder="Enter Value Set name or oid...">
           <span class="input-group-btn">
-            <button type="submit" class="btn btn-default search-button"> <i class="fa fa-search"></i> Search</button>
+            <button type="submit" class="btn btn-default search-button"> <i class="fa fa-search" aria-hidden="true"></i> Search</button>
           </span>
           <div class="input-group-btn">
-            <button type="button" class="btn btn-default dropdown-toggle measure-button" data-toggle="dropdown"> <i class="fa fa-tasks"></i> Measures <span class="caret"></span></button>
+            <button type="button" class="btn btn-default dropdown-toggle measure-button" data-toggle="dropdown"> <i class="fa fa-tasks" aria-hidden="true"></i> Measures <span class="caret"></span></button>
             {{#collection measures tag="ul" class="dropdown-menu pull-right"}}
               <li>{{#button 'selectMeasure' tag="a"}}[ <strong>{{cms_id}}</strong> ({{measure_id}}) ] {{hqmf_set_id}}{{/button}}</li>
             {{/collection}}
           </div>
           <span class="input-group-btn">
-            <button type="button" class="btn btn-default rebuild-patients" data-call-method="rebuildPatients"> <i class="fa fa-users"></i> Rebuild Patients</button>
+            <button type="button" class="btn btn-default rebuild-patients" data-call-method="rebuildPatients"> <i class="fa fa-users" aria-hidden="true"></i> Rebuild Patients</button>
           </span>
         </div>
       </form>

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -18,14 +18,14 @@
 
         <div class="form-group">
           <div class="input-group input-group-lg">
-            <span class="input-group-addon"><i class="fa fa-lock fa-lg fa-fw"></i></span>
+            <span class="input-group-addon"><i class="fa fa-lock fa-lg fa-fw" aria-hidden="true"></i></span>
             <%= f.password_field :password, class: "form-control", placeholder: "password", title: "password" %>
           </div>
           Must be at least 8 characters long and contain characters from at least two of: lowercase letters, uppercase letters, numbers, and special characters.
         </div>
 
         <div class="form-group input-group input-group-lg">
-          <span class="input-group-addon"><i class="fa fa-lock fa-lg fa-fw"></i></span>
+          <span class="input-group-addon"><i class="fa fa-lock fa-lg fa-fw" aria-hidden="true"></i></span>
           <%= f.password_field :password_confirmation, class: "form-control", placeholder: "confirm password", title: "confirm password" %>
         </div>
 

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -8,7 +8,7 @@
   <p>Just enter your email address, and we'll send you a link to reset your password.</p>
   <%= form_for(resource, :as => resource_name, :url => password_path(resource_name), :html => {:name=>"forgot_password_form"}) do |f| %>
     <div class="form-group input-group input-group-lg">
-      <span class="input-group-addon"><i class="fa fa-envelope fa-lg fa-fw"></i></span>
+      <span class="input-group-addon"><i class="fa fa-envelope fa-lg fa-fw" aria-hidden="true"></i></span>
       <label for="user_email" class="sr-only">Email: </label>
       <%= f.email_field :email, class: "form-control", placeholder: "email@example.com" %>
     </div>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -11,14 +11,14 @@
     <div class="col-md-6">
       <div class="input-group input-group-lg required">
         <label for="user_first_name" class="sr-only">First Name (required) </label>
-        <span class="input-group-addon"><i class="fa fa-user fa-lg fa-fw"></i></span>
+        <span class="input-group-addon"><i class="fa fa-user fa-lg fa-fw" aria-hidden="true"></i></span>
         <%= f.text_field :first_name, class: "form-control", placeholder: "first name*" %>
       </div>
     </div>
     <div class="col-md-6">
       <div class="input-group input-group-lg required">
         <label for="user_last_name" class="sr-only">Last Name (required) </label>
-        <span class="input-group-addon"><i class="fa fa-user fa-lg fa-fw"></i></span>
+        <span class="input-group-addon"><i class="fa fa-user fa-lg fa-fw" aria-hidden="true"></i></span>
         <%= f.text_field :last_name, class: "form-control", placeholder: "last name*" %>
       </div>
     </div>
@@ -27,14 +27,14 @@
     <div class="col-md-6">
       <div class="input-group input-group-lg">
         <label for="user_email" class="sr-only">Email </label>
-        <span class="input-group-addon"><i class="fa fa-envelope fa-lg fa-fw"></i></span>
+        <span class="input-group-addon"><i class="fa fa-envelope fa-lg fa-fw" aria-hidden="true"></i></span>
         <%= f.email_field :email, class: "form-control", placeholder: "email@example.com" %>
       </div>
     </div>
     <div class="col-md-6">
       <div class="input-group input-group-lg">
         <label for="user_telephone" class="sr-only">Telephone </label>
-        <span class="input-group-addon"><i class="fa fa-mobile fa-lg fa-fw"></i></span>
+        <span class="input-group-addon"><i class="fa fa-mobile fa-lg fa-fw" aria-hidden="true"></i></span>
         <%= f.text_field :telephone, class: "form-control", placeholder: "(000) 000-0000" %>
       </div>
     </div>
@@ -57,7 +57,7 @@
     <div class="col-md-6">
       <div class="input-group input-group-lg required">
         <label for="user_password" class="sr-only">Password (required) </label>
-        <span class="input-group-addon"><i class="fa fa-lock fa-lg fa-fw"></i></span>
+        <span class="input-group-addon"><i class="fa fa-lock fa-lg fa-fw" aria-hidden="true"></i></span>
         <%= f.password_field :password, class: "form-control", placeholder: "password*" %>
       </div>
       Must be at least 8 characters long and contain characters from at least two of: lowercase letters, uppercase letters, numbers, and special characters (leave blank if you don't want to change it).
@@ -65,7 +65,7 @@
     <div class="col-md-6">
       <div class="input-group input-group-lg required">
         <label for="user_password_confirmation" class="sr-only">confirm password (required) </label>
-        <span class="input-group-addon"><i class="fa fa-lock fa-lg fa-fw"></i></span>
+        <span class="input-group-addon"><i class="fa fa-lock fa-lg fa-fw" aria-hidden="true"></i></span>
         <%= f.password_field :password_confirmation, class: "form-control", placeholder: "confirm password*" %>
       </div>
     </div>
@@ -75,7 +75,7 @@
     <div class="col-md-6">
       <div class="input-group input-group-lg required">
         <label for="user_current_password" class="sr-only">current password (required: </label>
-        <span class="input-group-addon"><i class="fa fa-lock fa-lg fa-fw"></i></span>
+        <span class="input-group-addon"><i class="fa fa-lock fa-lg fa-fw" aria-hidden="true"></i></span>
         <%= f.password_field :current_password, class: "form-control", placeholder: "current password*" %>
       </div>
       Your current password is needed to confirm your changes.

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -16,14 +16,14 @@
     <div class="col-md-6">
       <div class="input-group input-group-lg">
         <label for="user_first_name" class="sr-only">First Name </label>
-        <span class="input-group-addon"><i class="fa fa-user fa-lg fa-fw"></i></span>
+        <span class="input-group-addon"><i class="fa fa-user fa-lg fa-fw" aria-hidden="true"></i></span>
         <%= f.text_field :first_name, class: "form-control", placeholder: "first name" %>
       </div>
     </div>
     <div class="col-md-6">
       <div class="input-group input-group-lg">
         <label for="user_last_name" class="sr-only">Last Name </label>
-        <span class="input-group-addon"><i class="fa fa-user fa-lg fa-fw"></i></span>
+        <span class="input-group-addon"><i class="fa fa-user fa-lg fa-fw" aria-hidden="true"></i></span>
         <%= f.text_field :last_name, class: "form-control", placeholder: "last name" %>
       </div>
     </div>
@@ -32,14 +32,14 @@
     <div class="col-md-6">
       <div class="input-group input-group-lg required">
         <label for="user_email" class="sr-only">Email </label>
-        <span class="input-group-addon"><i class="fa fa-envelope fa-lg fa-fw"></i></span>
+        <span class="input-group-addon"><i class="fa fa-envelope fa-lg fa-fw" aria-hidden="true"></i></span>
         <%= f.email_field :email, class: "form-control", placeholder: "email@example.com" %>
       </div>
     </div>
     <div class="col-md-6">
       <div class="input-group input-group-lg">
         <label for="user_telephone" class="sr-only">Telephone </label>
-        <span class="input-group-addon"><i class="fa fa-mobile fa-lg fa-fw"></i></span>
+        <span class="input-group-addon"><i class="fa fa-mobile fa-lg fa-fw" aria-hidden="true"></i></span>
         <%= f.text_field :telephone, class: "form-control", placeholder: "(000) 000-0000" %>
       </div>
     </div>
@@ -48,7 +48,7 @@
     <div class="col-md-6">
       <div class="input-group input-group-lg required">
         <label for="user_password" class="sr-only">Password (required) </label>
-        <span class="input-group-addon"><i class="fa fa-lock fa-lg fa-fw"></i></span>
+        <span class="input-group-addon"><i class="fa fa-lock fa-lg fa-fw" aria-hidden="true"></i></span>
         <%= f.password_field :password, class: "form-control", placeholder: "password*" %>
       </div>
       Must be at least 8 characters long and contain characters from at least two of: lowercase letters, uppercase letters, numbers, and special characters.
@@ -56,7 +56,7 @@
     <div class="col-md-6">
       <div class="input-group input-group-lg required">
         <label for="user_password_confirmation" class="sr-only">Password Confirmation (required) </label>
-        <span class="input-group-addon"><i class="fa fa-lock fa-lg fa-fw"></i></span>
+        <span class="input-group-addon"><i class="fa fa-lock fa-lg fa-fw" aria-hidden="true"></i></span>
         <%= f.password_field :password_confirmation, class: "form-control", placeholder: "confirm password*" %>
       </div>
     </div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -9,13 +9,13 @@
 
   <%= form_for(resource, :as => resource_name, :url => session_path(resource_name), :html => {:name=>"login_form"}) do |f| %>
     <div class="form-group input-group input-group-lg">
-      <span class="input-group-addon"><i class="fa fa-envelope fa-lg fa-fw"></i></span>
+      <span class="input-group-addon"><i class="fa fa-envelope fa-lg fa-fw" aria-hidden="true"></i></span>
       <label for="user_email" class="sr-only">Email </label>
       <%= f.email_field :email, class: "form-control", placeholder: "email@example.com" %>
     </div>
     <div class="form-group input-group input-group-lg">
       <label for="user_password" class="sr-only">Password </label>
-      <span class="input-group-addon"><i class="fa fa-lock fa-lg fa-fw"></i></span>
+      <span class="input-group-addon"><i class="fa fa-lock fa-lg fa-fw" aria-hidden="true"></i></span>
       <%= f.password_field :password, class: "form-control", placeholder: "password" %>
     </div>
 

--- a/app/views/devise/shared/_links.erb
+++ b/app/views/devise/shared/_links.erb
@@ -2,7 +2,7 @@
   <%- if devise_mapping.recoverable? && controller_name != 'passwords' %>
     <p>
       <%= link_to new_password_path(resource_name) do %>
-        <i class="fa fa-question-circle"></i>
+        <i class="fa fa-question-circle" aria-hidden="true"></i>
         forgot password?
       <% end %>
     </p>
@@ -11,7 +11,7 @@
   <%- if devise_mapping.registerable? && controller_name != 'registrations' %>
     <p>
       <%= link_to new_registration_path(resource_name) do %>
-        <i class="fa fa-plus-circle"></i>
+        <i class="fa fa-plus-circle" aria-hidden="true"></i>
         register
       <% end %>
     </p>
@@ -20,7 +20,7 @@
   <%- if controller_name != 'sessions' %>
     <p>
       <%= link_to new_session_path(resource_name) do %>
-        <i class="fa fa-plus-circle"></i>
+        <i class="fa fa-plus-circle" aria-hidden="true"></i>
         sign in
       <% end %>
     </p>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -26,7 +26,7 @@
   <% unless account_info %>
   <div class="col-md-4">
     <span class="measure-period">
-      <i class="fa fa-tasks"></i> measure period:
+      <i class="fa fa-tasks" aria-hidden="true"></i> measure period:
       <span class="year"><%= Time.zone.at(APP_CONFIG['measure_period_start']).year %></span>
     </span>
   </div>


### PR DESCRIPTION
### Story
- https://www.pivotaltracker.com/story/show/71501822
- https://www.pivotaltracker.com/story/show/71502040 (no longer an issue with icons hidden)
### Notes
- Font awesome icons [aren't going to be read by screen readers](https://github.com/FortAwesome/Font-Awesome/issues/389). So let screen readers skip over them using `aria-hidden="true"`
- Make sure each hidden icon has descriptive text available (either visible or `.sr-only`). I added a few bits of text in the last commit (4d1bf762eb5adc59ddc104e874d79e65ef0053da), need to make sure the information is correct

Don't have screenshots, but I can tell you the icons are no longer being read by OSX screen reader VoiceOver..
