### PR TITLE
Compute coverage with negated statements

### DIFF
--- a/app/assets/javascripts/models/coverage.js.coffee
+++ b/app/assets/javascripts/models/coverage.js.coffee
@@ -12,7 +12,7 @@ class Thorax.Model.Coverage extends Thorax.Model
     @rationaleCriteria = []
     @differences.each (difference) => if difference.get('done')
       result = difference.result
-      rationale = result.updatedRationale()
+      rationale = result.get('rationale')
       @rationaleCriteria.push(criteria) for criteria, result of rationale when result
     @rationaleCriteria = _(@rationaleCriteria).intersection(@measureCriteria)
 


### PR DESCRIPTION
### Story
- https://www.pivotaltracker.com/story/show/77141298
### Notes
- use `result` rationale instead of updatedRationale when computing coverage
  - updatedRationale ignores specific occurrences that are not true, so to achieve coverage you would need a valid path within the patient population for coverage to compute accurately
### Screenshot

![screen shot 2014-08-19 at 3 04 28 pm](https://cloud.githubusercontent.com/assets/456952/3971449/db928dd2-27d3-11e4-8cb5-6003900c297b.png)
