### PR TITLE
Move fulfillments label on medication above collection of fulfillments

### DIFF
--- a/app/assets/javascripts/templates/patient_builder/edit_criteria.hbs
+++ b/app/assets/javascripts/templates/patient_builder/edit_criteria.hbs
@@ -142,6 +142,7 @@
           </div>
         </div>
         <div class="form-group">
+          <label class="control-label"><i class="fa fa-files-o" aria-hidden="true"></i> Fulfillments<input class="sr-only" disabled></label>
 
           {{#collection fulfillments class="existing-values"}}
             <span>

--- a/app/assets/javascripts/templates/patient_builder/edit_fulfillments.hbs
+++ b/app/assets/javascripts/templates/patient_builder/edit_fulfillments.hbs
@@ -1,4 +1,3 @@
-<label class="control-label"><i class="fa fa-files-o"></i> Fulfillments<input class="sr-only" disabled></label>
 <div class="row">
   <div class="col-md-3">
     <label for="dispense_date_{{@cid}}" class="sr-only">dispense date</label>


### PR DESCRIPTION
### Note
- move the fulfillments label from the collection template to the patient data criteria template, which then renders each fulfillment below the label
### Screenshots
- before fix
  - ![screen shot 2014-06-03 at 9 32 51 am](https://cloud.githubusercontent.com/assets/456952/3160670/9af4c8ae-eb23-11e3-9ddb-ee5d0f8524cc.png)
- after fix
  - ![screen shot 2014-06-03 at 9 32 18 am](https://cloud.githubusercontent.com/assets/456952/3160671/9af97c14-eb23-11e3-9a2f-4ea80e179925.png)
