### PR TITLE
Expose includeDraft to measure upload UI as a toggle switch

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,14 +44,14 @@ GIT
 
 GIT
   remote: https://github.com/projecttacoma/bonnie_bundler.git
-  revision: eb2b2445572b9bb7dba237a0e6cecd067f09ef9b
+  revision: dfe8ac52ef75d1b76ff8f7eff0e66544220fc0ce
   branch: master
   specs:
     bonnie_bundler (1.0.0)
 
 GIT
   remote: https://github.com/projecttacoma/simplexml_parser.git
-  revision: 3957614508277c300bdf5d45cd5d3853639d56c0
+  revision: db4b42d433efd578f8d87548d1e4138793a8d90e
   branch: master
   specs:
     simplexml_parser (1.0.0)

--- a/app/assets/javascripts/templates/import/import_measure.hbs
+++ b/app/assets/javascripts/templates/import/import_measure.hbs
@@ -46,9 +46,21 @@
               <div class="col-sm-offset-{{titleSize}} vsac-registration"><a href="https://uts.nlm.nih.gov/license.html" target="_blank"><i class="fa fa-plus-circle" aria-hidden="true"></i> Register for VSAC</a></div>
             </div>
             <div class="form-group">
-              <label for="vsacDate" class="col-sm-{{titleSize}} control-label">VSAC Effective Date</label>
-              <div class="col-sm-{{dataSize}}">
-                <input type="text" name="vsac_date" id="vsacDate" class="date-picker form-control" placeholder="mm/dd/yyyy" data-date-format="mm/dd/yyyy" data-date-autoclose="true">
+              <label for="vsacDraft" class="col-sm-{{titleSize}} control-label">Value Sets</label>
+              <div class="col-sm-4">
+                <div class="switch-toggle switch-custom">
+                  <input id="value_sets_draft" type="radio" name="include_draft" value="true" checked="true">
+                  <label for="value_sets_draft" onclick=""><span class="sr-only">Value Sets</span> Draft</label>
+                  <input id="value_sets_published" type="radio" name="include_draft" value="false">
+                  <label for="value_sets_published" onclick=""><span class="sr-only">Value Sets</span> Published</label>
+                  <a class="btn btn-primary"></a>
+                </div>
+              </div>
+              <div class="col-sm-4 effective-date">
+                <label for="vsacDate" class="control-label pull-left">Before</label>
+                <div class="col-sm-{{dataSize}} effective-date-picker">
+                  <input type="text" name="vsac_date" id="vsacDate" class="date-picker form-control" placeholder="mm/dd/yyyy" data-date-format="mm/dd/yyyy" data-date-autoclose="true">
+                </div>
               </div>
             </div>
           </div>

--- a/app/assets/javascripts/views/import_measure_view.js.coffee
+++ b/app/assets/javascripts/views/import_measure_view.js.coffee
@@ -28,6 +28,7 @@ class Thorax.Views.ImportMeasure extends Thorax.Views.BonnieView
       @$el.on 'hidden.bs.modal', -> @remove() unless $('#pleaseWaitDialog').is(':visible')
       @$("input[type=radio]:checked").next().css("color","white")
       @$('.date-picker').datepicker('setDate', moment().format('L'))
+      @$('.effective-date').hide()
     'ready': 'setup'
     'change input:file':  'enableLoad'
     'keypress input:text': 'enableLoadVsac'
@@ -39,6 +40,7 @@ class Thorax.Views.ImportMeasure extends Thorax.Views.BonnieView
         else
           @$(element).next().css("color","")
     'focus input': (e) -> if not @$(e.target).hasClass('date-picker') and $('.datepicker').is(':visible') then @$('.date-picker').datepicker('hide')
+    'change input[name="include_draft"]': 'toggleDraft'
 
   enableLoadVsac: ->
     username = @$('#vsacUser')
@@ -57,6 +59,10 @@ class Thorax.Views.ImportMeasure extends Thorax.Views.BonnieView
     else
       @$('#vsacSignIn').addClass('hidden')
       @$('#loadButton').prop('disabled', !@$('input:file').val().length > 0)
+
+  toggleDraft: ->
+    isDraft = @$('#value_sets_draft').is(':checked')
+    if isDraft then @$('.effective-date').hide() else @$('.effective-date').show()
 
   setup: ->
     @importDialog = @$("#importMeasureDialog")

--- a/app/assets/stylesheets/measures.less
+++ b/app/assets/stylesheets/measures.less
@@ -152,3 +152,10 @@
 .vsac-registration {
   padding-left: 15px;
 }
+
+.effective-date {
+  padding-left: 0;
+  .effective-date-picker {
+    padding-right: 0;
+  }
+}

--- a/app/controllers/measures_controller.rb
+++ b/app/controllers/measures_controller.rb
@@ -129,7 +129,7 @@ class MeasuresController < ApplicationController
         elsif e.is_a? Measures::HQMFException
           flash[:error] = {title: "Error Loading Measure", summary: "Error loading XML file.", body: "There was an error loading the XML file you selected.  Please verify that the file you are uploading is an HQMF XML or SimpleXML file.  Message: #{e.message}"}
         elsif e.is_a? Measures::VSACException
-          flash[:error] = {title: "Error Loading VSAC Value Sets", summary: "VSAC value sets could not be loaded.", body: "Please verify that you are using the correct VSAC username and password."}
+          flash[:error] = {title: "Error Loading VSAC Value Sets", summary: "VSAC value sets could not be loaded.", body: "Please verify that you are using the correct VSAC username and password. #{e.message}"}
         else
           flash[:error] = {title: "Error Loading Measure", summary: "The measure could not be loaded.", body: "Please re-package the measure in the MAT, then re-download the MAT Measure Export.  If the measure has QDM elements without a VSAC Value Set defined the measure will not load."}
         end

--- a/app/controllers/measures_controller.rb
+++ b/app/controllers/measures_controller.rb
@@ -70,8 +70,12 @@ class MeasuresController < ApplicationController
 
     begin
       if extension == '.xml'
-        effectiveDate = Date.strptime(params[:vsac_date],'%m/%d/%Y').strftime('%Y%m%d')
-        measure = Measures::SourcesLoader.load_measure_xml(params[:measure_file].tempfile.path, current_user, params[:vsac_username], params[:vsac_password], measure_details, true, false, effectiveDate, true) # overwrite_valuesets=true, cache=false, includeDraft=true
+        includeDraft = params[:include_draft] == 'true'
+        effectiveDate = nil
+        unless includeDraft
+          effectiveDate = Date.strptime(params[:vsac_date],'%m/%d/%Y').strftime('%Y%m%d')
+        end
+        measure = Measures::SourcesLoader.load_measure_xml(params[:measure_file].tempfile.path, current_user, params[:vsac_username], params[:vsac_password], measure_details, true, false, effectiveDate, includeDraft) # overwrite_valuesets=true, cache=false, includeDraft=true
       else
         measure = Measures::MATLoader.load(params[:measure_file], current_user, measure_details)
       end


### PR DESCRIPTION
### Notes
- **updated** to include VSAC error messages in the error dialog
  - ![screen shot 2014-07-25 at 3 59 58 pm](https://cloud.githubusercontent.com/assets/456952/3707560/75bba364-1436-11e4-8f5f-6a44c66b3997.png)
- included Gemfile updates to <code>bonnie_bundler</code> and <code>simplexml_parser</code>
- add toggle-switch (like rebuild patients option) for Value Sets, which are either draft or published with an effective date
- handle parameters before calling sources_loader in measures controller
### Screenshots
- draft
  - ![screen shot 2014-07-25 at 3 34 39 pm](https://cloud.githubusercontent.com/assets/456952/3707242/f96d3730-1432-11e4-9c51-f4737c4036a4.png)
- published
  - ![screen shot 2014-07-25 at 3 34 45 pm](https://cloud.githubusercontent.com/assets/456952/3707243/01f5dbbe-1433-11e4-84b8-0a1b68cd62d6.png)
