### PR TITLE
Add focus to dropped criteria in patient builder

### DIFF
--- a/app/assets/javascripts/templates/patient_builder/edit_criteria.hbs
+++ b/app/assets/javascripts/templates/patient_builder/edit_criteria.hbs
@@ -9,8 +9,7 @@
           <h2>{{definition}}</h2>
           <div>{{description}}</div>
         </div>
-
-        <div class="col-md-6">
+        <div class="col-md-6  criteria-{{model.cid}}">
           <div class="pull-left">
             <h2>Date</h2>
             <div>{{start_date}}{{#if end_date}} &ndash; {{end_date}}{{/if}}</div>
@@ -201,6 +200,7 @@
           {{#button "removeCriteria" class="btn btn-danger hide"}}Delete{{/button}}
         </div>
       </div>
+      <span class="sr-only">{{#button "jumpToSelectCriteria"}}Return to {{type}} Clinical Elements{{/button}}</span>
     </form>
   </div>
 </div>

--- a/app/assets/javascripts/templates/patient_builder/select_criteria.hbs
+++ b/app/assets/javascripts/templates/patient_builder/select_criteria.hbs
@@ -1,5 +1,5 @@
 <div class="panel">
-  <a class="panel-title collapsed" data-toggle="collapse" data-parent="#criteriaElements" href="#collapse-{{cid}}">
+  <a class="panel-title collapsed {{title}}-elements" data-toggle="collapse" data-parent="#criteriaElements" href="#collapse-{{cid}}">
     <i class="fa fa-angle-right fa-2x panel-expander" aria-hidden="true"></i>
     <i class="fa {{faIcon}} fa-3x panel-icon" aria-hidden="true"></i>
     {{title}}

--- a/app/assets/javascripts/views/patient_builder/data_criteria.js.coffee
+++ b/app/assets/javascripts/views/patient_builder/data_criteria.js.coffee
@@ -163,6 +163,10 @@ class Thorax.Views.EditCriteriaView extends Thorax.Views.BuilderChildView
     @toggleDetails(e) unless @isExpanded()
     @$(":input[name=#{field}]").closest('.form-group').addClass('has-error')
 
+  jumpToSelectCriteria: (e) ->
+    e.preventDefault()
+    type = @$(e.target).model().get('type')
+    $(".#{type}-elements").focus()
 
 class Thorax.Views.CodeSelectionView extends Thorax.Views.BuilderChildView
   template: JST['patient_builder/edit_codes']

--- a/app/assets/javascripts/views/patient_builder/patient_builder.js.coffee
+++ b/app/assets/javascripts/views/patient_builder/patient_builder.js.coffee
@@ -122,6 +122,9 @@ class Thorax.Views.PatientBuilder extends Thorax.Views.BonnieView
   addCriteria: (criteria) ->
     @model.get('source_data_criteria').add criteria
     @materialize()
+    # close any open elements and then open the new element
+    @$('button[data-call-method="toggleDetails"] > .fa-angle-down:visible').click()
+    @$(".criteria-#{criteria.cid} > button").click()
 
   loadPopulation: (population) ->
     @measure = population.collection.parent

--- a/spec/javascripts/views/patient_builder_spec.js.coffee
+++ b/spec/javascripts/views/patient_builder_spec.js.coffee
@@ -61,9 +61,15 @@ describe 'PatientBuilderView', ->
       @addEncounter = (position, targetSelector) ->
         $('.panel-title').click() # Expand the criteria to make draggables visible
         criteria = @$el.find(".draggable:eq(#{position})").draggable()
+        target = @$el.find(targetSelector)
         criteriaOffset = criteria.offset()
-        droppableOffset = @$el.find(targetSelector).offset()
-        criteria.simulate 'drag', dx: droppableOffset.left - criteriaOffset.left - (criteria.width()/2), dy: droppableOffset.top - criteriaOffset.top - (criteria.height()/2)
+        droppableOffset = target.offset()
+        # use approximate center points of droppable and criteria for dragging
+        droppableCenterX = droppableOffset.left + target.width()/2
+        droppableCenterY = droppableOffset.top + target.height()/2
+        criteriaCenterX = criteriaOffset.left + criteria.width()/2
+        criteriaCenterY = criteriaOffset.top + criteria.height()/2
+        criteria.simulate 'drag', dx: droppableCenterX - criteriaCenterX, dy: droppableCenterY - criteriaCenterY
 
     it "adds data criteria to model when dragged", ->
       initialSourceDataCriteriaCount = @patientBuilder.model.get('source_data_criteria').length


### PR DESCRIPTION
### Story
- https://www.pivotaltracker.com/story/show/72903948
### Notes
- after dropping a criteria in the patient builder, all open patient data criteria are closed, and then the newly dropped one is opened and focused on
- each patient data criteria has an SR-only button, located after the delete button, that allows an SR user to jump back to the corresponding dropdown of draggable patient data criteria
- patient builder spec for jasmine has been updated to use center points for desired criteria and destination target point (to resolve Travis failures)
