### PR TITLE
Hide patient builder datepickers on input navigation

### DIFF
--- a/app/assets/javascripts/views/patient_builder/data_criteria.js.coffee
+++ b/app/assets/javascripts/views/patient_builder/data_criteria.js.coffee
@@ -105,6 +105,8 @@ class Thorax.Views.EditCriteriaView extends Thorax.Views.BuilderChildView
     'change :input[name=end_date_is_undefined]':  'toggleEndDateDefinition'
     'blur :text':                                 'triggerMaterialize'
     'change select':                              'triggerMaterialize'
+    # hide date-picker if it's still visible and focus is not on a .date-picker input (occurs with JAWS SR arrow-key navigation)
+    'focus .form-control': (e) -> if not @$(e.target).hasClass('date-picker') and $('.datepicker').is(':visible') then @$('.date-picker').datepicker('hide')
 
   dropCriteria: (e, ui) ->
     # When we drop a new criteria on an existing criteria
@@ -270,6 +272,8 @@ class Thorax.Views.EditCriteriaValueView extends Thorax.Views.BuilderChildView
       @advanceFocusToInput()
     'keyup input': 'validateForAddition'
     'change select[name=key]': 'changeFieldValueKey'
+    # hide date-picker if it's still visible and focus is not on a .date-picker input (occurs with JAWS SR arrow-key navigation)
+    'focus .form-control': (e) -> if not @$(e.target).hasClass('date-picker') and $('.datepicker').is(':visible') then @$('.date-picker').datepicker('hide')
 
   advanceFocusToInput: ->
     switch @model.get('type')

--- a/app/assets/javascripts/views/patient_builder/patient_builder.js.coffee
+++ b/app/assets/javascripts/views/patient_builder/patient_builder.js.coffee
@@ -67,7 +67,7 @@ class Thorax.Views.PatientBuilder extends Thorax.Views.BonnieView
           '' #where should the next field jump to?
     'click .deceased-checkbox': 'toggleDeceased'
     # hide date-picker if it's still visible and focus is not on a .date-picker input (occurs with JAWS SR arrow-key navigation)
-    'focus input': (e) -> if not @$(e.target).hasClass('date-picker') and $('.datepicker').is(':visible') then @$('.date-picker').datepicker('hide')
+    'focus .form-control': (e) -> if not @$(e.target).hasClass('date-picker') and $('.datepicker').is(':visible') then @$('.date-picker').datepicker('hide')
     rendered: ->
       @$('.draggable').draggable revert: 'invalid', helper: 'clone', zIndex: 10
 

--- a/app/assets/javascripts/views/patient_builder/patient_builder.js.coffee
+++ b/app/assets/javascripts/views/patient_builder/patient_builder.js.coffee
@@ -66,6 +66,8 @@ class Thorax.Views.PatientBuilder extends Thorax.Views.BonnieView
         when 'ethnicity'
           '' #where should the next field jump to?
     'click .deceased-checkbox': 'toggleDeceased'
+    # close date-picker if it's still visible (occurs with JAWS SR arrow-key navigation)
+    'blur input': -> if $('.datepicker').is(':visible') then @$('.date-picker').datepicker('hide')
     rendered: ->
       @$('.draggable').draggable revert: 'invalid', helper: 'clone', zIndex: 10
 

--- a/app/assets/javascripts/views/patient_builder/patient_builder.js.coffee
+++ b/app/assets/javascripts/views/patient_builder/patient_builder.js.coffee
@@ -66,8 +66,8 @@ class Thorax.Views.PatientBuilder extends Thorax.Views.BonnieView
         when 'ethnicity'
           '' #where should the next field jump to?
     'click .deceased-checkbox': 'toggleDeceased'
-    # close date-picker if it's still visible (occurs with JAWS SR arrow-key navigation)
-    'blur input': -> if $('.datepicker').is(':visible') then @$('.date-picker').datepicker('hide')
+    # hide date-picker if it's still visible and focus is not on a .date-picker input (occurs with JAWS SR arrow-key navigation)
+    'focus input': (e) -> if not @$(e.target).hasClass('date-picker') and $('.datepicker').is(':visible') then @$('.date-picker').datepicker('hide')
     rendered: ->
       @$('.draggable').draggable revert: 'invalid', helper: 'clone', zIndex: 10
 


### PR DESCRIPTION
### Story
- https://www.pivotaltracker.com/story/show/71504922
### Notes
- using a <code>focus input</code> event on the patient builder view, hide any open <code>.date-picker</code>'s if the <code>.datepicker</code> class is visible and the current focused input does not have a <code>date-picker</code> class
- this is a prominent issue when attempting to navigate the patient builder form(s) with arrow keys (e.g., with the JAWS screen reader application)
