### PR TITLE
Prevent false-highlighting-bubbling for specific occurrences within Unions

### DIFF
--- a/app/assets/javascripts/models/result.js.coffee
+++ b/app/assets/javascripts/models/result.js.coffee
@@ -158,11 +158,9 @@ class Thorax.Models.Result extends Thorax.Model
   # walk through data criteria to account for specific occurrences within a UNION
   calculateDataCriteriaOrCounts: (rationale) ->
     orCounts = {}
-    for key, dc of @measure.get('data_criteria') when dc.derivation_operator == 'UNION' && dc.key.indexOf('UNION') != -1
-      trueCount = 0
+    for key, dc of @measure.get('data_criteria') when dc.derivation_operator == 'UNION' && key.indexOf('UNION') != -1
       for child in dc.children_criteria
-        trueCount++ if rationale[dc.key]
-      if orCounts[dc.key]? then orCounts[dc.key] += trueCount else orCounts[dc.key] = trueCount
+        orCounts[key] = (orCounts[key] || 0) + 1 if rationale[key]
     orCounts
 
   codedEntriesForDataCriteria: (dataCriteriaKey) ->

--- a/app/assets/javascripts/models/result.js.coffee
+++ b/app/assets/javascripts/models/result.js.coffee
@@ -27,7 +27,7 @@ class Thorax.Models.Result extends Thorax.Model
       if specifics = @get('finalSpecifics')?[code]
         updatedRationale[code] = {} 
         # get the referenced occurrences in the logic tree using original population code
-        occurrences = @population.getDataCriteriaKeys(@measure.get('population_criteria')[@population.get(code)?.code])
+        occurrences = _.uniq @population.getDataCriteriaKeys(@measure.get('population_criteria')[@population.get(code)?.code])
         # get the good and bad specifics
         occurrenceResults = @checkSpecificsForRationale(specifics, occurrences, @measure.get('data_criteria'))
         parentMap = @buildParentMap(@measure.get('population_criteria')[code])
@@ -88,7 +88,6 @@ class Thorax.Models.Result extends Thorax.Model
     return unless parents
     for parent in parents
       parentKey = if parent.id? then "precondition_#{parent.id}" else parent.key || parent.type
-
       # we are negated if the parent is negated and the parent is a precondition.  If it's a data criteria, then negation is fine
       negated = parent.negation && parent.id?
       # do not bubble up negated unless we have no final specifics.  If we have no final specifics then we may not have positive statements to bubble up.
@@ -136,7 +135,7 @@ class Thorax.Models.Result extends Thorax.Model
     for code in Thorax.Models.Measure.allPopulationCodes
       if populationCriteria = @population.get(code)
         _.extend(orCounts, @calculateOrCountsRecursive(rationale, populationCriteria.preconditions))
-    orCounts
+    _.extend(orCounts, @calculateDataCriteriaOrCounts(rationale))
 
   # recursively walk preconditions to count true values for child ORs moving down the tree
   calculateOrCountsRecursive: (rationale, preconditions) ->
@@ -155,6 +154,16 @@ class Thorax.Models.Result extends Thorax.Model
         orCounts["precondition_#{precondition.id}"] = trueCount
       _.extend(orCounts, @calculateOrCountsRecursive(rationale, precondition.preconditions))
     return orCounts
+
+  # walk through data criteria to account for specific occurrences within a UNION
+  calculateDataCriteriaOrCounts: (rationale) ->
+    orCounts = {}
+    for key, dc of @measure.get('data_criteria') when dc.derivation_operator == 'UNION'
+      trueCount = 0
+      for child in dc.children_criteria
+        trueCount++
+      if orCounts[dc.key]? then orCounts[dc.key] += trueCount else orCounts[dc.key] = trueCount
+    orCounts
 
   codedEntriesForDataCriteria: (dataCriteriaKey) ->
     @get('rationale')[dataCriteriaKey]?['results']

--- a/app/assets/javascripts/models/result.js.coffee
+++ b/app/assets/javascripts/models/result.js.coffee
@@ -161,7 +161,7 @@ class Thorax.Models.Result extends Thorax.Model
     for key, dc of @measure.get('data_criteria') when dc.derivation_operator == 'UNION' && dc.key.indexOf('UNION') != -1
       trueCount = 0
       for child in dc.children_criteria
-        trueCount++
+        trueCount++ if rationale[dc.key]
       if orCounts[dc.key]? then orCounts[dc.key] += trueCount else orCounts[dc.key] = trueCount
     orCounts
 

--- a/app/assets/javascripts/models/result.js.coffee
+++ b/app/assets/javascripts/models/result.js.coffee
@@ -158,7 +158,7 @@ class Thorax.Models.Result extends Thorax.Model
   # walk through data criteria to account for specific occurrences within a UNION
   calculateDataCriteriaOrCounts: (rationale) ->
     orCounts = {}
-    for key, dc of @measure.get('data_criteria') when dc.derivation_operator == 'UNION'
+    for key, dc of @measure.get('data_criteria') when dc.derivation_operator == 'UNION' && dc.key.indexOf('UNION') != -1
       trueCount = 0
       for child in dc.children_criteria
         trueCount++


### PR DESCRIPTION
### Story
- https://www.pivotaltracker.com/story/show/78230864
### Notes
- only consider unique occurrences when building specificsRationale
- extend `orCounts` to consider grouping data criteria representing Unions
### Screenshots
- undesired false-bubbling
  - ![screen shot 2014-09-10 at 9 03 39 am](https://cloud.githubusercontent.com/assets/456952/4217738/0638fa26-38eb-11e4-93e8-68e8f08b3b3d.png)
- fixed false-bubbling
  - ![screen shot 2014-09-10 at 9 03 57 am](https://cloud.githubusercontent.com/assets/456952/4217737/063645a6-38eb-11e4-9416-e0502a8df015.png)
