### PR TITLE
Discrete export errors

### DIFF
--- a/app/assets/javascripts/templates/measure/export_patients.hbs
+++ b/app/assets/javascripts/templates/measure/export_patients.hbs
@@ -30,3 +30,19 @@
     </div>
   </div>
 </div>
+
+<div class="modal fade" id="exportSucceededDialog" tabindex="-1" role="dialog" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h1>Export Complete</h1>
+      </div>
+      <div class="modal-body">
+        Your export has completed. Please see the toplevel results file for an overview of the exported patients, including any errors exporting individual patients.
+      </div>
+      <div class="modal-footer">
+        {{#button "close" class="btn btn-default" data-dismiss="modal"}}Close{{/button}}
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/assets/javascripts/views/export_patients_view.js.coffee
+++ b/app/assets/javascripts/views/export_patients_view.js.coffee
@@ -1,7 +1,9 @@
 class Thorax.Views.ExportPatientsView extends Thorax.Views.BonnieView
   template: JST['measure/export_patients']
   exporting: -> @$("#exportPatientsDialog").modal backdrop: 'static'
-  success: -> @$("#exportPatientsDialog").modal 'hide'
+  success: ->
+    @$("#exportPatientsDialog").modal 'hide'
+    @$("#exportSucceededDialog").modal backdrop: 'static'
   fail: ->
     @$("#exportPatientsDialog").modal 'hide'
     @$("#exportFailedDialog").modal backdrop: 'static'

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -46,14 +46,16 @@ class PatientsController < ApplicationController
     stringio = Zip::ZipOutputStream::write_buffer do |zip|
       records.each_with_index do |patient, index|
         begin
+          qrda = qrda_exporter.export(patient, measure, start_time, end_time) # allow error to stop execution before header is written
           zip.put_next_entry(File.join("qrda","#{index+1}_#{patient.last}_#{patient.first}.xml"))
-          zip.puts qrda_exporter.export(patient, measure, start_time, end_time)
+          zip.puts qrda
         rescue Exception => e
           qrda_errors[patient.id] = e
         end
         begin
+          html = html_exporter.export(patient, if current_user.portfolio? then [] else measure end) # allow error to stop execution before header is written
           zip.put_next_entry(File.join("html","#{index+1}_#{patient.last}_#{patient.first}.html"))
-          zip.puts html_exporter.export(patient, if current_user.portfolio? then [] else measure end)
+          zip.puts html
         rescue Exception => e
           html_errors[patient.id] = e
         end

--- a/lib/templates/patient_summary/index.html.erb
+++ b/lib/templates/patient_summary/index.html.erb
@@ -70,6 +70,21 @@
     .btn:hover {
       background-color: #f2f2f2;
     }
+    div.error {
+      color: #a94442;
+      background-color: #f2dede;
+      border-color: #ebccd1;
+      padding: 15px;
+      margin-bottom: 20px;
+      border: 1px solid transparent;
+      border-radius: 4px;
+    }
+    div.error span.important {
+      font-weight: bold;
+    }
+    div.error span.secondary {
+      color: #888;
+    }
   </style>
 </head>
 <body>
@@ -118,12 +133,42 @@
           <td>
             <h2>
               <span class="<%= patient_result['status'] %>"><%= patient_result['status'] %>: </span>
-              <a href="<%= File.join(".","html","#{index+1}_#{record.last}_#{record.first}.html")%>"><%=record.last%>, <%=record.first%></a>
-              <a class="btn" href="<%= File.join(".","qrda","#{index+1}_#{record.last}_#{record.first}.xml")%>">qrda</a>
+              <% unless html_errors[record.id] %>
+                <a href="<%= File.join(".","html","#{index+1}_#{record.last}_#{record.first}.html")%>"><%=record.last%>, <%=record.first%></a>
+              <% else %>
+                <%=record.last%>, <%=record.first%>
+              <% end %>
+              <% unless qrda_errors[record.id] %>
+                <a class="btn" href="<%= File.join(".","qrda","#{index+1}_#{record.last}_#{record.first}.xml")%>">qrda</a>
+              <% end %>
             </h2>
           </td>
         </tr>
       </table>
+      <% if qrda_errors[record.id] %>
+        <div class="error">
+          <span class="important">There was an error exporting the QRDA for this patient record:</span>
+          <% data_criteria = qrda_errors[record.id].data_criteria rescue nil %>
+          <% if data_criteria %>
+            <span class="important">could not generate appropriate QRDA content for <%= data_criteria.description %></span>
+            <span class="secondary">(<%= qrda_errors[record.id].message %>)</span>
+          <% else %>
+            <%= qrda_errors[record.id].message %>
+          <% end %>
+        </div>
+      <% end %>
+      <% if html_errors[record.id] %>
+        <div class="error">
+          <span class="important">There was an error exporting the HTML for this patient record:</span>
+          <% data_criteria = html_errors[record.id].data_criteria rescue nil %>
+          <% if data_criteria %>
+            <span class="important">could not generate appropriate HTML content for <%= data_criteria.description %></span>
+            <span class="secondary">(<%= html_errors[record.id].message %>)</span>
+          <% else %>
+            <%= html_errors[record.id].message %>
+          <% end %>
+        </div>
+      <% end %>
       <table>
         <tr>
           <th>Status</th>


### PR DESCRIPTION
Allow patient export to complete even if there are errors exporting individual patient records. If errors do occur, the individual export file is excluded and an error is noted in the export summary.
