### PR TITLE
Update measure chords view button w/ text view toggle

### DIFF
--- a/app/assets/javascripts/templates/measure.hbs
+++ b/app/assets/javascripts/templates/measure.hbs
@@ -4,7 +4,8 @@
     <div class="full-title">{{title}}</div>
     <span class="settings-container">
       <div class="measure-settings">
-        {{#button "toggleVisualization" class="btn btn-default btn-measure-viz"}}<i class="fa fa-sitemap"></i> Chords View{{/button}}
+        {{#button "toggleVisualization" class="btn btn-default btn-measure-viz btn-viz-chords"}}<i class="fa fa-sitemap" aria-hidden="true"></i> Chords View{{/button}}
+        {{#button "toggleVisualization" class="btn btn-default btn-measure-viz btn-viz-text"}}<i class="fa fa-list" aria-hidden="true"></i> Text View{{/button}}
         {{#button "updateMeasure" class="btn btn-default update-measure"}}<i class="fa fa-upload" aria-hidden="true"></i> Update{{/button}}
         {{#button "deleteMeasure" class="btn btn-danger delete-measure hide"}}<i class="fa fa-times" aria-hidden="true"></i> Delete{{/button}}
         {{#button "showDelete" class="btn btn-danger-inverse delete-icon"}}<i class="fa fa-minus-circle" aria-hidden="true"></i> <span class="sr-only">Show Delete</span>{{/button}}

--- a/app/assets/javascripts/views/measure_view.js.coffee
+++ b/app/assets/javascripts/views/measure_view.js.coffee
@@ -7,7 +7,7 @@ class Thorax.Views.Measure extends Thorax.Views.BonnieView
       @exportPatientsView.appendTo(@$el)
       $('.indicator-circle, .navbar-nav > li').removeClass('active')
       $('.indicator-results').addClass('active')
-      @$('.d3-measure-viz').hide()
+      @$('.d3-measure-viz, .btn-viz-text').hide()
     'click .measure-listing': 'selectMeasureListing'
 
   initialize: ->
@@ -32,8 +32,8 @@ class Thorax.Views.Measure extends Thorax.Views.BonnieView
     @listenTo @logicView, 'population:update', (population) =>
       @$('.panel, .right-sidebar').animate(backgroundColor: '#fcf8e3').animate(backgroundColor: 'inherit')
       @$('.d3-measure-viz').empty()
-      @$('.d3-measure-viz').hide()
-      @$('.btn-measure-viz').removeClass('btn-primary').addClass('btn-default')
+      @$('.d3-measure-viz, .btn-viz-text').hide()
+      @$('.btn-viz-chords').show()
       @measureViz = Bonnie.viz.measureVisualzation().dataCriteria(@model.get("data_criteria")).measurePopulation(population).measureValueSets(@model.valueSets())
     @listenTo @populationCalculation, 'select-patients:change', ->
       if @$('.select-patient:checked').size()
@@ -117,6 +117,7 @@ class Thorax.Views.Measure extends Thorax.Views.BonnieView
 
   measureSettings: (e) ->
     e.preventDefault()
+    @$('.btn-measure-viz:visible').click() if @$('.btn-measure-viz:visible').hasClass('btn-viz-text')
     @$('.delete-icon').click() if @$('.delete-measure').is(':visible')
     @$('.measure-settings').toggleClass('measure-settings-expanded')
 
@@ -131,9 +132,7 @@ class Thorax.Views.Measure extends Thorax.Views.BonnieView
     $btn.toggleClass('btn-danger btn-danger-inverse').prev().toggleClass('hide')
 
   toggleVisualization: (e) ->
-    @$('.btn-measure-viz').toggleClass('btn-default btn-primary')
-    @$('.measure-viz').toggle()
-    @$('.d3-measure-viz').toggle()
+    @$('.btn-viz-chords, .btn-viz-text, .measure-viz, .d3-measure-viz').toggle()
     if @$('.d3-measure-viz').children().length == 0
       d3.select(@el).select('.d3-measure-viz').datum(@model.get("population_criteria")).call(@measureViz) 
       @$('rect').popover()


### PR DESCRIPTION
### Story
- https://www.pivotaltracker.com/story/show/77034560
### Notes
- added two buttons to measure settings template for chords and text views
- toggle the appropriate button via <code>.btn-viz-chords</code> and <code>.btn-viz-text</code>
- reset the logic view if measure settings is closed
### Screenshots
- chords
  - ![screen shot 2014-08-18 at 9 39 36 am](https://cloud.githubusercontent.com/assets/456952/3951966/40cb514a-26dd-11e4-9b2a-115390251db2.png)
- text
  - ![screen shot 2014-08-18 at 9 39 41 am](https://cloud.githubusercontent.com/assets/456952/3951965/40c3fe90-26dd-11e4-908c-0b1e514a77fd.png)
