### PR TITLE
Handle latest MAT comments in population logic views

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -25,7 +25,7 @@ GIT
 
 GIT
   remote: https://github.com/projectcypress/health-data-standards.git
-  revision: 7cf6ba52a8eb9aa6bb5c87ff4de78a4fdddd2585
+  revision: c412f671a99aa001bc3c528d4d01674fce264f73
   branch: bonnie_master
   specs:
     health-data-standards (3.4.6)
@@ -44,14 +44,14 @@ GIT
 
 GIT
   remote: https://github.com/projecttacoma/bonnie_bundler.git
-  revision: d35ec87da3f39065e588fccd64882dc91e4fcc34
+  revision: eb2b2445572b9bb7dba237a0e6cecd067f09ef9b
   branch: master
   specs:
     bonnie_bundler (1.0.0)
 
 GIT
   remote: https://github.com/projecttacoma/simplexml_parser.git
-  revision: 4224b5799b6ba614d0f6a3db74bd927877ef1926
+  revision: 3957614508277c300bdf5d45cd5d3853639d56c0
   branch: master
   specs:
     simplexml_parser (1.0.0)

--- a/app/assets/javascripts/templates/logic/population_criteria.hbs
+++ b/app/assets/javascripts/templates/logic/population_criteria.hbs
@@ -21,7 +21,7 @@
     {{#if deferRender}}
       <img src="/assets/loading.gif"></img>
     {{else}}
-      {{#if population.comments}}{{#each population.comments}}<div># {{this}}</div>{{/each}}{{/if}}
+      {{#if comments}}{{#each comments}}<div class="logic-comment"># {{this}}</div>{{/each}}{{/if}}
       {{#if rootPreconditon}}
         {{#if rootPreconditon.preconditions }}
           {{#each rootPreconditon.preconditions}}

--- a/app/assets/javascripts/templates/logic/precondition.hbs
+++ b/app/assets/javascripts/templates/logic/precondition.hbs
@@ -1,6 +1,6 @@
 <ul id="precondition_{{precondition.id}}">
   <li>
-    {{#if comments}}{{#each comments}}<div># {{this}}</div>{{/each}}{{/if}}
+    {{#if comments}}{{#each comments}}<div class="logic-comment"># {{this}}</div>{{/each}}{{/if}}
     <span class="conjunction {{parentPreconditionKey}} rationale-target">
       {{translate_conjunction parentPrecondition.conjunction_code}}
       {{#if negation}} NOT{{/if}}: 

--- a/app/assets/javascripts/views/logic/population_criteria_logic_view.js.coffee
+++ b/app/assets/javascripts/views/logic/population_criteria_logic_view.js.coffee
@@ -19,6 +19,7 @@ class Thorax.Views.PopulationCriteriaLogic extends Thorax.Views.BonnieView
     @rootPreconditon = @population.preconditions[0] if @population.preconditions?.length > 0
     @aggregator = @population.aggregator
     @deferRender = @exceedsComplexityThreshold()
+    @comments = _(@rootPreconditon?.comments || []).union(@population?.comments || [])
 
   translate_population: (code) ->
     @population_map[code]

--- a/app/assets/javascripts/views/logic/precondition_logic_view.js.coffee
+++ b/app/assets/javascripts/views/logic/precondition_logic_view.js.coffee
@@ -10,9 +10,10 @@ class Thorax.Views.PreconditionLogic extends Thorax.Views.BonnieView
     @parentPreconditionKey = "precondition_#{@parentPrecondition.id}"
     @negation = @precondition.negation
     @unwrapNegation() if @negation
+    @comments = @precondition.comments
     if @precondition.reference
       dataCriteria = @measure.get('data_criteria')[@precondition.reference]
-      @comments = dataCriteria?.comments
+      @comments = _(@comments || []).union(dataCriteria?.comments || [])
 
   # this gets negation logic display to align with the human readable from the MAT
   unwrapNegation: ->

--- a/app/assets/stylesheets/bootstrap3.less
+++ b/app/assets/stylesheets/bootstrap3.less
@@ -6,6 +6,7 @@
 @brand-primary: #0075C4;
 @gray-lighter: #f6f6f6;
 @gray-light: #e2e2e2;
+@gray-medium: #aaa;
 @gray-darker: #888;
 
 @border-radius-base: 0px;

--- a/app/assets/stylesheets/bootstrap3.less
+++ b/app/assets/stylesheets/bootstrap3.less
@@ -6,7 +6,6 @@
 @brand-primary: #0075C4;
 @gray-lighter: #f6f6f6;
 @gray-light: #e2e2e2;
-@gray-medium: #aaa;
 @gray-darker: #888;
 
 @border-radius-base: 0px;

--- a/app/assets/stylesheets/measure.less
+++ b/app/assets/stylesheets/measure.less
@@ -186,9 +186,11 @@
     .make-sm-column(12);
     padding-top: 15px;
     padding-left: 0px;
-    .logic-comment {
-      font-style: italic;
-      color: @gray-medium;
-    }
   }
+}
+.logic-comment {
+  font-style: italic;
+  color: @gray-darker;
+  font-size: 12px;
+  padding: 5px 0;
 }

--- a/app/assets/stylesheets/measure.less
+++ b/app/assets/stylesheets/measure.less
@@ -186,5 +186,8 @@
     .make-sm-column(12);
     padding-top: 15px;
     padding-left: 0px;
+    .logic-comment {
+      font-style: italic;
+    }
   }
 }

--- a/app/assets/stylesheets/measure.less
+++ b/app/assets/stylesheets/measure.less
@@ -188,6 +188,7 @@
     padding-left: 0px;
     .logic-comment {
       font-style: italic;
+      color: @gray-medium;
     }
   }
 }


### PR DESCRIPTION
### Story
- https://www.pivotaltracker.com/story/show/75374788
### Notes
- updated Gemfile to point to latest <code>bonnie_bundler</code>, <code>health-data-standards</code> (bonnie_master branch), and <code>simplexml_parser</code>
- renders comments for preconditions (including root preconditions within populations)
- styled to match generated MAT human readable with italicized comments
### Screenshot

![screen shot 2014-07-22 at 9 24 50 am](https://cloud.githubusercontent.com/assets/456952/3658473/f1aa3b74-11a3-11e4-9d81-ca733be74c8f.png)
