### PR TITLE
Move expected values form into a popover

### DIFF
--- a/app/assets/javascripts/helpers.js.coffee
+++ b/app/assets/javascripts/helpers.js.coffee
@@ -31,3 +31,16 @@ Handlebars.registerHelper 'ifCond', (v1, operator, v2, options) ->
     when '||'
       if (v1 || v2) then options.fn(this) else options.inverse(this)
     else return options.inverse(this)
+
+# A simple math helper for basic arithmetic operations within templates
+# Useful for rendering indexes starting from 1
+Handlebars.registerHelper 'math', (lvalue, operator, rvalue, options) ->
+  lvalue = parseFloat(lvalue)
+  rvalue = parseFloat(rvalue)
+  return {
+    '+' : lvalue + rvalue,
+    '-' : lvalue - rvalue,
+    '*' : lvalue * rvalue,
+    '/' : lvalue / rvalue,
+    '%' : lvalue % rvalue
+  }[operator]

--- a/app/assets/javascripts/templates/patient_builder/expected_value.hbs
+++ b/app/assets/javascripts/templates/patient_builder/expected_value.hbs
@@ -1,27 +1,19 @@
 <h3>Expected Value</h3>
-<div class="form-inline tab-pane">
-  {{#each currentCriteria}}
-    {{#ifCond key "==" "OBSERV"}}
-      <div class="form-group">
-        <label for="{{key}}_{{@cid}}" class="checkbox-inline">{{displayName}}</label>
-        <div class="btn-group">
-          {{#button "setPerc" class="btn btn-xs btn-observ-unit-perc"}} % {{/button}}
-          {{#button "setMins" class="btn btn-xs btn-observ-unit-mins"}} mins {{/button}}
-        </div>
-        {{#each ../../OBSERV}}
-          <input type="number" id="{{../key}}_{{@index}}" name="{{../key}}" min="0" value="{{this}}">
-        {{/each}}
-      </div>
-    {{else}}
-      {{#if isEoC}}
-        <div class="form-group">
-          <label for="{{key}}_{{@cid}}">{{displayName}}</label>
-          <input type="number" id="{{key}}_{{@cid}}" name="{{key}}" min="0">
-        </div>
+<div class="tab-pane">
+  <span class="span-expected-values">
+    {{#each parsedValues}}
+      {{#ifCond key "==" "OBSERV"}}
+        {{#if value}}
+          <strong>{{displayName}}</strong>: {{value}}{{../../../OBSERV_UNIT}}
+        {{/if}}
       {{else}}
-        <label for="{{key}}_{{@cid}}" class="checkbox-inline">{{displayName}}</label>
-        <input type="checkbox" id="{{key}}_{{@cid}}" name="{{key}}">
-      {{/if}}
-    {{/ifCond}}
-  {{/each}}
+        {{#if value}}
+          <strong>{{displayName}}</strong>{{#if ../../../isNumbers}}: {{value}}{{/if}}
+        {{/if}}
+      {{/ifCond}}
+    {{else}}
+      None
+    {{/each}}
+  </span>
 </div>
+{{#button "togglePopover" class="btn btn-default btn-expected-value ev-" data-toggle="popover" data-placement="bottom" data-html="true"}}<i class="fa fa-pencil" aria-hidden="true"></i>{{/button}}

--- a/app/assets/javascripts/templates/patient_builder/expected_value_popover.hbs
+++ b/app/assets/javascripts/templates/patient_builder/expected_value_popover.hbs
@@ -4,7 +4,7 @@
       {{#ifCond key "==" "OBSERV"}}
         <li class="list-group-item">
           <div class="form-group">
-            <label for="{{key}}_{{@cid}}" class="checkbox-inline">{{displayName}}</label>
+            <label for="{{key}}_{{@cid}}">{{displayName}}</label>
             <div class="btn-group">
               {{#button "setPerc" class="btn btn-xs btn-observ-unit-perc"}} % {{/button}}
               {{#button "setMins" class="btn btn-xs btn-observ-unit-mins"}} mins {{/button}}
@@ -15,7 +15,7 @@
           <li class="list-group-item">
             <div class="form-group">
               <label for="{{../key}}_{{@index}}">
-                <input type="number" id="{{../key}}_{{@index}}" name="{{../key}}" min="0" value="{{this}}">
+                <input type="number" id="{{../key}}_{{@index}}" name="{{../key}}" min="0" value="{{this}}"> {{../displayName}}_{{#math @index "+" 1}}{{/math}}
               </label>
             </div>
           </li>

--- a/app/assets/javascripts/templates/patient_builder/expected_value_popover.hbs
+++ b/app/assets/javascripts/templates/patient_builder/expected_value_popover.hbs
@@ -1,0 +1,40 @@
+<div class="form-inline">
+  <ul class="list-group">
+    {{#each currentCriteria}}
+      {{#ifCond key "==" "OBSERV"}}
+        <li class="list-group-item">
+          <div class="form-group">
+            <label for="{{key}}_{{@cid}}" class="checkbox-inline">{{displayName}}</label>
+            <div class="btn-group">
+              {{#button "setPerc" class="btn btn-xs btn-observ-unit-perc"}} % {{/button}}
+              {{#button "setMins" class="btn btn-xs btn-observ-unit-mins"}} mins {{/button}}
+            </div>
+          </div>
+        </li>
+        {{#each ../../OBSERV}}
+          <li class="list-group-item">
+            <div class="form-group">
+              <label for="{{../key}}_{{@index}}">
+                <input type="number" id="{{../key}}_{{@index}}" name="{{../key}}" min="0" value="{{this}}">
+              </label>
+            </div>
+          </li>
+        {{/each}}
+      {{else}}
+        <li class="list-group-item">
+          {{#if isEoC}}
+            <div class="form-group">
+              <input type="number" id="{{key}}_{{@cid}}" name="{{key}}" min="0">
+              <label for="{{key}}_{{@cid}}">{{displayName}}</label>
+            </div>
+          {{else}}
+            <div class="checkbox">
+              <input type="checkbox" id="{{key}}_{{@cid}}" name="{{key}}">
+              <label for="{{key}}_{{@cid}}" class="checkbox-inline">{{displayName}}</label>
+            </div>
+          {{/if}}
+        </li>
+      {{/ifCond}}
+    {{/each}}
+  </ul>
+</div>

--- a/app/assets/javascripts/views/patient_builder/expected_values.js.coffee
+++ b/app/assets/javascripts/views/patient_builder/expected_values.js.coffee
@@ -100,6 +100,7 @@ class Thorax.Views.ExpectedValueView extends Thorax.Views.BonnieView
       @popover.setObservs()
       @popover.$('input[name="MSRPOPL"]').focus() if e == 'MSRPOPL'
       @popover.$(".#{e}").focus() if e == 'btn-observ-unit-mins' or e == 'btn-observ-unit-perc'
+      $("a[href=\"#expected-#{@model.get('population_index')}\"]").parent().addClass('active') # reset active tab
 
 class Thorax.Views.ExpectedValuePopoverView extends Thorax.Views.BuilderChildView
 

--- a/app/assets/javascripts/views/patient_builder/expected_values.js.coffee
+++ b/app/assets/javascripts/views/patient_builder/expected_values.js.coffee
@@ -63,7 +63,7 @@ class Thorax.Views.ExpectedValueView extends Thorax.Views.BonnieView
     @isMultipleObserv = @measure.get('continuous_variable')
     @isCheckboxes = not @isNumbers and not @isMultipleObserv
     @parseValues()
-    @model.on 'change', => @parseValues()
+    @model.on 'change', => @parseValues() # parse model changes -- needed for CV render triggers
 
   parseValues: ->
     @parsedValues = []
@@ -75,7 +75,7 @@ class Thorax.Views.ExpectedValueView extends Thorax.Views.BonnieView
         value: @model.get(pc)
     if not @isNumbers then @parsedValues = _(@parsedValues).filter( (pc) => pc.value )
 
-  # FIXME: this is required to serialize popovers that are left open during Save
+  # FIXME: this is required to serialize popovers that are left open when saving the patient
   serialize: (attr) ->
 
   togglePopover: (e) ->
@@ -150,21 +150,18 @@ class Thorax.Views.ExpectedValuePopoverView extends Thorax.Views.BuilderChildVie
 
   updateObserv: ->
     popoverVisible = $('.popover').is(':visible')
-    focusIndex = 0
     if @isMultipleObserv and @model.has('MSRPOPL') and @model.get('MSRPOPL')?
       values = @model.get('MSRPOPL')
       if @model.get('OBSERV')
         current = @model.get('OBSERV').length
         if values > current
           @model.set 'OBSERV', @model.get('OBSERV').concat(0 for n in [(current+1)..values])
-          focusIndex = current
         else if values < current
           @model.set 'OBSERV', _(@model.get('OBSERV')).first(values)
       else
         @model.set 'OBSERV', (0 for n in [1..values]) if values
       @setObservs()
-    if popoverVisible
-      @parent.togglePopover('MSRPOPL')
+    @parent.togglePopover('MSRPOPL') if popoverVisible
 
   setObservs: ->
     if @model.get('OBSERV')?.length

--- a/app/assets/javascripts/views/patient_builder/expected_values.js.coffee
+++ b/app/assets/javascripts/views/patient_builder/expected_values.js.coffee
@@ -75,6 +75,8 @@ class Thorax.Views.ExpectedValueView extends Thorax.Views.BonnieView
     if not @isNumbers then @parsedValues = _(@parsedValues).filter( (pc) => pc.value )
     # console.log @model.attributes
 
+  # FIXME: this is required to serialize popovers that are left open during Save
+  serialize: (attr) ->
   # serialize: ->
     # childView.serialize() for cid, childView of @expectedValueCollectionView.children
     # if @popoverVisible then @$('.btn-expected-value').click()
@@ -107,6 +109,8 @@ class Thorax.Views.ExpectedValueView extends Thorax.Views.BonnieView
       @$('.btn-expected-value').popover('show')
       @$('.popover > .arrow').css('left', '25%') # hack for fixing the arrow after rendering form
       @popover.appendTo(@$('.popover-content'))
+      @popover.toggleUnits()
+      @popover.setObservs()
 
 class Thorax.Views.ExpectedValuePopoverView extends Thorax.Views.BuilderChildView
 
@@ -140,7 +144,7 @@ class Thorax.Views.ExpectedValuePopoverView extends Thorax.Views.BuilderChildVie
 
   context: ->
     context = super
-    console.log context
+    # console.log context
     for pc in @measure.populationCriteria()
       unless @isNumbers || (@isMultipleObserv && (pc == 'OBSERV'))
         context[pc] = (context[pc] == 1)
@@ -159,7 +163,7 @@ class Thorax.Views.ExpectedValuePopoverView extends Thorax.Views.BuilderChildVie
         displayName: pc
         isEoC: @isNumbers
     unless @model.has('OBSERV_UNIT') or not @isMultipleObserv then @model.set 'OBSERV_UNIT', ' mins', {silent:true}
-    console.log @model
+    # console.log @model
 
   updateObserv: ->
     if @isMultipleObserv and @model.has('MSRPOPL') and @model.get('MSRPOPL')?

--- a/app/assets/stylesheets/builder.less
+++ b/app/assets/stylesheets/builder.less
@@ -107,13 +107,16 @@
       background-color: @gray-lighter;
     }
     .tab-content {
+      padding-left: 10px;
       padding-bottom: 10px;
       h2, h3 {
         &:extend(h2);
         margin-top: 0;
         padding-top: 6px;
       }
-
+      .span-expected-values {
+        word-wrap: break-word;
+      }
       .form-inline {
         .form-group {
           padding-right: 10px;
@@ -129,6 +132,16 @@
           }
           .btn-observ-unit-perc, .btn-observ-unit-mins {
             opacity: 1.0;
+          }
+        }
+        .list-group {
+          margin-bottom: 0;
+          .list-group-item {
+            padding: 5px 5px;
+            border: none;
+            .expected-value-checkbox {
+              vertical-align: top;
+            }
           }
         }
       }

--- a/spec/javascripts/views/patient_builder_spec.js.coffee
+++ b/spec/javascripts/views/patient_builder_spec.js.coffee
@@ -258,25 +258,27 @@ describe 'PatientBuilderView', ->
     beforeEach ->
       @patientBuilder.appendTo 'body'
       @selectPopulationEV = (population, save=true) ->
+        @patientBuilder.$(".btn-expected-value:first").click() # open the popover before setting the expected value
         @patientBuilder.$("input[type=checkbox][name=#{population}]:first").click()
+        @patientBuilder.$(".btn-expected-value:first").click() # close the popover before saving the patient
         @patientBuilder.$("button[data-call-method=save]").click() if save
 
     it "serializes the expected values correctly", ->
-      @selectPopulationEV('DENOM')
-      expectedValues = @patientBuilder.model.get('expected_values').findWhere(population_index: 0)
-      expect(expectedValues.get('IPP')).toEqual 1
-      expect(expectedValues.get('DENOM')).toEqual 1
-      expect(expectedValues.get('NUMER')).toEqual 0
-
-    it "auto selects IPP when DENOM is selected", ->
       @selectPopulationEV('DENOM', true)
       expectedValues = @patientBuilder.model.get('expected_values').findWhere(population_index: 0)
       expect(expectedValues.get('IPP')).toEqual 1
       expect(expectedValues.get('DENOM')).toEqual 1
       expect(expectedValues.get('NUMER')).toEqual 0
 
+    it "auto selects IPP when DENOM is selected", ->
+      @selectPopulationEV('DENOM')
+      expectedValues = @patientBuilder.model.get('expected_values').findWhere(population_index: 0)
+      expect(expectedValues.get('IPP')).toEqual 1
+      expect(expectedValues.get('DENOM')).toEqual 1
+      expect(expectedValues.get('NUMER')).toEqual 0
+
     it "auto selects DENOM and IPP when NUMER is selected", ->
-      @selectPopulationEV('NUMER', true)
+      @selectPopulationEV('NUMER')
       expectedValues = @patientBuilder.model.get('expected_values').findWhere(population_index: 0)
       expect(expectedValues.get('IPP')).toEqual 1
       expect(expectedValues.get('DENOM')).toEqual 1
@@ -284,7 +286,7 @@ describe 'PatientBuilderView', ->
 
     it "auto unselects DENOM when IPP is unselected", ->
       @selectPopulationEV('DENOM', false)
-      @selectPopulationEV('IPP', true)
+      @selectPopulationEV('IPP')
       expectedValues = @patientBuilder.model.get('expected_values').findWhere(population_index: 0)
       expect(expectedValues.get('IPP')).toEqual 0
       expect(expectedValues.get('DENOM')).toEqual 0
@@ -292,7 +294,7 @@ describe 'PatientBuilderView', ->
 
     it "auto unselects DENOM and NUMER when IPP is unselected", ->
       @selectPopulationEV('NUMER', false)
-      @selectPopulationEV('IPP', true)
+      @selectPopulationEV('IPP')
       expectedValues = @patientBuilder.model.get('expected_values').findWhere(population_index: 0)
       expect(expectedValues.get('IPP')).toEqual 0
       expect(expectedValues.get('DENOM')).toEqual 0


### PR DESCRIPTION
### Story
- https://www.pivotaltracker.com/story/show/63991566
### Notes
- reworking of https://github.com/projecttacoma/bonnie/pull/278
- created new Thorax view for popover (instead of handlebars script approach)
- displays set expected values, with pencil button for editing (can be set on popover close or by saving the patient)
### Screenshots
- checkboxes
  - ![screen shot 2014-08-01 at 9 10 33 am](https://cloud.githubusercontent.com/assets/456952/3779313/7ad498b6-1980-11e4-915b-3543bc678b4e.png)
- numbers (EoC)
  - ![screen shot 2014-08-01 at 9 11 22 am](https://cloud.githubusercontent.com/assets/456952/3779310/7ad11c22-1980-11e4-8a4e-28a03c226e25.png)
- patient-based CV
  - ![screen shot 2014-08-01 at 9 10 03 am](https://cloud.githubusercontent.com/assets/456952/3779312/7ad471f6-1980-11e4-9e6e-8b9e3928ed47.png)
- EoC CV
  - ![screen shot 2014-08-01 at 9 27 31 am](https://cloud.githubusercontent.com/assets/456952/3779311/7ad1983c-1980-11e4-9495-6d0cfa4752e3.png)
