### PR TITLE
fix episodes of care selection box width

### DIFF
--- a/app/assets/javascripts/templates/import/import_measure.hbs
+++ b/app/assets/javascripts/templates/import/import_measure.hbs
@@ -110,8 +110,8 @@
             {{#if episode_of_care}}
               <input type="hidden" name="{{@cid}}[hqmf_id]" value="{{hqmf_id}}">
               <div class="form-group">
-                <label for="episodeSelect_{{@cid}}" class="col-sm-{{titleSize}} control-label">Episode(s) of Care:</label>
-                <div class="col-sm-{{titleSize}}">
+                <label for="episodeSelect_{{@cid}}" class="col-sm-{{titleSize}} control-label">Episode(s) of Care</label>
+                <div class="col-sm-{{dataSize}}">
                   <select multiple="true" class="form-control" id="episodeSelect_{{@cid}}" name="eoc_{{hqmfSetId}}[episode_ids][]">
                     {{#each source_data_criteria.models}}
                       {{#with attributes}}


### PR DESCRIPTION
No story, just something I noticed while going through the demo script on staging

Goes from first screenshot to second screenshot
(not shown: I also removed the colon from the episodes of care label)

![screen shot 2014-07-23 at 13 15 49](https://cloud.githubusercontent.com/assets/2136286/3677126/9222a984-128e-11e4-8a06-45dc86ad19f1.png)
![screen shot 2014-07-23 at 13 16 26](https://cloud.githubusercontent.com/assets/2136286/3677127/92272b26-128e-11e4-8221-15698fce4685.png)
