### PR TITLE
add license

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,16 @@ bonnie
 ======
 
 Clinical Quality Measure Testing Tool
+
+License
+======
+
+Copyright 2014 The MITRE Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
+
+```
+http://www.apache.org/licenses/LICENSE-2.0
+```
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.


### PR DESCRIPTION
Story: https://www.pivotaltracker.com/story/show/76274576

Taking the example from health data standards, I put the license in the repo's readme, which I'm hoping was the intent.
