### PR TITLE
Disable measures in measure listing in patient transfers

### DIFF
--- a/app/assets/javascripts/templates/measure.hbs
+++ b/app/assets/javascripts/templates/measure.hbs
@@ -66,7 +66,7 @@
   <div class="list-group">
     {{#collection measures}}
       {{#ifCond hqmf_set_id "!=" ../hqmf_set_id}}
-        <a class="list-group-item measure-listing measure-{{hqmf_set_id}}">
+        <a class="list-group-item measure-listing measure-{{hqmf_set_id}} disabled">
           <div class="row">
             <div class="col-sm-6">
               {{cms_id}}

--- a/app/assets/javascripts/views/measure_view.js.coffee
+++ b/app/assets/javascripts/views/measure_view.js.coffee
@@ -29,7 +29,12 @@ class Thorax.Views.Measure extends Thorax.Views.BonnieView
     @populationCalculation.listenTo @, 'patients:toggleListing', -> @togglePatientsListing()
     @listenTo @logicView, 'population:update', (population) =>
       @$('.panel, .right-sidebar').animate(backgroundColor: '#fcf8e3').animate(backgroundColor: 'inherit')
-    @listenTo @populationCalculation, 'select-patients:change', -> unless @$('.select-patient:checked').size() then @clearMeasureListings()
+    @listenTo @populationCalculation, 'select-patients:change', ->
+      if @$('.select-patient:checked').size()
+        @$('.measure-listing').removeClass('disabled')
+      else
+        @clearMeasureListings()
+        @$('.measure-listing').addClass('disabled')
     # FIXME: change the name of these events to reflect what the measure calculation view is actually saying
     @logicView.listenTo @populationCalculation, 'rationale:clear', -> @clearRationale()
     @logicView.listenTo @populationCalculation, 'rationale:show', (result) -> @showRationale(result)

--- a/app/assets/stylesheets/measure.less
+++ b/app/assets/stylesheets/measure.less
@@ -31,6 +31,16 @@
   }
   .list-group {
     padding-top: 30px;
+    a.disabled  {
+      color: @nav-disabled-link-color;
+      &:hover,
+      &:focus {
+        color: @nav-disabled-link-hover-color;
+        text-decoration: none;
+        background-color: transparent;
+        cursor: not-allowed;
+      }
+    }
   }
 }
 


### PR DESCRIPTION
### Story
- https://www.pivotaltracker.com/story/show/75227692
### Notes
- disabled measure listings by default
- enable/disable measure listings based on patient select when transferring patients
- borrowed styling for disabled list-group-item from [here](http://stackoverflow.com/a/19436160)
### Screenshots
- disabled by default
  - ![screen shot 2014-07-23 at 3 19 59 pm](https://cloud.githubusercontent.com/assets/456952/3678837/7516450c-129e-11e4-830b-7c8ca3697f4d.png)
- enabled on patient selection
  - ![screen shot 2014-07-23 at 3 20 10 pm](https://cloud.githubusercontent.com/assets/456952/3678836/75145832-129e-11e4-8fe1-9e1eadc5905c.png)
