### PR TITLE
Update patient model parse handling of race and ethnicity

### DIFF
--- a/app/assets/javascripts/models/patient.js.coffee
+++ b/app/assets/javascripts/models/patient.js.coffee
@@ -11,8 +11,8 @@ class Thorax.Models.Patient extends Thorax.Model
     # This section is a bit unusual: we map from server side values to a more straight forward client
     # side representation; the reverse mapping would usually happen in toJSON(), but in this case it
     # happens on the server in the controller
-    attrs.ethnicity = attrs.ethnicity?.code
-    attrs.race = attrs.race?.code
+    attrs.ethnicity = attrs.ethnicity?.code if typeof attrs.ethnicity == 'object'
+    attrs.race = attrs.race?.code if typeof attrs.race == 'object'
     attrs.payer = attrs.insurance_providers?[0]?.type || 'OT'
 
     attrs

--- a/app/assets/javascripts/models/patient.js.coffee
+++ b/app/assets/javascripts/models/patient.js.coffee
@@ -11,8 +11,9 @@ class Thorax.Models.Patient extends Thorax.Model
     # This section is a bit unusual: we map from server side values to a more straight forward client
     # side representation; the reverse mapping would usually happen in toJSON(), but in this case it
     # happens on the server in the controller
-    attrs.ethnicity = attrs.ethnicity?.code if typeof attrs.ethnicity == 'object'
-    attrs.race = attrs.race?.code if typeof attrs.race == 'object'
+    # extract demographics from hash, or use extracted values when cloning
+    attrs.ethnicity = attrs.ethnicity?.code || attrs.ethnicity
+    attrs.race = attrs.race?.code || attrs.race
     attrs.payer = attrs.insurance_providers?[0]?.type || 'OT'
 
     attrs


### PR DESCRIPTION
### Story
- https://www.pivotaltracker.com/story/show/79806350
### Notes
- `race` and `ethnicity` are extracted from the backend hash/object representation, which happens twice when loading the `deepClone()`'d model in the patient builder
- Note: the desired race and ethnicity were always being saved correctly, but not rendered when editing the patient within the patient builder
