### PR TITLE
Fix "COUNT >= 2 and <= 2" to "COUNT == 2"

### DIFF
--- a/app/assets/javascripts/templates/logic/value.hbs
+++ b/app/assets/javascripts/templates/logic/value.hbs
@@ -7,8 +7,12 @@
   {{else}}
     {{#if isRange}}
       {{#ifCond value.high '&&' value.low}}
+        {{#if isEquivalent}}
+          {{view "ValueLogic" value=value.low rangeComparison="=" tag="span"}} and
+        {{else}}
           {{view "ValueLogic" value=value.low rangeComparison=">" tag="span"}} and
           {{view "ValueLogic" value=value.high rangeComparison="<" tag="span"}}
+        {{/if}}
       {{else}}
         {{#if value.high}}
           {{view "ValueLogic" value=value.high rangeComparison="<" tag="span"}}

--- a/app/assets/javascripts/views/logic/value_logic_view.js.coffee
+++ b/app/assets/javascripts/views/logic/value_logic_view.js.coffee
@@ -12,6 +12,7 @@ class Thorax.Views.ValueLogic extends Thorax.Views.BonnieView
 
   initialize: ->
     @isRange = @value.type == 'IVL_PQ'
+    @isEquivalent = @isRange && @value.high?.value == @value.low?.value && @value.high['inclusive?'] && @value.low['inclusive?']
     @isValue = @value.type == 'PQ'
     @isAnyNonNull = @value.type == 'ANYNonNull'
 


### PR DESCRIPTION
### Story
- https://www.pivotaltracker.com/story/show/71284742
### Notes
- checked out how an equivalent range was defined in [hds](https://github.com/projectcypress/health-data-standards/blob/ecfa2bc231a2acc2dac11d4fd752ba3a1059295d/lib/hqmf-model/types.rb#L122) when converting to string values
- added an <code>isEquivalent</code> variable to the logic value view for accounting for an equivalent range (`high.value == low.value && high.inclusive? && low.inclusive?`)
