### PR TITLE
Auto un/select expected values in patient builder

### DIFF
--- a/app/assets/javascripts/templates/logic/data_criteria.hbs
+++ b/app/assets/javascripts/templates/logic/data_criteria.hbs
@@ -17,7 +17,11 @@
         {{/each}}
         {{#if dataCriteria.temporal_references}}
           {{#each dataCriteria.temporal_references}}
-            <li>{{view "TemporalReferenceLogic" temporalReference=this measure=../measure tag="span"}}</li>
+            <li>
+              <span class="{{../dataCriteria.key}} rationale-target">
+                {{view "TemporalReferenceLogic" temporalReference=this measure=../measure tag="span"}}
+              </span>
+            </li>
           {{/each}}
         {{/if}}
       </ul>

--- a/app/assets/javascripts/templates/patient_builder/expected_value.hbs
+++ b/app/assets/javascripts/templates/patient_builder/expected_value.hbs
@@ -3,8 +3,11 @@
   {{#each currentCriteria}}
     {{#ifCond key "==" "OBSERV"}}
       <div class="form-group">
-        <label for="{{key}}_{{@cid}}">{{displayName}}</label>
-        {{#button "toggleUnits" class="btn btn-xs btn-default"}}{{../../../OBSERV_UNIT}}{{/button}}
+        <label for="{{key}}_{{@cid}}" class="checkbox-inline">{{displayName}}</label>
+        <div class="btn-group">
+          {{#button "setPerc" class="btn btn-xs btn-observ-unit-perc"}} % {{/button}}
+          {{#button "setMins" class="btn btn-xs btn-observ-unit-mins"}} mins {{/button}}
+        </div>
         {{#each ../../OBSERV}}
           <input type="number" id="{{../key}}_{{@index}}" name="{{../key}}" min="0" value="{{this}}">
         {{/each}}
@@ -16,15 +19,8 @@
           <input type="number" id="{{key}}_{{@cid}}" name="{{key}}" min="0">
         </div>
       {{else}}
-        {{#ifCond key "==" "MSRPOPL"}}
-          <div class="form-group">
-            <label for="{{key}}_{{@cid}}">{{displayName}}</label>
-            <input type="number" id="{{key}}_{{@cid}}" name="{{key}}" min="0">
-          </div>
-        {{else}}
-          <label for="{{key}}_{{@cid}}" class="checkbox-inline">{{displayName}}</label>
-          <input type="checkbox" id="{{key}}_{{@cid}}" name="{{key}}">
-        {{/ifCond}}
+        <label for="{{key}}_{{@cid}}" class="checkbox-inline">{{displayName}}</label>
+        <input type="checkbox" id="{{key}}_{{@cid}}" name="{{key}}">
       {{/if}}
     {{/ifCond}}
   {{/each}}

--- a/app/assets/javascripts/views/patient_builder/expected_values.js.coffee
+++ b/app/assets/javascripts/views/patient_builder/expected_values.js.coffee
@@ -57,7 +57,7 @@ class Thorax.Views.ExpectedValueView extends Thorax.Views.BuilderChildView
     serialize: (attr) ->
       population = @measure.get('populations').at @model.get('population_index')
       for pc in @measure.populationCriteria() when population.has(pc)
-        if @isNumbers || (@isMultipleObserv && (pc == 'OBSERV' || pc == 'MSRPOPL'))
+        if @isNumbers || (@isMultipleObserv && (pc == 'OBSERV'))
           # Only parse existing values
           if attr[pc]
             if pc == 'OBSERV'
@@ -66,7 +66,7 @@ class Thorax.Views.ExpectedValueView extends Thorax.Views.BuilderChildView
             else
               attr[pc] = parseFloat(attr[pc])
             # if we're dealing with OBSERV or MSRPOPL, set to undefined for empty value
-          else attr[pc] = undefined if pc == 'OBSERV' or pc == 'MSRPOPL'
+          else attr[pc] = undefined if pc == 'OBSERV'
         else
           attr[pc] = if attr[pc] then 1 else 0 # Convert from check-box true/false to 0/1
     'blur input': 'selectPopulations'
@@ -76,7 +76,7 @@ class Thorax.Views.ExpectedValueView extends Thorax.Views.BuilderChildView
   context: ->
     context = super
     for pc in @measure.populationCriteria()
-      unless @isNumbers || (@isMultipleObserv && (pc == 'OBSERV' || pc == 'MSRPOPL'))
+      unless @isNumbers || (@isMultipleObserv && (pc == 'OBSERV'))
         context[pc] = (context[pc] == 1)
     context
 
@@ -103,7 +103,6 @@ class Thorax.Views.ExpectedValueView extends Thorax.Views.BuilderChildView
         isEoC: @isNumbers
     unless @model.has('OBSERV_UNIT') or not @isMultipleObserv then @model.set 'OBSERV_UNIT', ' mins', {silent:true}
 
-
   updateObserv: ->
     if @isMultipleObserv and @model.has('MSRPOPL') and @model.get('MSRPOPL')?
       values = @model.get('MSRPOPL')
@@ -121,26 +120,37 @@ class Thorax.Views.ExpectedValueView extends Thorax.Views.BuilderChildView
     if @model.get('OBSERV')?.length
         for val, index in @model.get('OBSERV')
           @$("#OBSERV_#{index}").val(val)
+    @toggleUnits()
 
   toggleUnits: (e) ->
-    if @model.get('OBSERV_UNIT') == ' mins'
-      @model.set 'OBSERV_UNIT', '%'
+    if @model.has('OBSERV_UNIT') and @model.get('OBSERV')?.length
+      if @model.get('OBSERV_UNIT') == '%'
+        @$('.btn-observ-unit-perc').removeClass('btn-default').addClass('btn-primary').prop('disabled',true)
+        @$('.btn-observ-unit-mins').addClass('btn-default').removeClass('btn-primary').prop('disabled',false)
+      else
+        @$('.btn-observ-unit-mins').removeClass('btn-default').addClass('btn-primary').prop('disabled',true)
+        @$('.btn-observ-unit-perc').addClass('btn-default').removeClass('btn-primary').prop('disabled',false)
     else
-      @model.set 'OBSERV_UNIT', ' mins'
+      @$('.btn-observ-unit-mins').removeClass('btn-default btn-primary').prop('disabled',true)
+      @$('.btn-observ-unit-perc').removeClass('btn-default btn-primary').prop('disabled',true)
+
+  setPerc: (e) ->
+    @model.set 'OBSERV_UNIT', '%'
+    @updateObserv()
+
+  setMins: (e) ->
+    @model.set 'OBSERV_UNIT', ' mins'
     @updateObserv()
 
   selectPopulations: (e) ->
     populationCode = @$(e.target).attr('name')
-    if @isCheckboxes
+    if @isCheckboxes or not @isNumbers and @isMultipleObserv
       currentValue = @$(e.target).prop('checked')
       @handleSelect(populationCode, currentValue, currentValue)
     else if @isNumbers
       currentValue = @$(e.target).val()
       increment = currentValue > @model.get(populationCode)
-      console.log "#{increment} = #{currentValue} >= #{@model.get(populationCode)}"
       @handleSelect(populationCode, currentValue, increment)
-    else if @isMultipleObserv
-      ''
     @triggerMaterialize()
 
   handleSelect: (population, value, increment) ->
@@ -171,9 +181,10 @@ class Thorax.Views.ExpectedValueView extends Thorax.Views.BuilderChildView
 
   setPopulation: (population, value) ->
     if @model.has(population) and @model.get(population)?
-      if @isCheckboxes
+      if @isCheckboxes or not @isNumbers and @isMultipleObserv
         @$("input[name=\"#{population}\"]").prop('checked', value)
       else if @isNumbers
         @$("input[name=\"#{population}\"]").val(value)
-      else if @isMultipleObserv
-        ''
+    if @isMultipleObserv
+      @serialize()
+      @updateObserv() if @isMultipleObserv and population == 'MSRPOPL'

--- a/app/assets/stylesheets/builder.less
+++ b/app/assets/stylesheets/builder.less
@@ -124,6 +124,9 @@
           input[name=OBSERV] {
             width: 45px;
           }
+          .btn-observ-unit-perc, .btn-observ-unit-mins {
+            opacity: 1.0;
+          }
         }
       }
     }

--- a/spec/javascripts/views/patient_builder_spec.js.coffee
+++ b/spec/javascripts/views/patient_builder_spec.js.coffee
@@ -257,13 +257,46 @@ describe 'PatientBuilderView', ->
   describe "setting expected values", ->
     beforeEach ->
       @patientBuilder.appendTo 'body'
-      @patientBuilder.$('input[type=checkbox][name=DENOM]:first').click()
-      @patientBuilder.$("button[data-call-method=save]").click()
+      @selectPopulationEV = (population, save=true, blur=false) ->
+        @patientBuilder.$("input[type=checkbox][name=#{population}]:first").click()
+        @patientBuilder.$("input[type=checkbox][name=#{population}]:first").blur() if blur
+        @patientBuilder.$("button[data-call-method=save]").click() if save
 
     it "serializes the expected values correctly", ->
+      @selectPopulationEV('DENOM')
       expectedValues = @patientBuilder.model.get('expected_values').findWhere(population_index: 0)
       expect(expectedValues.get('IPP')).toEqual 0
       expect(expectedValues.get('DENOM')).toEqual 1
+      expect(expectedValues.get('NUMER')).toEqual 0
+
+    it "auto selects IPP when DENOM is selected", ->
+      @selectPopulationEV('DENOM', true, true)
+      expectedValues = @patientBuilder.model.get('expected_values').findWhere(population_index: 0)
+      expect(expectedValues.get('IPP')).toEqual 1
+      expect(expectedValues.get('DENOM')).toEqual 1
+      expect(expectedValues.get('NUMER')).toEqual 0
+
+    it "auto selects DENOM and IPP when NUMER is selected", ->
+      @selectPopulationEV('NUMER', true, true)
+      expectedValues = @patientBuilder.model.get('expected_values').findWhere(population_index: 0)
+      expect(expectedValues.get('IPP')).toEqual 1
+      expect(expectedValues.get('DENOM')).toEqual 1
+      expect(expectedValues.get('NUMER')).toEqual 1
+
+    it "auto unselects DENOM when IPP is unselected", ->
+      @selectPopulationEV('DENOM', true, true)
+      @selectPopulationEV('IPP', true, true)
+      expectedValues = @patientBuilder.model.get('expected_values').findWhere(population_index: 0)
+      expect(expectedValues.get('IPP')).toEqual 0
+      expect(expectedValues.get('DENOM')).toEqual 0
+      expect(expectedValues.get('NUMER')).toEqual 0
+
+    it "auto unselects DENOM and NUMER when IPP is unselected", ->
+      @selectPopulationEV('NUMER', true, true)
+      @selectPopulationEV('IPP', true, true)
+      expectedValues = @patientBuilder.model.get('expected_values').findWhere(population_index: 0)
+      expect(expectedValues.get('IPP')).toEqual 0
+      expect(expectedValues.get('DENOM')).toEqual 0
       expect(expectedValues.get('NUMER')).toEqual 0
 
     afterEach -> @patientBuilder.remove()

--- a/spec/javascripts/views/patient_builder_spec.js.coffee
+++ b/spec/javascripts/views/patient_builder_spec.js.coffee
@@ -257,43 +257,42 @@ describe 'PatientBuilderView', ->
   describe "setting expected values", ->
     beforeEach ->
       @patientBuilder.appendTo 'body'
-      @selectPopulationEV = (population, save=true, blur=false) ->
+      @selectPopulationEV = (population, save=true) ->
         @patientBuilder.$("input[type=checkbox][name=#{population}]:first").click()
-        @patientBuilder.$("input[type=checkbox][name=#{population}]:first").blur() if blur
         @patientBuilder.$("button[data-call-method=save]").click() if save
 
     it "serializes the expected values correctly", ->
       @selectPopulationEV('DENOM')
       expectedValues = @patientBuilder.model.get('expected_values').findWhere(population_index: 0)
-      expect(expectedValues.get('IPP')).toEqual 0
+      expect(expectedValues.get('IPP')).toEqual 1
       expect(expectedValues.get('DENOM')).toEqual 1
       expect(expectedValues.get('NUMER')).toEqual 0
 
     it "auto selects IPP when DENOM is selected", ->
-      @selectPopulationEV('DENOM', true, true)
+      @selectPopulationEV('DENOM', true)
       expectedValues = @patientBuilder.model.get('expected_values').findWhere(population_index: 0)
       expect(expectedValues.get('IPP')).toEqual 1
       expect(expectedValues.get('DENOM')).toEqual 1
       expect(expectedValues.get('NUMER')).toEqual 0
 
     it "auto selects DENOM and IPP when NUMER is selected", ->
-      @selectPopulationEV('NUMER', true, true)
+      @selectPopulationEV('NUMER', true)
       expectedValues = @patientBuilder.model.get('expected_values').findWhere(population_index: 0)
       expect(expectedValues.get('IPP')).toEqual 1
       expect(expectedValues.get('DENOM')).toEqual 1
       expect(expectedValues.get('NUMER')).toEqual 1
 
     it "auto unselects DENOM when IPP is unselected", ->
-      @selectPopulationEV('DENOM', true, true)
-      @selectPopulationEV('IPP', true, true)
+      @selectPopulationEV('DENOM', false)
+      @selectPopulationEV('IPP', true)
       expectedValues = @patientBuilder.model.get('expected_values').findWhere(population_index: 0)
       expect(expectedValues.get('IPP')).toEqual 0
       expect(expectedValues.get('DENOM')).toEqual 0
       expect(expectedValues.get('NUMER')).toEqual 0
 
     it "auto unselects DENOM and NUMER when IPP is unselected", ->
-      @selectPopulationEV('NUMER', true, true)
-      @selectPopulationEV('IPP', true, true)
+      @selectPopulationEV('NUMER', false)
+      @selectPopulationEV('IPP', true)
       expectedValues = @patientBuilder.model.get('expected_values').findWhere(population_index: 0)
       expect(expectedValues.get('IPP')).toEqual 0
       expect(expectedValues.get('DENOM')).toEqual 0


### PR DESCRIPTION
### Story
- https://www.pivotaltracker.com/story/show/73827152
### Notes
- **updated**
  - include highlight fix for nested subtree temporal references
  - updated auto selection to trigger on <code>change</code> rather than <code>blur</code> events
  - added manual fix for tab deselection when modifying CV EoC measures
  - updated jasmine tests to reflect materialization removal
- included fix for CV measures having only one MSRPOPL for patient-based measure
- included update to OBSERV_UNIT toggle buttons to be better aligned with the UI
- added jasmine tests for IPP, DENOM, NUMER auto selections
- added <code>selectPopulations</code> method that is triggered when a population's expected value is blurred, which enforces the following rules
  - if using non-episode of care and non-CV or patient-based CV measures
    - select IPP -> handle STRAT if it exists (untested)
    - select DENOM or MSRPOPL -> handle IPP
    - select NUMER or DENEX or DENEXCEP -> handle DENOM
    - unselect STRAT -> handle IPP
    - unselect IPP -> handle DENOM and MSRPOPL (if CV measure)
    - unselect DENOM or MSRPOPL -> handle NUMER and DENEX and DENEXCEP
  - else if using Episode of care measures
    - increment IPP -> handle STRAT if it exists and is lesser (untested)
    - increment DENOM or MSRPOPL -> handle IPP if it is lesser
    - increment NUMER or DENEX or DENEXCEP -> handle DENOM if it is lesser
    - decrement STRAT -> handle IPP if it is greater
    - decrement IPP -> handle DENOM and MSRPOPL (if CV measure) if they are greater
    - decrement DENOM or MSRPOPL -> handle NUMER and DENEX and DENEXCEP if they are greater
