### PR TITLE
Update Union/Intersection rendering in population logic view

### DIFF
--- a/app/assets/javascripts/templates/logic/data_criteria.hbs
+++ b/app/assets/javascripts/templates/logic/data_criteria.hbs
@@ -1,5 +1,5 @@
 {{#unless expandVariable}}
-  <span class="{{dataCriteria.key}} rationale-target{{#ifCond dataCriteria.type '!=' 'derived'}} highlight-target{{/ifCond}}">
+  <span class="{{#if ../isSetOp}}{{#unless ../../dataCriteria.variable}}set-op-group{{/unless}}{{/if}} {{dataCriteria.key}} rationale-target{{#ifCond dataCriteria.type '!=' 'derived'}} highlight-target{{/ifCond}}">
 {{/unless}}
 
 {{#each dataCriteria.subset_operators}}
@@ -12,7 +12,7 @@
     {{#if dataCriteria.children_criteria}}
       {{#if isSetOp}}
         {{#unless expandVariable}}
-          <ul><li><span class="set-op {{dataCriteria.key}} rationale-target">{{translate_set_operator dataCriteria.derivation_operator}}:</span></li>
+          <ul><li><span class="set-op {{dataCriteria.key}} rationale-target"> {{translate_set_operator dataCriteria.derivation_operator}}:</span></li>
         {{/unless}}
       {{/if}}
       <ul>

--- a/app/assets/javascripts/templates/logic/data_criteria.hbs
+++ b/app/assets/javascripts/templates/logic/data_criteria.hbs
@@ -12,12 +12,12 @@
     {{#if dataCriteria.children_criteria}}
       {{#if isSetOp}}
         {{#unless expandVariable}}
-          <span class="set-op">{{translate_set_operator dataCriteria.derivation_operator}} :</span>
+          <ul><li><span class="set-op {{dataCriteria.key}} rationale-target">{{translate_set_operator dataCriteria.derivation_operator}}:</span></li>
         {{/unless}}
       {{/if}}
       <ul>
         {{#each dataCriteria.children_criteria}}
-          <li>
+          <li{{#if ../isSetOp}}{{#unless ../../expandVariable}} class="set-op-item"{{/unless}}{{/if}}>
             {{#unless ../isSetOp}}
               <span class="conjunction {{../../dataCriteria.key}} rationale-target">{{translate_logic_operator ../../dataCriteria.derivation_operator}} : <span class="sr-only sr-highlight-status"></span></span>
             {{/unless}}
@@ -34,6 +34,11 @@
           {{/each}}
         {{/if}}
       </ul>
+      {{#if isSetOp}}
+        {{#unless expandVariable}}
+          </ul>
+        {{/unless}}
+      {{/if}}
     {{/if}}
   {{/if}}
 {{else}}

--- a/app/assets/stylesheets/measure.less
+++ b/app/assets/stylesheets/measure.less
@@ -203,6 +203,11 @@
       padding-left: 20px;
       list-style-type: none;
       margin-bottom: 0px;
+      li {
+        .set-op-item {
+          list-style-type: square;
+        }
+      }
     }
   }
   .d3-measure-viz {

--- a/app/assets/stylesheets/mixins.less
+++ b/app/assets/stylesheets/mixins.less
@@ -49,7 +49,8 @@
     font-weight: bold;
   }
   .set-op {
-    font-weight: bold;
+    font-weight: 300;
+    text-transform: uppercase;
   }
   ul {
     padding-left: 20px;

--- a/app/assets/stylesheets/rationale.less
+++ b/app/assets/stylesheets/rationale.less
@@ -4,8 +4,13 @@
   .eval-true, .eval-false, .eval-bad-specifics, .eval-coverage {
     font-weight: 500;
     padding: 2px 0px;
-    ul li.set-op-item {
-      list-style-type: none;
+    &.set-op-group {
+      &:before {
+        content: none;
+      }
+      ul li.set-op-item {
+        list-style-type: none;
+      }
     }
   }
   .eval-true {

--- a/app/assets/stylesheets/rationale.less
+++ b/app/assets/stylesheets/rationale.less
@@ -4,6 +4,9 @@
   .eval-true, .eval-false, .eval-bad-specifics, .eval-coverage {
     font-weight: 500;
     padding: 2px 0px;
+    ul li.set-op-item {
+      list-style-type: none;
+    }
   }
   .eval-true {
     background-color: @state-success-bg;


### PR DESCRIPTION
### Story
- https://www.pivotaltracker.com/story/show/77034966
### Notes
- Set operators are rendered differently than preconditions (lighter font-weight, uppercase)
- Bullets are used when the rationale highlighting is off
### Screenshots
- previous default
  - ![screen shot 2014-09-12 at 9 36 14 am](https://cloud.githubusercontent.com/assets/456952/4250286/e514c5d0-3a81-11e4-9185-3eb38efc62b9.png)
- previous rationale
  - ![screen shot 2014-09-12 at 9 36 22 am](https://cloud.githubusercontent.com/assets/456952/4250284/e5121b3c-3a81-11e4-9c33-336543807abb.png)
- new default
  - ![screen shot 2014-09-12 at 9 35 44 am](https://cloud.githubusercontent.com/assets/456952/4250285/e5146e6e-3a81-11e4-8547-956bfa65c4c0.png)
- new rationale
  - ![screen shot 2014-09-12 at 9 35 52 am](https://cloud.githubusercontent.com/assets/456952/4250283/e510857e-3a81-11e4-8d8f-e495e4ebbc5a.png)
