### PR TITLE
Display temporal references for subtree data criteria in logic view

### DIFF
--- a/app/assets/javascripts/templates/logic/data_criteria.hbs
+++ b/app/assets/javascripts/templates/logic/data_criteria.hbs
@@ -15,6 +15,11 @@
             {{view "DataCriteriaLogic" reference=this measure=../measure tag="span"}}
           </li>
         {{/each}}
+        {{#if dataCriteria.temporal_references}}
+          {{#each dataCriteria.temporal_references}}
+            <li>{{view "TemporalReferenceLogic" temporalReference=this measure=../measure tag="span"}}</li>
+          {{/each}}
+        {{/if}}
       </ul>
     {{/if}}
   {{/if}}


### PR DESCRIPTION
### Notes
- render temporal reference statements as list items below a subtree group of data criteria in logic view
