### PR TITLE
Add $ for variables in LHS of satisfies clause

### DIFF
--- a/app/assets/javascripts/templates/logic/satisfies.hbs
+++ b/app/assets/javascripts/templates/logic/satisfies.hbs
@@ -1,5 +1,5 @@
   <span class="criteria-title">
-    {{#if rootCriteria.specific_occurrence}}Occurrence {{rootCriteria.specific_occurrence}}: {{/if}}{{rootCriteria.description}}
+    {{#if rootCriteria.specific_occurrence}}Occurrence {{rootCriteria.specific_occurrence}}: {{/if}}{{#if rootCriteria.variable}}${{/if}}{{rootCriteria.description}}
     <span class="sr-only sr-highlight-status"></span>
     {{translate_operator dataCriteria.definition}}
     <ul class="multi-statement">


### PR DESCRIPTION
### Story
- https://www.pivotaltracker.com/story/show/76450414
### Notes
- added $ before root criteria description in <code>satisifes</code> template if the criteria is also a variable
### Screenshot

![screen shot 2014-08-18 at 4 08 32 pm](https://cloud.githubusercontent.com/assets/456952/3957193/74552c6c-2713-11e4-98e7-b082e8466cda.png)
