### PR TITLE
Have SR read that this is a drop down menu

### DIFF
--- a/app/assets/javascripts/templates/patient_builder/edit_codes.hbs
+++ b/app/assets/javascripts/templates/patient_builder/edit_codes.hbs
@@ -1,6 +1,6 @@
 <div class="row">
   <div class="col-md-3">
-    <label class="sr-only" for="codeset_{{@cid}}"> Code Set</label>
+    <label class="sr-only" for="codeset_{{@cid}}">Select code set dropdown</label>
     <select id="codeset_{{@cid}}" name="codeset" class="codeset-control">
       <option value="">Code Set</option>
       {{#each codeSets}}

--- a/app/assets/javascripts/templates/patient_builder/edit_value.hbs
+++ b/app/assets/javascripts/templates/patient_builder/edit_value.hbs
@@ -12,7 +12,7 @@
 
 <div class="row">
   <div class="col-md-3">
-    <label class="sr-only" for="type_{{@cid}}">Value type</label>
+    <label class="sr-only" for="type_{{@cid}}">Value type dropdown</label>
     <select id="type_{{@cid}}" name="type">
       <option value="PQ" data-icon="fa fa-pencil-square-o">Scalar</option>
       <option value="CD" data-icon="fa fa-list">Coded</option>

--- a/app/assets/javascripts/views/patient_builder/data_criteria.js.coffee
+++ b/app/assets/javascripts/views/patient_builder/data_criteria.js.coffee
@@ -170,7 +170,7 @@ class Thorax.Views.CodeSelectionView extends Thorax.Views.BuilderChildView
     'change select':           'validateForAddition'
     'change .codeset-control': 'changeConcepts'
     rendered: ->
-      @$('select.codeset-control').selectBoxIt()
+      @$('select.codeset-control').selectBoxIt('native': true)
 
   initialize: ->
     @model = new Thorax.Model
@@ -260,7 +260,7 @@ class Thorax.Views.EditCriteriaValueView extends Thorax.Views.BuilderChildView
       title = @measure?.valueSets().findWhere(oid: attr.code_list_id)?.get('display_name')
       attr.title = title if title
     rendered: ->
-      @$("select[name=type]").selectBoxIt()
+      @$("select[name=type]").selectBoxIt('native': true)
       @$('.date-picker').datepicker().on 'changeDate', _.bind(@validateForAddition, this)
       @$('.time-picker').timepicker(template: false).on 'changeTime.timepicker', _.bind(@validateForAddition, this)
     'change select[name=type]': (e) ->
@@ -318,7 +318,7 @@ class Thorax.Views.EditCriteriaValueView extends Thorax.Views.BuilderChildView
     @values.add @model.clone()
     # Reset model to default values
     @model.clear()
-    @model.set type: 'PQ'
+    @model.set type: 'CD'
     # clear() removes fields (which we want), but then populate() doesn't clear the select; clear it
     @$('select[name=key]').val('')
     # Let the selectBoxIt() select box know that its value may have changed


### PR DESCRIPTION
Story: https://www.pivotaltracker.com/story/show/71505088

The story cites that JAWS is not reading the value type scalar elements. It's actually not reading either of the SelectBoxIt-styled dropdowns at all. (It _seems_ to read "Code Set" but is actually reading a hidden label rather than the visible `<option>` value.)

One way to get around this, which I've done here, is give both dropdowns a label that'll tell the SR that this is a dropdown. It's an improvement over not indicating the presence of a dropdown, but more might be needed to make it accessible..
