### PR TITLE
Pass in submeasure population code to build correct parentMap

### DIFF
--- a/app/assets/javascripts/models/result.js.coffee
+++ b/app/assets/javascripts/models/result.js.coffee
@@ -30,7 +30,8 @@ class Thorax.Models.Result extends Thorax.Model
         occurrences = _.uniq @population.getDataCriteriaKeys(@measure.get('population_criteria')[@population.get(code)?.code])
         # get the good and bad specifics
         occurrenceResults = @checkSpecificsForRationale(specifics, occurrences, @measure.get('data_criteria'))
-        parentMap = @buildParentMap(@measure.get('population_criteria')[code])
+        submeasureCode = @population.get(code)?.code || code
+        parentMap = @buildParentMap(@measure.get('population_criteria')[submeasureCode])
 
         # check each bad occurrence and remove highlights marking true
         for badOccurrence in occurrenceResults.bad


### PR DESCRIPTION
### Story
- https://www.pivotaltracker.com/story/show/78675006
### Notes
- resolve rationale highlighting glitch on identical IPP across two submeasures by referencing the correct submeasure population codes when building the `parentMap` for handling specific occurrences
### Screenshot

![screen shot 2014-09-30 at 2 09 49 pm](https://cloud.githubusercontent.com/assets/456952/4463651/01439c28-48cd-11e4-9591-54d13a7ffc02.png)
