### PR TITLE
Fix patient builder birthdate/deathdate errors

### DIFF
--- a/app/assets/javascripts/views/patient_builder/patient_builder.js.coffee
+++ b/app/assets/javascripts/views/patient_builder/patient_builder.js.coffee
@@ -91,7 +91,7 @@ class Thorax.Views.PatientBuilder extends Thorax.Views.BonnieView
 
   # When we create the form and populate it, we want to convert some values to those appropriate for the form
   context: ->
-    birthdatetime = moment.utc(@model.get('birthdate'), 'X') if @model.has('birthdate')
+    birthdatetime = moment.utc(@model.get('birthdate'), 'X') if @model.has('birthdate') && !!@model.get('birthdate')
     deathdatetime = moment.utc(@model.get('deathdate'), 'X') if @model.get('expired') && @model.has('deathdate')
     _(super).extend
       measureTitle: @measure.get('title')


### PR DESCRIPTION
### Story
- https://www.pivotaltracker.com/story/show/81387898
### Notes
- updated Thorax.Models.Patient.`validate()` to utilize MomentJS versions of `birthdate`, `deathdate`, `start_date`, and `end_date` to prevent undesired string comparisons
- updated Thorax.Views.PatientBuilder.`context()` to check for a birthdate value before computing `birthdatetime`
### Testing
1. Save a patient that is born on `02/01/1970, 8:00AM` and expired on `11/04/2014, 8:00AM`.
   - ![screen shot 2014-11-13 at 1 20 18 pm](https://cloud.githubusercontent.com/assets/456952/5033912/2c4ed0a8-6b38-11e4-9279-b3e486e95514.png)
2. Start building a new patient, before entering any characteristics, toggle the deceased checkbox and then remove the date of death.
   - This should no longer populate the birthdate/time fields with 'Invalid date'.
