### PR TITLE
Screen readers read name before action for "add criteria" buttons

### DIFF
--- a/app/assets/javascripts/templates/patient_builder/select_criteria.hbs
+++ b/app/assets/javascripts/templates/patient_builder/select_criteria.hbs
@@ -10,7 +10,7 @@
       <div class="draggable">
         <div class="pull-right" style="margin: 0 0 3px 3px"><i class="fa fa-arrows" aria-hidden="true"></i></div>
         <strong class="ui-draggable">{{description}}</strong>
-        <span class="sr-only">{{#button "addCriteriaToPatient"}}add criteria to patient: {{description}}{{/button}}</span>
+        <span class="sr-only">{{#button "addCriteriaToPatient"}}{{description}}; add criteria to patient{{/button}}</span>
       </div>
     {{/collection}}
   </div>


### PR DESCRIPTION
The buttons that allow screen reader users to add criteria to patients read the name of the criteria first, before reading the repetitive "add criteria to patient" action description.
