### PR TITLE
Subset map defaults to using provided term except for exception cases

### DIFF
--- a/app/assets/javascripts/measure_visual.js.coffee
+++ b/app/assets/javascripts/measure_visual.js.coffee
@@ -95,18 +95,7 @@ Bonnie.viz.measureVisualzation = ->
       's':'second'
 
     subset_map =
-      'COUNT': 'COUNT'
-      'FIRST': 'FIRST'
-      'SECOND': 'SECOND'
-      'THIRD': 'THIRD'
-      'FOURTH': 'FOURTH'
-      'FIFTH': 'FIFTH'
       'RECENT': 'MOST RECENT'
-      'LAST': 'LAST'
-      'MIN': 'MIN'
-      'MAX': 'MAX'
-      'MEAN': 'MEAN'
-      'MEDIAN': 'MEDIAN'
       'TIMEDIFF': 'Difference between times'
       'DATEDIFF': 'Difference between dates'
       'DATETIMEDIFF': 'Difference between date/times'
@@ -397,7 +386,7 @@ Bonnie.viz.measureVisualzation = ->
         when 'satisfies_all' then 'SATISFIES ALL'
         when 'satisfies_any' then 'SATISFIES ANY'
 
-    translateSubset = (subset) -> subset_map[subset]
+    translateSubset = (subset) -> subset_map[subset] || subset
 
     translateOid = (oid) -> measureValueSets.findWhere({oid: oid})?.get('display_name')
 

--- a/app/assets/javascripts/views/logic/subset_operator_logic_view.js.coffee
+++ b/app/assets/javascripts/views/logic/subset_operator_logic_view.js.coffee
@@ -2,18 +2,7 @@ class Thorax.Views.SubsetOperatorLogic extends Thorax.Views.BonnieView
 
   template: JST['logic/subset_operator']
   subset_map:
-    'COUNT':'COUNT'
-    'FIRST':'FIRST'
-    'SECOND':'SECOND'
-    'THIRD':'THIRD'
-    'FOURTH':'FOURTH',
-    'FIFTH':'FIFTH'
     'RECENT':'MOST RECENT'
-    'LAST':'LAST'
-    'MIN':'MIN'
-    'MAX':'MAX',
-    'MEAN':'MEAN'
-    'MEDIAN':'MEDIAN'
     'TIMEDIFF':'Difference between times'
     'DATEDIFF':'Difference between dates'
     'DATETIMEDIFF':'Difference between date/times'
@@ -22,4 +11,4 @@ class Thorax.Views.SubsetOperatorLogic extends Thorax.Views.BonnieView
     ""
 
   translate_subset: (subset) ->
-    @subset_map[subset]
+    @subset_map[subset] || subset


### PR DESCRIPTION
The lookup table was mostly replacing existing terms with themselves, so we change the default behavior for a non-match to provide the originally supplied term, and reduce the mapping to only those where the output is different from the input. This provides correct behavior for the SUM operator, which is the immediately driving concern, but also will help with any future new operators.
