### PR TITLE
Use reasonable default date for medication fulfillments

### DIFF
--- a/app/assets/javascripts/views/patient_builder/data_criteria.js.coffee
+++ b/app/assets/javascripts/views/patient_builder/data_criteria.js.coffee
@@ -220,7 +220,8 @@ class Thorax.Views.MedicationFulfillmentsView extends Thorax.Views.BuilderChildV
     serialize: (attr) ->
       if dispenseDate = attr.dispense_date
         dispenseDate += " #{attr.dispense_time}" if attr.dispense_time
-        attr.dispense_datetime = moment(dispenseDate, 'L LT').format('X')
+        attr.dispense_datetime = moment.utc(dispenseDate, 'L LT').format('X')
+    rendered: -> @setDefaultDate()
 
   initialize: ->
     @model = new Thorax.Model
@@ -231,13 +232,32 @@ class Thorax.Views.MedicationFulfillmentsView extends Thorax.Views.BuilderChildV
     isDisabled = !attributes.dispense_date || !attributes.dispense_time || !attributes.quantity_dispensed_value
     @$('button[data-call-method=addFulfillment]').prop 'disabled', isDisabled
 
+  setDefaultDate: ->
+    # use the latest fulfillment as a template
+    latest_fulfillment = @fulfillments.max((f) -> f.get('dispense_datetime')) if @fulfillments.length
+    # if dosage and frequency are specified then compute a CMD offset (derived from HQMF2JS Patient API Extension)
+    if @criteria.get('dose_value') and @criteria.get('frequency_value')
+      switch @criteria.get('frequency_unit')
+        when 'h'
+          days = 24
+        when 'd'
+          days = 1
+      dosesPerDay = days / @criteria.get('frequency_value')
+      offset = ( latest_fulfillment.get('quantity_dispensed_value') / @criteria.get('dose_value') / dosesPerDay ) * 60 * 60 * 24 * 1000
+    offset ?= 15 * 60 * 1000 # otherwise use a default offset of 15 mins
+    # use the latest date, starting with the start_date
+    date = moment.utc( @criteria.get('start_date') + offset ) if @criteria.has('start_date')
+    if latest_fulfillment?.get('dispense_datetime') * 1000 > @criteria.get('start_date')
+      date = moment.utc( latest_fulfillment.get('dispense_datetime') * 1000 + offset )
+    @$('input[name=dispense_date]').datepicker('setDate', date.format('L')) if date
+    @$('input[name=dispense_date]').datepicker('update')
+    @$('input[name=dispense_time]').timepicker('setTime', date.format('LT')) if date
+
   addFulfillment: (e) ->
     e.preventDefault()
     @serialize()
     @fulfillments.add @model.clone()
     @model.clear()
-    @$('input[name="dispense_date"]').val('')
-    @$('input[name="dispense_date"]').datepicker('update')
     @$('input[name="quantity_dispensed_value"]').val('')
     @triggerMaterialize()
 

--- a/app/assets/javascripts/views/patient_builder/data_criteria.js.coffee
+++ b/app/assets/javascripts/views/patient_builder/data_criteria.js.coffee
@@ -238,11 +238,8 @@ class Thorax.Views.MedicationFulfillmentsView extends Thorax.Views.BuilderChildV
     # if dosage and frequency are specified then compute a CMD offset (derived from HQMF2JS Patient API Extension)
     if @criteria.get('dose_value') and @criteria.get('frequency_value')
       switch @criteria.get('frequency_unit')
-        when 'h'
-          days = 24
-        when 'd'
-          days = 1
-      dosesPerDay = days / @criteria.get('frequency_value')
+        when 'h' then dosesPerDay = 24 / @criteria.get('frequency_value')
+        when 'd' then dosesPerDay = 1 / @criteria.get('frequency_value')
       offset = ( latest_fulfillment.get('quantity_dispensed_value') / @criteria.get('dose_value') / dosesPerDay ) * 60 * 60 * 24 * 1000
     offset ?= 15 * 60 * 1000 # otherwise use a default offset of 15 mins
     # use the latest date, starting with the start_date


### PR DESCRIPTION
### Story
- https://www.pivotaltracker.com/story/show/72793588
### Notes
- fixed issue with non-UTC moment usage in <code>serialize()</code> view method
- added default date method for populating fulfillment <code>dispense_date</code> and <code>dispense_time</code> based on the following logic
  - if the patient data criteria has a <code>start_date</code>
    - if the patient data criteria has at least one fulfillment
      - if the patient data criteria has both <code>dose_value</code> and <code>frequency_value</code>
        - then compute the number of days given the <code>dose_value</code>, <code>frequency_value</code>, <code>quantity_dispensed_value</code>, and fulfillment <code>dispense_datetime</code> and use that as the offset
      - else set the offset to 15 minutes after the latest fulfillment <code>dispense_date</code>
    - else set the offset to 15 minutes after the <code>start_date</code>
