### PR TITLE
Rework user admin summary to use dedicated model and views

### DIFF
--- a/app/assets/javascripts/models/user.js.coffee
+++ b/app/assets/javascripts/models/user.js.coffee
@@ -14,6 +14,22 @@ class Thorax.Collections.Users extends Thorax.Collection
 
   initialize: ->
     @setComparator('approved')
+    @summary = new Thorax.Model
+    @on 'change add reset destroy remove', @updateSummary, this
+    @updateSummary()
+
+  updateSummary: ->
+    activeUsers = new Thorax.Collection(@filter((u) -> u.get('measure_count')))
+    @summary.set
+      totalUsers: @length
+      totalMeasures: @reduce(((sum, user) -> sum + user.get('measure_count')), 0)
+      totalPatients: @reduce(((sum, user) -> sum + user.get('patient_count')), 0)
+      activeUsers: activeUsers
+      activeMeasuresCount: activeUsers.reduce(((sum, user) -> sum + user.get('measure_count')), 0)
+      activeMeasuresMax: _.max(activeUsers.pluck('measure_count'))
+      activePatientsCount: activeUsers.reduce(((sum, user) -> sum + user.get('patient_count')), 0)
+      activePatientsMax: _.max(activeUsers.pluck('patient_count'))
+      topTenPatientCounts: _((new Thorax.Collection(@models, comparator: (u) -> parseInt(u.get('patient_count')) * -1 )).sort().pluck('patient_count')).first(10)
 
   setComparator: (key) ->
     @comparator = @comparators[key]

--- a/app/assets/javascripts/templates/users/table_header.hbs
+++ b/app/assets/javascripts/templates/users/table_header.hbs
@@ -1,0 +1,13 @@
+<tr>
+  <th width="200px">Email Address</th>
+  <th width="70px">Bundle</th>
+  <th width="75px" class="centered">Measures ({{totalMeasures}})</th>
+  <th width="75px" class="centered">Patients ({{totalPatients}})</th>
+  <th width="75px" class="centered">Admin?</th>
+  <th width="75px" class="centered">Portfolio?</th>
+  <th width="75px" class="centered">Approved?</th>
+  <th width="110px"></th>
+  <th width="95px"></th>
+  <th width="155px"></th>
+  <th width="75px"></th>
+</tr>

--- a/app/assets/javascripts/templates/users/user_summary.hbs
+++ b/app/assets/javascripts/templates/users/user_summary.hbs
@@ -1,0 +1,32 @@
+<h1><i class="fa fa-users" aria-hidden="true"></i> Users ({{totalUsers}})</h1>
+
+<div class="row stats-panel hidden">
+  <div class="panel panel-primary col-sm-4">
+    <div class="panel-heading">
+      <h4 class="panel-title">Users</h4>
+    </div>
+    <div class="panel-body">
+      <p><strong>{{totalUsers}}</strong> registered users.</p>
+      <p><strong>{{activeUsers.length}}</strong> users have measures loaded.</p>
+    </div>
+  </div>
+  <div class="panel panel-primary col-sm-4">
+    <div class="panel-heading">
+      <h4 class="panel-title">Measures</h4>
+    </div>
+    <div class="panel-body">
+      <p><strong>{{activeMeasuresCount}}</strong> measures loaded by <strong>{{activeUsers.length}}</strong> users.</p>
+      <p>The user with the most measures loaded has <strong>{{activeMeasuresMax}}</strong> measures.</p>
+    </div>
+  </div>
+  <div class="panel panel-primary col-sm-4">
+    <div class="panel-heading">
+      <h4 class="panel-title">Patients</h4>
+    </div>
+    <div class="panel-body">
+      <p><strong>{{activePatientsCount}}</strong> patients created by <strong>{{activeUsers.length}}</strong> users.</p>
+      <p>The user with the most patients has <strong>{{activePatientsMax}}</strong> patients.</p>
+      <p>The top users have the following patient counts: <strong>{{topTenPatientCounts}}</strong>.</p>
+    </div>
+  </div>
+</div>

--- a/app/assets/javascripts/templates/users/user_summary.hbs
+++ b/app/assets/javascripts/templates/users/user_summary.hbs
@@ -1,3 +1,5 @@
+{{#button "toggleStats" class="btn btn-default pull-right btn-toggle-stats"}}<i class="fa fa-bar-chart-o"></i> Stats{{/button}}
+
 <h1><i class="fa fa-users" aria-hidden="true"></i> Users ({{totalUsers}})</h1>
 
 <div class="row stats-panel hidden">

--- a/app/assets/javascripts/templates/users/users.hbs
+++ b/app/assets/javascripts/templates/users/users.hbs
@@ -1,37 +1,6 @@
 {{#button "toggleStats" class="btn btn-default pull-right btn-toggle-stats"}}<i class="fa fa-bar-chart-o"></i> Stats{{/button}}
 
-<h1><i class="fa fa-users" aria-hidden="true"></i> Users ({{collection.length}})</h1>
-
-<div class="row stats-panel hidden">
-  <div class="panel panel-primary col-sm-4">
-    <div class="panel-heading">
-      <h4 class="panel-title">Users</h4>
-    </div>
-    <div class="panel-body">
-      <p><strong>{{collection.length}}</strong> registered users.</p>
-      <p><strong>{{activeUsers.length}}</strong> users have measures loaded.</p>
-    </div>
-  </div>
-  <div class="panel panel-primary col-sm-4">
-    <div class="panel-heading">
-      <h4 class="panel-title">Measures</h4>
-    </div>
-    <div class="panel-body">
-      <p><strong>{{activeMeasuresCount}}</strong> measures loaded by <strong>{{activeUsers.length}}</strong> users.</p>
-      <p>The user with the most measures loaded has <strong>{{activeMeasuresMax}}</strong> measures.</p>
-    </div>
-  </div>
-  <div class="panel panel-primary col-sm-4">
-    <div class="panel-heading">
-      <h4 class="panel-title">Patients</h4>
-    </div>
-    <div class="panel-body">
-      <p><strong>{{activePatientsCount}}</strong> patients created by <strong>{{activeUsers.length}}</strong> users.</p>
-      <p>The user with the most patients has <strong>{{activePatientsMax}}</strong> patients.</p>
-      <p>The top users have the following patient counts: <strong>{{topTenPatientCounts}}</strong>.</p>
-    </div>
-  </div>
-</div>
+{{view userSummaryView}}
 
 Sort by: <select name="users_sort_list" class="users-sort-list">
   <option value="approved">Approval Status</option>
@@ -41,21 +10,7 @@ Sort by: <select name="users_sort_list" class="users-sort-list">
 </select>
 
 <table class="table table-striped table-hover">
-  <thead>
-    <tr>
-      <th width="200px">Email Address</th>
-      <th width="70px">Bundle</th>
-      <th width="75px" class="centered">Measures ({{totalMeasures}})</th>
-      <th width="75px" class="centered">Patients ({{totalPatients}})</th>
-      <th width="75px" class="centered">Admin?</th>
-      <th width="75px" class="centered">Portfolio?</th>
-      <th width="75px" class="centered">Approved?</th>
-      <th width="110px"></th>
-      <th width="95px"></th>
-      <th width="155px"></th>
-      <th width="75px"></th>
-    </tr>
-  </thead>
+  {{view tableHeaderView}}
   {{collection item-view="User" tag="tbody"}}
 </table>
 

--- a/app/assets/javascripts/templates/users/users.hbs
+++ b/app/assets/javascripts/templates/users/users.hbs
@@ -1,5 +1,3 @@
-{{#button "toggleStats" class="btn btn-default pull-right btn-toggle-stats"}}<i class="fa fa-bar-chart-o"></i> Stats{{/button}}
-
 {{view userSummaryView}}
 
 Sort by: <select name="users_sort_list" class="users-sort-list">

--- a/app/assets/javascripts/views/users_view.js.coffee
+++ b/app/assets/javascripts/views/users_view.js.coffee
@@ -6,20 +6,8 @@ class Thorax.Views.Users extends Thorax.Views.BonnieView
     'change .users-sort-list': 'sortUsers'
 
   initialize: ->
-    @totalMeasures = 0
-    @totalPatients = 0
-    @collection.on 'change add reset destroy remove', @updateSummary, this
-
-  updateSummary: ->
-    @totalMeasures = @collection.reduce(((sum, user) -> sum + user.get('measure_count')), 0)
-    @totalPatients = @collection.reduce(((sum, user) -> sum + user.get('patient_count')), 0)
-    @activeUsers = new Thorax.Collection(@collection.filter((u) -> u.get('measure_count')))
-    @activeMeasuresCount = @activeUsers.reduce(((sum, user) -> sum + user.get('measure_count')), 0)
-    @activeMeasuresMax = _.max(@activeUsers.pluck('measure_count'))
-    @activePatientsCount = @activeUsers.reduce(((sum, user) -> sum + user.get('patient_count')), 0)
-    @activePatientsMax = _.max(@activeUsers.pluck('patient_count'))
-    @topTenPatientCounts = _((new Thorax.Collection(@collection.models, comparator: (u) -> parseInt(u.get('patient_count')) * -1 )).sort().pluck('patient_count')).first(10)
-    @render()
+    @userSummaryView = new Thorax.View model: @collection.summary, template: JST['users/user_summary']
+    @tableHeaderView = new Thorax.View model: @collection.summary, template: JST['users/table_header'], tagName: 'thead'
 
   sortUsers: (e) ->
     attr = $(e.target).val()

--- a/app/assets/javascripts/views/users_view.js.coffee
+++ b/app/assets/javascripts/views/users_view.js.coffee
@@ -6,7 +6,9 @@ class Thorax.Views.Users extends Thorax.Views.BonnieView
     'change .users-sort-list': 'sortUsers'
 
   initialize: ->
-    @userSummaryView = new Thorax.View model: @collection.summary, template: JST['users/user_summary']
+    @userSummaryView = new Thorax.View model: @collection.summary, template: JST['users/user_summary'], toggleStats: ->
+      @$('.stats-panel').toggleClass('hidden')
+      @$('.btn-toggle-stats').toggleClass('btn-default btn-primary')
     @tableHeaderView = new Thorax.View model: @collection.summary, template: JST['users/table_header'], tagName: 'thead'
 
   sortUsers: (e) ->
@@ -18,10 +20,6 @@ class Thorax.Views.Users extends Thorax.Views.BonnieView
       @emailAllUsersView = new Thorax.Views.EmailAllUsers()
       @emailAllUsersView.appendTo(@$el)
     @emailAllUsersView.display()
-
-  toggleStats: ->
-    @$('.stats-panel').toggleClass('hidden')
-    @$('.btn-toggle-stats').toggleClass('btn-default btn-primary')
 
 class Thorax.Views.User extends Thorax.Views.BonnieView
   template: JST['users/user']


### PR DESCRIPTION
This reworked approach, using minimalist sub-views and sub-models to handle the updating and display of user summary info, avoids the need to re-render the whole users view, which in turn prevents the aw-snap issue encountered when manipulating multiple user accounts.
