### PR TITLE
fix typo in update measure error dialog

### DIFF
--- a/app/controllers/measures_controller.rb
+++ b/app/controllers/measures_controller.rb
@@ -91,7 +91,7 @@ class MeasuresController < ApplicationController
       else
         if existing.hqmf_set_id != measure.hqmf_set_id
           measure.delete
-          flash[:error] = {title: "Error Updating Measure", summary: "The update file does not match the measure.", body: "You have attempted to update a measure with a file that represents a differnt measure.  Please update the correct measure or upload the file as a new measure."}
+          flash[:error] = {title: "Error Updating Measure", summary: "The update file does not match the measure.", body: "You have attempted to update a measure with a file that represents a different measure.  Please update the correct measure or upload the file as a new measure."}
           redirect_to "#{root_path}##{params[:redirect_route]}"
           return
         end


### PR DESCRIPTION
Story: https://www.pivotaltracker.com/story/show/77314672

Old: You have attempted to update a measure with a file that represents a **differnt** measure. Please update the correct measure or upload the file as a new measure.

New: 
![image](https://cloud.githubusercontent.com/assets/2136286/4139609/7c913516-339c-11e4-8951-517712c7d120.png)
