### PR TITLE
Remove redundant SR labels & tweak loading dialog

### DIFF
--- a/app/assets/javascripts/templates/import/import_measure.hbs
+++ b/app/assets/javascripts/templates/import/import_measure.hbs
@@ -151,13 +151,12 @@
   <div class="modal-dialog">
     <div class="modal-content">
       <div class="modal-header">
-        <h1 id="modalTitle">Loading Measure...</h1>
-        <span class="sr-only" id="modalInstructions">This dialog will dismiss automatically once processing is complete.</span>
+        <h1 id="modalTitle">Loading Measure</h1>
       </div>
       <div class="modal-body">
         <div class="progress progress-striped active">
           <div class="progress-bar progress-bar-success" role="progressbar" aria-valuenow="100" aria-valuemin="0" aria-valuemax="100" style="width: 100%">
-            <span class="sr-only">Loading...</span>
+            <span class="sr-only">loading dialog will dismiss upon completion</span>
           </div>
         </div>
       </div>

--- a/app/assets/javascripts/templates/patient_builder/edit_criteria.hbs
+++ b/app/assets/javascripts/templates/patient_builder/edit_criteria.hbs
@@ -42,7 +42,7 @@
 
       <div class="row">
         <div class="form-group col-md-6">
-          <label for="start_date_{{@cid}}" class="control-label"><i class="fa fa-clock-o" aria-hidden="true"></i> Start<span class="sr-only"> start date month/day/year</span></label></label>
+          <label for="start_date_{{@cid}}" class="control-label"><i class="fa fa-clock-o" aria-hidden="true"></i> Start<span class="sr-only"> date month/day/year</span></label></label>
           <div class="datetime-control">
             <div>
               <input type="text" name="start_date" id="start_date_{{@cid}}" class="date-picker form-control" placeholder="mm/dd/yyyy" data-date-format="mm/dd/yyyy" data-date-keyboard-navigation="false" data-date-autoclose="true">
@@ -56,7 +56,7 @@
         </div>
 
         <div class="form-group col-md-6">
-          <label for="end_date_{{@cid}}" class="control-label"><i class="fa fa-clock-o" aria-hidden="true"></i> Stop<span class="sr-only"> end date month/day/year</span></label>
+          <label for="end_date_{{@cid}}" class="control-label"><i class="fa fa-clock-o" aria-hidden="true"></i> Stop<span class="sr-only"> date month/day/year</span></label>
           <div class="datetime-control">
             <div>
               <input type="text" name="end_date" id="end_date_{{@cid}}" class="date-picker form-control" placeholder="mm/dd/yyyy" data-date-format="mm/dd/yyyy" data-date-keyboard-navigation="false" data-date-autoclose="true"{{#if end_date_is_undefined}} disabled{{/if}}>
@@ -109,7 +109,7 @@
       {{#ifCond definition "==" "medication"}}
         <div class="row">
           <div class="form-group col-md-6">
-            <label for="dose_value_{{@cid}}" class="control-label"><i class="fa fa-medkit"></i> Dose<span class="sr-only"> dose value</span></label>
+            <label for="dose_value_{{@cid}}" class="control-label"><i class="fa fa-medkit" aria-hidden="true"></i> Dose<span class="sr-only"> value</span></label>
             <div class="row">
               <div class="col-xs-8">
                 <input type="text" name="dose_value" id="dose_value_{{@cid}}" class="form-control" placeholder="input">
@@ -124,7 +124,7 @@
             </div>
           </div>
           <div class="form-group col-md-6">
-            <label for="frequency_value_{{@cid}}" class="control-label"><i class="fa fa-spinner"></i> Frequency<span class="sr-only"> frequency value</span></label>
+            <label for="frequency_value_{{@cid}}" class="control-label"><i class="fa fa-spinner" aria-hidden="true"></i> Frequency<span class="sr-only"> value</span></label>
             <div class="row">
               <div class="col-xs-7">
                 <input type="text" name="frequency_value" id="frequency_value_{{@cid}}" class="form-control" placeholder="input">


### PR DESCRIPTION
### Notes
- these are leftover changes from @jmccloud 's current <code>loadingDialog</code> branch
- changed measure upload loading dialog title and SR-only text
- removed redundant SR-only text from patient data criteria input fields
