### PR TITLE
Expectation naming

### DIFF
--- a/app/assets/javascripts/models/expected_value.js.coffee
+++ b/app/assets/javascripts/models/expected_value.js.coffee
@@ -32,17 +32,6 @@ class Thorax.Models.ExpectedValue extends Thorax.Model
     if result.get('values')?
       result.set 'values', _(result.get('values')).sortBy( (v) -> v)
 
-    # criteria map from expected_values.js.coffee
-    criteriaMap =
-      IPP:      'IPP'
-      STRAT:    'STRAT'
-      DENOM:    'DEN'
-      NUMER:    'NUM'
-      DENEXCEP: 'EXCP'
-      DENEX:    'EXCL'
-      MSRPOPL:  'MSRPOPL'
-      OBSERV:   'OBSERV'  
-
     for popCrit in @populationCriteria()
       if popCrit.indexOf('OBSERV') != -1
         expected = if popCrit == 'OBSERV' then @get('OBSERV')?[0] else @get('OBSERV')?[@observIndex(popCrit)]
@@ -54,7 +43,7 @@ class Thorax.Models.ExpectedValue extends Thorax.Model
         actual = result.get(popCrit)
         key = popCrit
       # Here's the hash we return:
-      name: criteriaMap[popCrit]
+      name: popCrit
       key: key
       expected: expected
       actual: actual

--- a/app/assets/javascripts/models/expected_value.js.coffee
+++ b/app/assets/javascripts/models/expected_value.js.coffee
@@ -32,6 +32,17 @@ class Thorax.Models.ExpectedValue extends Thorax.Model
     if result.get('values')?
       result.set 'values', _(result.get('values')).sortBy( (v) -> v)
 
+    # criteria map from expected_values.js.coffee
+    criteriaMap =
+      IPP:      'IPP'
+      STRAT:    'STRAT'
+      DENOM:    'DEN'
+      NUMER:    'NUM'
+      DENEXCEP: 'EXCP'
+      DENEX:    'EXCL'
+      MSRPOPL:  'MSRPOPL'
+      OBSERV:   'OBSERV'  
+
     for popCrit in @populationCriteria()
       if popCrit.indexOf('OBSERV') != -1
         expected = if popCrit == 'OBSERV' then @get('OBSERV')?[0] else @get('OBSERV')?[@observIndex(popCrit)]
@@ -43,7 +54,7 @@ class Thorax.Models.ExpectedValue extends Thorax.Model
         actual = result.get(popCrit)
         key = popCrit
       # Here's the hash we return:
-      name: popCrit
+      name: criteriaMap[popCrit]
       key: key
       expected: expected
       actual: actual

--- a/app/assets/javascripts/views/patient_builder/expected_values.js.coffee
+++ b/app/assets/javascripts/views/patient_builder/expected_values.js.coffee
@@ -81,15 +81,6 @@ class Thorax.Views.ExpectedValueView extends Thorax.Views.BuilderChildView
     context
 
   initialize: ->
-    criteriaMap =
-      IPP:      'IPP'
-      STRAT:    'STRAT'
-      DENOM:    'DEN'
-      NUMER:    'NUM'
-      DENEXCEP: 'EXCP'
-      DENEX:    'EXCL'
-      MSRPOPL:  'MSRPOPL'
-      OBSERV:   'OBSERV'
     @currentCriteria = []
     # get population criteria from the measure to include OBSERV
     population = @measure.get('populations').at @model.get('population_index')
@@ -99,7 +90,7 @@ class Thorax.Views.ExpectedValueView extends Thorax.Views.BuilderChildView
     for pc in @measure.populationCriteria() when population.has(pc)
       @currentCriteria.push
         key: pc
-        displayName: criteriaMap[pc]
+        displayName: pc
         isEoC: @isNumbers
     unless @model.has('OBSERV_UNIT') or not @isMultipleObserv then @model.set 'OBSERV_UNIT', ' mins', {silent:true}
 


### PR DESCRIPTION
- https://www.pivotaltracker.com/story/show/75148928

It was just really bugging me to have different shorthands for the different expectations as I went back and forth between the patient builder view and the measure view. From what I understand, the rationale for the shorter names in the patient builder was because they sometimes overflow from one line of text. From what I've seen, they still overflow depending on the measure. So to me it makes sense to stop using the shorter names in this particular place.
