### PR TITLE
Simple Admin view stats

### DIFF
--- a/app/assets/javascripts/router.js.coffee
+++ b/app/assets/javascripts/router.js.coffee
@@ -41,8 +41,8 @@ class BonnieRouter extends Backbone.Router
   renderUsers: ->
     @calculator.cancelCalculations()
     @users = new Thorax.Collections.Users()
-    @users.fetch()
     usersView = new Thorax.Views.Users(collection: @users)
+    @users.fetch(success: => usersView.render())
     @mainView.setView(usersView)
 
   renderPatientBuilder: (measureHqmfSetId, patientId) ->

--- a/app/assets/javascripts/templates/users/users.hbs
+++ b/app/assets/javascripts/templates/users/users.hbs
@@ -1,4 +1,18 @@
+{{#button "toggleStats" class="btn btn-default pull-right btn-toggle-stats"}}<i class="fa fa-bar-chart-o"></i> Stats{{/button}}
+
 <h1><i class="fa fa-users" aria-hidden="true"></i> Users ({{collection.length}})</h1>
+
+<div class="panel panel-default stats-panel hidden">
+  <div class="panel-heading">
+    <h3 class="panel-title">Stats</h3>
+  </div>
+  <div class="panel-body">
+    Total registered users: <strong>{{collection.length}}</strong></br>
+    <strong>{{activeUsers.length}}</strong> users have measures loaded.</br>
+    Those <strong>{{activeUsers.length}}</strong> users have <strong>{{activeMeasuresCount}}</strong> measures loaded; the user with the most measures loaded has <strong>{{activeMeasuresMax}}</strong>.</br>
+    Those <strong>{{activeUsers.length}}</strong> users have created <strong>{{activePatientsCount}}</strong> patients; the user with the most patients has <strong>{{activePatientsMax}}</strong>. The top 10 users have the following patient counts ({{topTenPatientCounts}}).
+  </div>
+</div>
 
 Sort by: <select name="users_sort_list" class="users-sort-list">
   <option value="approved">Approval Status</option>

--- a/app/assets/javascripts/templates/users/users.hbs
+++ b/app/assets/javascripts/templates/users/users.hbs
@@ -2,15 +2,34 @@
 
 <h1><i class="fa fa-users" aria-hidden="true"></i> Users ({{collection.length}})</h1>
 
-<div class="panel panel-default stats-panel hidden">
-  <div class="panel-heading">
-    <h3 class="panel-title">Stats</h3>
+<div class="row stats-panel hidden">
+  <div class="panel panel-primary col-sm-4">
+    <div class="panel-heading">
+      <h4 class="panel-title">Users</h4>
+    </div>
+    <div class="panel-body">
+      <p><strong>{{collection.length}}</strong> registered users.</p>
+      <p><strong>{{activeUsers.length}}</strong> users have measures loaded.</p>
+    </div>
   </div>
-  <div class="panel-body">
-    Total registered users: <strong>{{collection.length}}</strong></br>
-    <strong>{{activeUsers.length}}</strong> users have measures loaded.</br>
-    Those <strong>{{activeUsers.length}}</strong> users have <strong>{{activeMeasuresCount}}</strong> measures loaded; the user with the most measures loaded has <strong>{{activeMeasuresMax}}</strong>.</br>
-    Those <strong>{{activeUsers.length}}</strong> users have created <strong>{{activePatientsCount}}</strong> patients; the user with the most patients has <strong>{{activePatientsMax}}</strong>. The top 10 users have the following patient counts ({{topTenPatientCounts}}).
+  <div class="panel panel-primary col-sm-4">
+    <div class="panel-heading">
+      <h4 class="panel-title">Measures</h4>
+    </div>
+    <div class="panel-body">
+      <p><strong>{{activeMeasuresCount}}</strong> measures loaded by <strong>{{activeUsers.length}}</strong> users.</p>
+      <p>The user with the most measures loaded has <strong>{{activeMeasuresMax}}</strong> measures.</p>
+    </div>
+  </div>
+  <div class="panel panel-primary col-sm-4">
+    <div class="panel-heading">
+      <h4 class="panel-title">Patients</h4>
+    </div>
+    <div class="panel-body">
+      <p><strong>{{activePatientsCount}}</strong> patients created by <strong>{{activeUsers.length}}</strong> users.</p>
+      <p>The user with the most patients has <strong>{{activePatientsMax}}</strong> patients.</p>
+      <p>The top users have the following patient counts: <strong>{{topTenPatientCounts}}</strong>.</p>
+    </div>
   </div>
 </div>
 

--- a/app/assets/javascripts/views/users_view.js.coffee
+++ b/app/assets/javascripts/views/users_view.js.coffee
@@ -19,7 +19,6 @@ class Thorax.Views.Users extends Thorax.Views.BonnieView
     @activePatientsCount = @activeUsers.reduce(((sum, user) -> sum + user.get('patient_count')), 0)
     @activePatientsMax = _.max(@activeUsers.pluck('patient_count'))
     @topTenPatientCounts = _((new Thorax.Collection(@collection.models, comparator: (u) -> parseInt(u.get('patient_count')) * -1 )).sort().pluck('patient_count')).first(10)
-    @render()
 
   sortUsers: (e) ->
     attr = $(e.target).val()

--- a/app/assets/javascripts/views/users_view.js.coffee
+++ b/app/assets/javascripts/views/users_view.js.coffee
@@ -13,6 +13,12 @@ class Thorax.Views.Users extends Thorax.Views.BonnieView
   updateSummary: ->
     @totalMeasures = @collection.reduce(((sum, user) -> sum + user.get('measure_count')), 0)
     @totalPatients = @collection.reduce(((sum, user) -> sum + user.get('patient_count')), 0)
+    @activeUsers = new Thorax.Collection(@collection.filter((u) -> u.get('measure_count')))
+    @activeMeasuresCount = @activeUsers.reduce(((sum, user) -> sum + user.get('measure_count')), 0)
+    @activeMeasuresMax = _.max(@activeUsers.pluck('measure_count'))
+    @activePatientsCount = @activeUsers.reduce(((sum, user) -> sum + user.get('measure_count')), 0)
+    @activePatientsMax = _.max(@activeUsers.pluck('patient_count'))
+    @topTenPatientCounts = _((new Thorax.Collection(@collection.models, comparator: (u) -> parseInt(u.get('patient_count')) * -1 )).sort().pluck('patient_count')).first(10)
     @render()
 
   sortUsers: (e) ->
@@ -24,6 +30,10 @@ class Thorax.Views.Users extends Thorax.Views.BonnieView
       @emailAllUsersView = new Thorax.Views.EmailAllUsers()
       @emailAllUsersView.appendTo(@$el)
     @emailAllUsersView.display()
+
+  toggleStats: ->
+    @$('.stats-panel').toggleClass('hidden')
+    @$('.btn-toggle-stats').toggleClass('btn-default btn-primary')
 
 class Thorax.Views.User extends Thorax.Views.BonnieView
   template: JST['users/user']

--- a/app/assets/javascripts/views/users_view.js.coffee
+++ b/app/assets/javascripts/views/users_view.js.coffee
@@ -16,7 +16,7 @@ class Thorax.Views.Users extends Thorax.Views.BonnieView
     @activeUsers = new Thorax.Collection(@collection.filter((u) -> u.get('measure_count')))
     @activeMeasuresCount = @activeUsers.reduce(((sum, user) -> sum + user.get('measure_count')), 0)
     @activeMeasuresMax = _.max(@activeUsers.pluck('measure_count'))
-    @activePatientsCount = @activeUsers.reduce(((sum, user) -> sum + user.get('measure_count')), 0)
+    @activePatientsCount = @activeUsers.reduce(((sum, user) -> sum + user.get('patient_count')), 0)
     @activePatientsMax = _.max(@activeUsers.pluck('patient_count'))
     @topTenPatientCounts = _((new Thorax.Collection(@collection.models, comparator: (u) -> parseInt(u.get('patient_count')) * -1 )).sort().pluck('patient_count')).first(10)
     @render()


### PR DESCRIPTION
### Story
- there isn't one, I did this for fun
### Notes
- added a hidden panel with a toggle button on the admin users view
- expanded the summary method to include totals and associated stats details
### Screenshots
- untoggled
  - ![screen shot 2014-07-22 at 3 33 39 pm](https://cloud.githubusercontent.com/assets/456952/3672893/22092574-1266-11e4-861d-f1daa70168c0.png)
- toggled
  - ![screen shot 2014-07-23 at 8 32 56 am](https://cloud.githubusercontent.com/assets/456952/3672894/2209a062-1266-11e4-8b26-60c698ce2794.png)
