### PR TITLE
fix shifting input fields when logging into bonnie with jaws

### DIFF
--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -14,8 +14,8 @@
       <%= f.email_field :email, class: "form-control", placeholder: "email@example.com" %>
     </div>
     <div class="form-group input-group input-group-lg">
-      <label for="user_password" class="sr-only">Password </label>
       <span class="input-group-addon"><i class="fa fa-lock fa-lg fa-fw" aria-hidden="true"></i></span>
+      <label for="user_password" class="sr-only">Password </label>
       <%= f.password_field :password, class: "form-control", placeholder: "password" %>
     </div>
 


### PR DESCRIPTION
### Story

https://www.pivotaltracker.com/story/show/73904952
### Notes
- I moved the password `<label>` from before to after the `<span>` (so it now follows the pattern of the email login). Somehow that seems to have fixed [the problem](https://s3.amazonaws.com/prod.tracker2/resource/33089136/bonnieIE.png?AWSAccessKeyId=AKIAIKWOAN6H4H3QMJ6Q&Expires=1403892653&Signature=gM6RTAZAKTzKoXB3PtV6FV6fK1A%3D)!
