### PR TITLE
Fix empty string start_date values on patient data criteria

### DIFF
--- a/lib/measures/patient_builder.rb
+++ b/lib/measures/patient_builder.rb
@@ -94,8 +94,8 @@ module Measures
     end
 
     def self.derive_time_range(value)
-      low = {'value' => Time.at(value['start_date'].to_i / 1000).utc.strftime('%Y%m%d%H%M%S'), 'type'=>'TS' } unless value['start_date'].nil?
-      high = {'value' => Time.at(value['end_date'].to_i / 1000).utc.strftime('%Y%m%d%H%M%S'), 'type'=>'TS' } unless value['end_date'].nil?
+      low = {'value' => Time.at(value['start_date'].to_i / 1000).utc.strftime('%Y%m%d%H%M%S'), 'type'=>'TS' } unless value['start_date'].blank?
+      high = {'value' => Time.at(value['end_date'].to_i / 1000).utc.strftime('%Y%m%d%H%M%S'), 'type'=>'TS' } unless value['end_date'].blank?
       HQMF::Range.from_json({'low' => low,'high' => high})
     end
 


### PR DESCRIPTION
### Story
- https://www.pivotaltracker.com/story/show/72535994
- http://jira.oncprojectracking.org/browse/BONNIE-6
### Notes
- this is an issue with the current [<code>production</code>](https://github.com/projecttacoma/bonnie/tree/production), but is not reproducible on the current [<code>master</code>](https://github.com/projecttacoma/bonnie/tree/master)
- replacing <code>.nil?</code> with <code>.blank?</code> resolves this issue on [<code>production</code>](https://github.com/projecttacoma/bonnie/tree/production), and should behave accordingly for [<code>master</code>](https://github.com/projecttacoma/bonnie/tree/master)
- this was tested using [CMS314v0](http://jira.oncprojectracking.org/browse/MUCD-63?jql=project%20%3D%20MUCD%20AND%20status%20%3D%20%221.%20Create%20%2F%20update%20eCQM%20bundle%22%20ORDER%20BY%20priority%20DESC) from a backup copy of production
