### PR TITLE
Measure complexity

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,7 +44,7 @@ GIT
 
 GIT
   remote: https://github.com/projecttacoma/bonnie_bundler.git
-  revision: 9fc0fe6fc4749a1cb34b3a34581618854bd75fe8
+  revision: d35ec87da3f39065e588fccd64882dc91e4fcc34
   branch: master
   specs:
     bonnie_bundler (1.0.0)

--- a/app/assets/javascripts/templates/logic/population_criteria.hbs
+++ b/app/assets/javascripts/templates/logic/population_criteria.hbs
@@ -18,12 +18,15 @@
   </div>
   <div id="collapse{{cid}}" class="panel-collapse collapse{{#unless exceedsComplexityThreshold}} in{{/unless}}">
     <div class="panel-body">
-    {{#if population.comments}}{{#each population.comments}}<div># {{this}}</div>{{/each}}{{/if}}
+    {{#if deferRender}}
+      <img src="/assets/loading.gif"></img>
+    {{else}}
+      {{#if population.comments}}{{#each population.comments}}<div># {{this}}</div>{{/each}}{{/if}}
       {{#if rootPreconditon}}
         {{#if rootPreconditon.preconditions }}
-         {{#each rootPreconditon.preconditions}}
-          {{view "PreconditionLogic" precondition=this parentPrecondition=../rootPreconditon measure=../measure}}
-        {{/each}}
+          {{#each rootPreconditon.preconditions}}
+            {{view "PreconditionLogic" precondition=this parentPrecondition=../rootPreconditon measure=../measure}}
+          {{/each}}
         {{else}}
           <ul>
             <li>
@@ -34,6 +37,7 @@
       {{else}}
         None
       {{/if}}
+    {{/if}}
     </div>
   </div>
 </div>

--- a/app/assets/javascripts/templates/logic/population_criteria.hbs
+++ b/app/assets/javascripts/templates/logic/population_criteria.hbs
@@ -5,14 +5,18 @@
         <div>
           <span class="population-label {{population.type}} rationale-target"><b>{{translate_population population.type}}: </b><span class="sr-only sr-highlight-status"></span></span>
           <div class="pull-right">
-            <i class="fa fa-lg fa-angle-down toggle-icon" aria-hidden="true"></i>
+            {{#if exceedsComplexityThreshold}}
+              <i class="fa fa-lg fa-angle-right toggle-icon" aria-hidden="true"></i>
+            {{else}}
+              <i class="fa fa-lg fa-angle-down toggle-icon" aria-hidden="true"></i>
+            {{/if}}
             <span class="sr-only">toggle {{translate_population population.type}}</span>
           </div>
         </div>
       </a>
     </h4>
   </div>
-  <div id="collapse{{cid}}" class="panel-collapse collapse in">
+  <div id="collapse{{cid}}" class="panel-collapse collapse{{#unless exceedsComplexityThreshold}} in{{/unless}}">
     <div class="panel-body">
     {{#if population.comments}}{{#each population.comments}}<div># {{this}}</div>{{/each}}{{/if}}
       {{#if rootPreconditon}}

--- a/app/assets/javascripts/views/logic/population_criteria_logic_view.js.coffee
+++ b/app/assets/javascripts/views/logic/population_criteria_logic_view.js.coffee
@@ -18,12 +18,22 @@ class Thorax.Views.PopulationCriteriaLogic extends Thorax.Views.BonnieView
   initialize: ->
     @rootPreconditon = @population.preconditions[0] if @population.preconditions?.length > 0
     @aggregator = @population.aggregator
+    @deferRender = @exceedsComplexityThreshold()
 
   translate_population: (code) ->
     @population_map[code]
 
   translate_aggregator: (code) ->
     @aggregator_map[code]
+
+  render: ->
+    # If this population is big and complex, the first render just renders a placeholder image (not visible
+    # because the population isn't expanded), and we render again immediately after in a deferred fashion
+    result = super
+    if @deferRender
+      @deferRender = false
+      setTimeout (=> @render()), 0
+    result
 
   # If we have complexity data, and if it exceeds 50 (a reasonable baseline indicating
   # a complex measure) for this population, we start with the panel unexpanded

--- a/app/assets/javascripts/views/logic/population_criteria_logic_view.js.coffee
+++ b/app/assets/javascripts/views/logic/population_criteria_logic_view.js.coffee
@@ -24,3 +24,9 @@ class Thorax.Views.PopulationCriteriaLogic extends Thorax.Views.BonnieView
 
   translate_aggregator: (code) ->
     @aggregator_map[code]
+
+  # If we have complexity data, and if it exceeds 50 (a reasonable baseline indicating
+  # a complex measure) for this population, we start with the panel unexpanded
+  exceedsComplexityThreshold: ->
+    return false unless complexity = @measure.get('complexity')
+    return !!complexity[@population.code] && complexity[@population.code] > 50

--- a/app/assets/javascripts/views/logic/population_logic_view.js.coffee
+++ b/app/assets/javascripts/views/logic/population_logic_view.js.coffee
@@ -46,8 +46,6 @@ class Thorax.Views.PopulationLogic extends Thorax.Views.BonnieView
           @showRationaleForPopulation(code, rationale, updatedRationale)
       @showRationaleForPopulation('variables', rationale, updatedRationale)
 
-    @expandPopulations()
-
   showRationaleForPopulation: (code, rationale, updatedRationale) ->
     for key, value of rationale
       target = @$(".#{code}_children .#{key}")
@@ -107,9 +105,3 @@ class Thorax.Views.PopulationLogic extends Thorax.Views.BonnieView
     if @$('.eval-coverage').length > 0
       @$('.rationale .rationale-target').removeClass('eval-coverage')
       @$('.sr-highlight-status').empty()
-
-  expandPopulations: ->
-    @$('.panel-population > a[data-toggle="collapse"]').removeClass('collapsed')
-    @$('.toggle-icon').removeClass('fa-angle-right').addClass('fa-angle-down')
-    @$('.panel-collapse').removeClass('collapse').addClass('in').css('height','auto')
-


### PR DESCRIPTION
Don't automatically expand population logic that exceeds a complexity threshold, and defer rendering of complex measure populations.

Before merging, please see if the functionality feels reasonable from a usability perspective in addition to looking at the code.
