### PR TITLE
Set the height for native select clickable area with SelectBoxIt

### DIFF
--- a/app/assets/javascripts/templates/patient_builder/edit_codes.hbs
+++ b/app/assets/javascripts/templates/patient_builder/edit_codes.hbs
@@ -1,7 +1,7 @@
 <div class="row">
   <div class="col-md-3">
     <label class="sr-only" for="codeset_{{@cid}}">Select code set dropdown</label>
-    <select id="codeset_{{@cid}}" name="codeset" class="codeset-control">
+    <select id="codeset_{{@cid}}" name="codeset" class="codeset-control selectBoxIt-native">
       <option value="">Code Set</option>
       {{#each codeSets}}
       <option>{{this}}</option>

--- a/app/assets/javascripts/templates/patient_builder/edit_value.hbs
+++ b/app/assets/javascripts/templates/patient_builder/edit_value.hbs
@@ -13,7 +13,7 @@
 <div class="row">
   <div class="col-md-3">
     <label class="sr-only" for="type_{{@cid}}">Value type dropdown</label>
-    <select id="type_{{@cid}}" name="type">
+    <select id="type_{{@cid}}" name="type" class="selectBoxIt-native">
       <option value="PQ" data-icon="fa fa-pencil-square-o">Scalar</option>
       <option value="CD" data-icon="fa fa-list">Coded</option>
       {{#if fieldValue}}

--- a/app/assets/stylesheets/builder.less
+++ b/app/assets/stylesheets/builder.less
@@ -306,5 +306,5 @@
   }
 }
 .selectBoxIt-native {
-  height: 30px !important;
+  height: @input-height-base !important;
 }

--- a/app/assets/stylesheets/builder.less
+++ b/app/assets/stylesheets/builder.less
@@ -305,3 +305,6 @@
     }
   }
 }
+.selectBoxIt-native {
+  height: 30px !important;
+}


### PR DESCRIPTION
### Note
- fix the SelectBoxIt height when using <code>"native": true</code> to fix clickable area triggering select dropdown
  - bootstrap <code>form-control</code> uses <code>30px</code> for select dropdown height
