### PR TITLE
Replace measure title with CMS id in patient builder logic view

### DIFF
--- a/app/assets/javascripts/templates/patient_builder/population_logic.hbs
+++ b/app/assets/javascripts/templates/patient_builder/population_logic.hbs
@@ -1,4 +1,4 @@
-<h1 class="heading-muted"><i class="fa fa-tasks" aria-hidden="true"></i> Measure</h1>
+<h1 class="heading-muted"><i class="fa fa-tasks" aria-hidden="true"></i> {{cms_id}}</h1>
 <p class="submeasure">{{title}}</p>
 
 {{layout-element}}

--- a/app/assets/javascripts/views/patient_builder/patient_builder.js.coffee
+++ b/app/assets/javascripts/views/patient_builder/patient_builder.js.coffee
@@ -184,3 +184,4 @@ class Thorax.Views.BuilderPopulationLogic extends Thorax.LayoutView
   context: ->
     _(super).extend
       title: if @model.collection.parent.get('populations').length > 1 then (@model.get('title') || @model.get('sub_id')) else ''
+      cms_id: @model.collection.parent.get('cms_id')


### PR DESCRIPTION
### Story
- https://www.pivotaltracker.com/story/show/77041134
### Notes
- supplied context value for population logic view's measure's <code>cms_id</code> in patient builder logic view
### Screenshots
- undesired measure title
  - ![screen shot 2014-08-18 at 3 34 41 pm](https://cloud.githubusercontent.com/assets/456952/3956744/c8637db8-270e-11e4-87af-230d25c3f673.png)
- cms id as measure title
  - ![screen shot 2014-08-18 at 3 34 22 pm](https://cloud.githubusercontent.com/assets/456952/3956745/c8669048-270e-11e4-8238-b77a408d4295.png)
