### PR TITLE
Fix EoC numerical checks for IPP and DENOM, reset tab for CV measures

### DIFF
--- a/app/assets/javascripts/views/patient_builder/expected_values.js.coffee
+++ b/app/assets/javascripts/views/patient_builder/expected_values.js.coffee
@@ -169,11 +169,11 @@ class Thorax.Views.ExpectedValueView extends Thorax.Views.BuilderChildView
     else
       switch population
         when 'STRAT'
-          @setPopulation('IPP', value)
+          @setPopulation('IPP', value) unless @isNumbers and @attrs['IPP'] < value
           @handleSelect('IPP', value, increment)
         when 'IPP'
-          @setPopulation('DENOM', value)
-          @setPopulation('MSRPOPL', value) if @isMultipleObserv
+          @setPopulation('DENOM', value) unless @isNumbers and @attrs['DENOM'] < value
+          @setPopulation('MSRPOPL', value) unless @isNumbers and @attrs['MSRPOPL'] < value or not @isMultipleObserv
           @handleSelect('DENOM', value, increment)
         when 'DENOM', 'MSRPOPL'
           @setPopulation('DENEX', value) unless @isNumbers and @attrs['DENEX'] < value
@@ -188,4 +188,5 @@ class Thorax.Views.ExpectedValueView extends Thorax.Views.BuilderChildView
         @$("input[name=\"#{population}\"]").val(value)
     if @isMultipleObserv
       @serialize()
+      $("a[href=\"#expected-#{@model.get('population_index')}\"]").parent().addClass('active') # reset the active tab for CV measures
       @updateObserv() if @isMultipleObserv and population == 'MSRPOPL'


### PR DESCRIPTION
### Notes
- added value checks for EoC measures for IPP, DENOM, and MSRPOPL
- added tab selection fix for CV measures
- resolved test cases
  - for EoC measure, set NUMER to 9, drop DENOM to 7, and then increment IPP to 8 (DENOM incorrectly incremented to 8)
  - for CV measure, set MSRPOPL to 5, and then modify IPP, tab selection issue resurfaces
