### PR TITLE
Fixes browse button being hard to click

### DIFF
--- a/app/assets/javascripts/templates/import/import_measure.hbs
+++ b/app/assets/javascripts/templates/import/import_measure.hbs
@@ -46,8 +46,8 @@
               <div class="col-sm-offset-{{titleSize}} vsac-registration"><a href="https://uts.nlm.nih.gov/license.html" target="_blank"><i class="fa fa-plus-circle" aria-hidden="true"></i> Register for VSAC</a></div>
             </div>
             <div class="form-group">
-              <label for="vsacDate" class="col-lg-{{titleSize}} control-label">VSAC Effective Date</label>
-              <div class="col-lg-{{dataSize}}">
+              <label for="vsacDate" class="col-sm-{{titleSize}} control-label">VSAC Effective Date</label>
+              <div class="col-sm-{{dataSize}}">
                 <input type="text" name="vsac_date" id="vsacDate" class="date-picker form-control" placeholder="mm/dd/yyyy" data-date-format="mm/dd/yyyy" data-date-autoclose="true">
               </div>
             </div>

--- a/app/assets/javascripts/views/import_measure_view.js.coffee
+++ b/app/assets/javascripts/views/import_measure_view.js.coffee
@@ -26,7 +26,6 @@ class Thorax.Views.ImportMeasure extends Thorax.Views.BonnieView
     rendered: -> 
       @$("option[value=\"#{eoc}\"]").attr('selected','selected') for eoc in @model.get('episode_ids') if @model? && @model.get('episode_of_care') && @model.get('episode_ids')?
       @$el.on 'hidden.bs.modal', -> @remove() unless $('#pleaseWaitDialog').is(':visible')
-      @$('.nice_input').bootstrapFileInput()
       @$("input[type=radio]:checked").next().css("color","white")
       @$('.date-picker').datepicker('setDate', moment().format('L'))
     'ready': 'setup'
@@ -69,6 +68,7 @@ class Thorax.Views.ImportMeasure extends Thorax.Views.BonnieView
       "backdrop" : "static",
       "keyboard" : true,
       "show" : true)
+    @$('.nice_input').bootstrapFileInput()
 
   submit: ->
     @importWait.modal(


### PR DESCRIPTION
### Story
- https://www.pivotaltracker.com/story/show/75061966
### Notes
- The mouseover event that fixes this issue had not been properly binding to the input when being called in the rendered event, so it's moved to the display method and now works. Very thankful for @jtferns's investigation!

I also made a small markup change so that the input/label for VSAC Effective Date lines up with the rest of the parts of the dialog.
