### PR TITLE
Support measure diff within the size view for the Complexity Dashboard

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem "non-stupid-digest-assets"
 gem 'health-data-standards', :git => 'https://github.com/projectcypress/health-data-standards.git', :branch => 'bonnie_master'
 gem 'simplexml_parser', :git => 'https://github.com/projecttacoma/simplexml_parser.git', :branch => 'master'
 gem 'hqmf2js', :git => 'https://github.com/projecttacoma/hqmf2js.git', :branch => 'master'
-gem 'bonnie_bundler', :git => 'https://github.com/projecttacoma/bonnie_bundler.git', :branch => 'master'
+gem 'bonnie_bundler', :git => 'https://github.com/projecttacoma/bonnie_bundler.git', :branch => 'measure_diffs'
 gem 'quality-measure-engine', :git => 'https://github.com/pophealth/quality-measure-engine.git', :branch => 'master'
 gem 'hquery-patient-api', :git => 'https://github.com/projecttacoma/patientapi.git', :branch => 'master'
 
@@ -32,6 +32,7 @@ gem 'mongoid'
 gem 'protected_attributes'
 gem 'devise'
 gem 'systemu'
+gem 'diffy'
 
 
 # needed for parsing value sets (we need to use roo rather than rubyxl because the value sets are in xls rather than xlsx)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -30,8 +30,8 @@ GIT
 
 GIT
   remote: https://github.com/projecttacoma/bonnie_bundler.git
-  revision: 6d6b2c60a8e2164297cc98462af3eebc6320a477
-  branch: master
+  revision: 09cd9dd84bd1657407a3c7ef37f90bbdd52ccb17
+  branch: measure_diffs
   specs:
     bonnie_bundler (1.0.0)
 
@@ -126,6 +126,7 @@ GEM
       railties (>= 3.2.6, < 5)
       thread_safe (~> 0.1)
       warden (~> 1.2.3)
+    diffy (3.0.7)
     docile (1.1.3)
     dotenv (0.11.1)
       dotenv-deployment (~> 0.0.2)
@@ -294,6 +295,7 @@ DEPENDENCIES
   capistrano-rails
   coffee-rails
   devise
+  diffy
   exception_notification
   foreman
   handlebars_assets

--- a/app/assets/javascripts/measure_size.js.coffee
+++ b/app/assets/javascripts/measure_size.js.coffee
@@ -22,9 +22,14 @@ bonnie.viz.MeasureSize = ->
   height = 460
   barHeight = 3
   spacing = 5
+  # size_data = null
 
   my = (selection) ->
     selection.each (data) ->
+
+      # data.sort( (a,b) -> b.change - a.change)
+      # size_data = data
+      d3.selectAll('svg').remove()
 
       color = (line) ->
         switch line
@@ -108,5 +113,11 @@ bonnie.viz.MeasureSize = ->
   my.hideDeletedLines = ->
     updateLines('')
     deletedLabels(false)
+
+  my.sortByLargest = ->
+    d3.selectAll('svg').data(size_data.sort( (a,b) -> b.size - a.size))
+
+  my.sortByMostChange = ->
+    d3.selectAll('svg').data(size_data.sort( (a,b) -> b.change - a.change))
 
   my

--- a/app/assets/javascripts/models/measure_set.js.coffee
+++ b/app/assets/javascripts/models/measure_set.js.coffee
@@ -23,6 +23,14 @@ class Thorax.Models.MeasurePair extends Thorax.Model
     scores = scores.concat _(complexity.variables).pluck('complexity')
     _(scores).max()
 
+  # Transform data to something approrpriate for the D3 size visualization
+  sizeVizData: ->
+    measure2 = @get('measure_2')
+    data = measure2['latest_diff']
+    data['size'] = data['totals']['total']
+    data['change'] = data['totals']['insertions'] + data['totals']['deletions']
+    data
+
 class Thorax.Collections.MeasurePairs extends Thorax.Collection
   url: -> "complexity_dashboard/measure_sets/#{@measureSet1},#{@measureSet2}"
   model: Thorax.Models.MeasurePair
@@ -30,3 +38,8 @@ class Thorax.Collections.MeasurePairs extends Thorax.Collection
     @measureSet1 = options.measureSet1
     @measureSet2 = options.measureSet2
   complexityVizData: -> @map (pair) -> pair.complexityVizData()
+  sizeVizData: (sort) ->
+    if sort
+      _(@map (pair) -> pair.sizeVizData()).sortBy((p) => -p[sort])
+    else
+      @map (pair) -> pair.sizeVizData()

--- a/app/assets/javascripts/views/dashboard_view.js.coffee
+++ b/app/assets/javascripts/views/dashboard_view.js.coffee
@@ -24,83 +24,10 @@ class Thorax.Views.SizeDashboard extends Thorax.Views.BonnieView
       # FIXME: instead of these two lines, maybe just more buttons in the grid/graph area
       $('.indicator-circle, .navbar-nav > li').removeClass('active')
       $('.nav-dashboard-size').addClass('active')
-      example_data = [
-        {
-          cms_id: 'cms126v1'
-          populations: [
-            {
-              code: 'IPP'
-              lines: ['unchanged', 'unchanged', 'ins', 'del', 'unchanged', 'del']
-              insertions: 1
-              deletions: 2
-              unchanged: 3
-              total: 6
-            },{
-              code: 'DENOM'
-              lines: ['unchanged', 'ins', 'ins', 'del', 'ins', 'del']
-              insertions: 3
-              deletions: 2
-              unchanged: 1
-              total: 6
-            },{
-              code: 'NUMER'
-              lines: ['unchanged', 'unchanged', 'unchanged', 'unchanged', 'unchanged', 'del']
-              insertions: 0
-              deletions: 1
-              unchanged: 5
-              total: 6
-            }
-          ]
-          totals: {
-            total: 18
-            deletions: 5
-            insertions: 4
-          }
-        }
-      ]
-
-      LINE_STATES = ['unchanged', 'ins', 'del']
-      MEASURE_POPULATIONS = [
-        ['IPP', 'DENOM', 'NUMER']
-        ['IPP', 'DENOM', 'DENEX', 'NUMER']
-        ['IPP', 'DENOM', 'NUMER', 'DENEXCL']
-        ['IPP', 'DENOM', 'DENEX', 'NUMER', 'DENEXCL']
-        ['IPP', 'MSRPOPL', 'OBSERV']
-      ]
-
-      for i in [0..93]
-        measure = {}
-        measure['cms_id'] = "cms#{Math.floor(Math.random() * 300) + 1}v#{Math.floor(Math.random() * 4) + 1}"
-        measure['populations'] = []
-        sum =
-          total: 0
-          deletions: 0
-          insertions: 0
-
-        p = Math.floor(Math.random() * 5)
-        for criteria in MEASURE_POPULATIONS[p]
-          n = Math.floor(Math.random() * 10) + 1
-          population = {
-            code: "#{criteria}_#{i}"
-          }
-          lines = []
-          for ii in [0..n]
-            lines.push LINE_STATES[Math.floor(Math.random() * 3)]
-          population['lines'] = lines
-          population['insertions'] = _(lines).filter( (l) -> l == 'ins' ).length
-          population['deletions'] = _(lines).filter( (l) -> l == 'del' ).length
-          population['unchanged'] = _(lines).filter( (l) -> l == 'unchanged' ).length
-          population['total'] = lines.length
-          measure['populations'].push population
-          sum.total += lines.length
-          sum.deletions += population['insertions']
-          sum.insertions += population['deletions']
-
-        measure['totals'] = sum
-        example_data.push measure
-
       @viz = bonnie.viz.MeasureSize()
-      d3.select(@$el.find('#size-grid').get(0)).datum(example_data).call(@viz)
+      d3.select(@$el.find('#size-grid').get(0)).datum(@collection.sizeVizData('change')).call(@viz)
+    collection:
+      sync: -> @render()
 
   showAddedLines: (e) ->
     @$('.added-box').addClass('darker')
@@ -119,11 +46,11 @@ class Thorax.Views.SizeDashboard extends Thorax.Views.BonnieView
     @viz.hideDeletedLines()
 
   sortByLargest: (e) ->
-    console.log "Should sort by largest size..."
+    d3.select(@$el.find('#size-grid').get(0)).datum(@collection.sizeVizData('size')).call(@viz)
     @$('.sort').toggleClass('btn-primary btn-default') unless @$('.sort-largest').hasClass('btn-primary')
 
   sortByMostChange: (e) ->
-    console.log "Should sort by most change..."
+    d3.select(@$el.find('#size-grid').get(0)).datum(@collection.sizeVizData('change')).call(@viz)
     @$('.sort').toggleClass('btn-primary btn-default') unless @$('.sort-change').hasClass('btn-primary')
 
 class Thorax.Views.ComplexityDashboard extends Thorax.Views.BonnieView

--- a/app/assets/stylesheets/dashboard.less
+++ b/app/assets/stylesheets/dashboard.less
@@ -21,6 +21,11 @@
     shape-rendering: crispEdges;
   }
 
+  .legend {
+    position: fixed;
+    right: 50px;
+  }
+
   .legend, .added-key, .deleted-key {
     display: inline-block;
     float: right;
@@ -45,6 +50,7 @@
   }
 
   .logic-line {
+    fill-opacity: 0.8;
     &.ins-line {
       fill: @red-darker;
       &.added-darker {

--- a/app/controllers/complexity_dashboard/measure_sets_controller.rb
+++ b/app/controllers/complexity_dashboard/measure_sets_controller.rb
@@ -23,10 +23,11 @@ class ComplexityDashboard::MeasureSetsController < ApplicationController
     end
     # Pair up the measures
     measure_pairs = []
-    measures_1 = measure_set_1.measures.only(:cms_id, :hqmf_set_id, :complexity).index_by(&:hqmf_set_id)
-    measures_2 = measure_set_2.measures.only(:cms_id, :hqmf_set_id, :complexity).index_by(&:hqmf_set_id)
+    measures_1 = measure_set_1.measures.only(:cms_id, :hqmf_set_id, :complexity, :measure_logic, :latest_diff).index_by(&:hqmf_set_id)
+    measures_2 = measure_set_2.measures.only(:cms_id, :hqmf_set_id, :complexity, :measure_logic, :latest_diff).index_by(&:hqmf_set_id)
     measures_1.each do |hqmf_set_id, measure_1|
       if measure_2 = measures_2[hqmf_set_id]
+        measure_1.diff(measure_2)
         measure_pairs << { measure_1: measure_1, measure_2: measure_2 }
       end
     end


### PR DESCRIPTION
- requires **bonnie_bundler**'s `measure_diffs` branch
- requires `bundle exec rake bonnie:db:resave_measures` to compute each measure's logic as text
- UI is missing main nav bar fix for switching to size from complexity
