### PR TITLE
data criteria collapses nicely

### DIFF
--- a/app/assets/javascripts/templates/patient_builder/select_criteria.hbs
+++ b/app/assets/javascripts/templates/patient_builder/select_criteria.hbs
@@ -2,7 +2,7 @@
   <a class="panel-title collapsed {{title}}-elements" data-toggle="collapse" data-parent="#criteriaElements" href="#collapse-{{cid}}">
     <i class="fa fa-angle-right fa-2x panel-expander" aria-hidden="true"></i>
     <i class="fa {{faIcon}} fa-3x panel-icon" aria-hidden="true"></i>
-    {{title}}
+    <span class="element-title">{{title}}</span>
   </a>
 
   <div id="collapse-{{cid}}" class="collapse">

--- a/app/assets/javascripts/views/patient_builder/data_criteria.js.coffee
+++ b/app/assets/javascripts/views/patient_builder/data_criteria.js.coffee
@@ -16,11 +16,12 @@ class Thorax.Views.SelectCriteriaView extends Thorax.Views.BonnieView
   events:
     rendered: ->
       # FIXME: We'd like to do this via straight thorax events, doesn't seem to work...
-      @$('.collapse').on 'show.bs.collapse hide.bs.collapse', => 
-        @$('.panel-expander').toggleClass('fa-angle-right fa-angle-down').toggleClass('fa-2x fa-1x')
-        @$('.panel-icon').toggleClass('fa-3x fa-1x').toggleClass('opened')
-      @$('.collapse').on 'show.bs.collapse', (e) ->
-        $('a[data-parent="#criteriaElements"]').next('.in').not(e.target).collapse 'hide' #hide open groups
+      @$('.collapse').on 'show.bs.collapse hide.bs.collapse', (e) =>
+        $('a.panel-title[data-toggle="collapse"]').toggleClass('closed').find('.panel-icon').toggleClass('fa-3x fa-1x') #shrink others
+        @$('.panel-expander').toggleClass('fa-angle-right fa-angle-down')
+        @$('.panel-icon').toggleClass('fa-3x fa-2x')
+        @$('a.panel-title[data-toggle="collapse"]').toggleClass('closed')
+        if e.type is 'show' then $('a.panel-title[data-toggle="collapse"]').next('div.in').not(e.target).collapse('hide') # hide open ones
 
   faIcon: -> @collection.first()?.toPatientDataCriteria()?.faIcon()
 

--- a/app/assets/stylesheets/builder.less
+++ b/app/assets/stylesheets/builder.less
@@ -172,20 +172,35 @@
       font-size: @font-size-base;
       padding: (@grid-gutter-width / 2);
       text-transform: uppercase;
-      .panel-icon {
-        display: block;
-        .transition(font-size .35s ease);
-        &.opened {
-          display: inline-block;
+      &[class*="-elements"] {
+        .transition(all .35s ease);
+        background-color: @blue-lighter;
+        &.closed {
+          padding: 4px (@grid-gutter-width / 2);
+          overflow: hidden;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+          &:before {
+            content: ''; // IE9 ellipsis fix
+          }
+          .panel-icon {
+            display: inline-block;
+            font-weight: bold;
+          }
+          .element-title {
+            line-height: 28px; // center it with arrow
+          }
         }
-      }
-      .panel-expander {
-        .transition(font-size .35s ease);
-        .pull-right;
-        line-height: 2;
-      }
-      &:hover {
-        text-decoration: none;
+        .panel-icon {
+          display: block;
+        }
+        .panel-expander {
+          .pull-right;
+        }
+        &:hover {
+          background-color: @blue-darker;
+          text-decoration: none;
+        }
       }
     }
     .draggable {


### PR DESCRIPTION
The main change is that, when opening a category, all others compress to save space gracefully. Long text is handled by cutting it off with an ellipsis.

![image](https://cloud.githubusercontent.com/assets/2136286/5014740/3232f6b6-6a66-11e4-8b80-d086c892ddfa.png)
