### PR TITLE
Fix "skip to main content" not focusing for screen readers

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,7 +15,7 @@
     <%= render 'layouts/ie8_alert' %>
     <div class="container">
       <%= render 'layouts/header' %>
-      <div id="bonnie">
+      <div id="bonnie" role="main">
         <div class="loading-indicator">
           <%= image_tag 'loading.gif' %>
           <div class="loading-text">loading</div>


### PR DESCRIPTION
### Story
- https://www.pivotaltracker.com/story/show/71503760
### Notes
- using [this blogpost](http://blog.paciellogroup.com/2013/02/using-wai-aria-landmarks-2013/) as a reference, added <code>role="main"</code> landmark to main <code>#bonnie</code> div for desired "skip to main content" behavior
