### PR TITLE
Medication dose/fulfillment entry

### DIFF
--- a/app/assets/javascripts/templates/patient_builder/edit_criteria.hbs
+++ b/app/assets/javascripts/templates/patient_builder/edit_criteria.hbs
@@ -117,6 +117,8 @@
                   <label for="dose_unit_{{@cid}}" class="sr-only">dose unit</label>
                   <select id="dose_unit_{{@cid}}" name="dose_unit" class="form-control medications-control">
                     <option value="mg">mg</option>
+                    <option value="tablet(s)">tablet(s)</option>
+                    <option value="capsule(s)">capsule(s)</option>
                   </select>
                 </div>
               </div>

--- a/app/assets/javascripts/templates/patient_builder/edit_criteria.hbs
+++ b/app/assets/javascripts/templates/patient_builder/edit_criteria.hbs
@@ -110,32 +110,30 @@
         <div class="row">
           <div class="form-group col-md-6">
             <label for="dose_value_{{@cid}}" class="control-label"><i class="fa fa-medkit" aria-hidden="true"></i> Prescription<span class="sr-only"> value</span></label>
-            <div class="row">
-              <div class="col-xs-8">
+            <div class="form-inline">
+              <div class="input-group">
                 <input type="text" name="dose_value" id="dose_value_{{@cid}}" class="form-control" placeholder="dose">
-              </div>
-              <div class="col-xs-4">
-                <label for="dose_unit_{{@cid}}" class="sr-only">dose unit</label>
-                <select id="dose_unit_{{@cid}}" name="dose_unit" class="form-control medications-control">
-                  <option value="mg">mg</option>
-                </select>
-                {{!-- <input type="text" name="dose_unit" id="dose_unit{{@cid}}" class="form-control" placeholder="units"> --}}
+                <div class="input-group-addon">
+                  <label for="dose_unit_{{@cid}}" class="sr-only">dose unit</label>
+                  <select id="dose_unit_{{@cid}}" name="dose_unit" class="form-control medications-control">
+                    <option value="mg">mg</option>
+                  </select>
+                </div>
               </div>
             </div>
           </div>
           <div class="form-group col-md-6">
             <label for="frequency_value_{{@cid}}" class="control-label"><i class="fa fa-spinner" aria-hidden="true"></i> Regimen<span class="sr-only"> value</span></label>
-            <div class="row">
-              <div class="col-xs-7">
+            <div class="form-inline">
+              <div class="input-group">
                 <input type="text" name="frequency_value" id="frequency_value_{{@cid}}" class="form-control" placeholder="frequency">
-              </div>
-              <div class="col-xs-5">
-                <label for="frequency_unit_{{@cid}}" class="sr-only">frequency unit</label>
-                <select id="frequency_unit_{{@cid}}" name="frequency_unit" class="form-control medications-control">
-                  <option value="h">hour(s)</option>
-                  <option value="d">day(s)</option>
-                </select>
-                {{!-- <input type="text" name="frequency_unit" id="frequency_unit{{@cid}}" class="form-control" placeholder="units"> --}}
+                <div class="input-group-addon">
+                  <label for="frequency_unit_{{@cid}}" class="sr-only">frequency unit</label>
+                  <select id="frequency_unit_{{@cid}}" name="frequency_unit" class="form-control medications-control">
+                    <option value="h">hour(s)</option>
+                    <option value="d">day(s)</option>
+                  </select>
+                </div>
               </div>
             </div>
           </div>

--- a/app/assets/javascripts/templates/patient_builder/edit_fulfillments.hbs
+++ b/app/assets/javascripts/templates/patient_builder/edit_fulfillments.hbs
@@ -21,6 +21,8 @@
         <label for="quantity_dispensed_unit_{{@cid}}" class="sr-only">quantity dispensed unit</label>
         <select id="quantity_dispensed_unit_{{@cid}}" name="quantity_dispensed_unit" class="form-control medications-control">
           <option value="mg">mg</option>
+          <option value="tablet(s)">tablet(s)</option>
+          <option value="capsule(s)">capsule(s)</option>
         </select>
       </div>
     </div>

--- a/app/assets/javascripts/templates/patient_builder/edit_fulfillments.hbs
+++ b/app/assets/javascripts/templates/patient_builder/edit_fulfillments.hbs
@@ -1,26 +1,32 @@
 <div class="row">
   <div class="col-md-6">
-    <div class="row">
-      <div class="col-xs-8">
-        <input type="number" name="quantity_dispensed_value" id="quantity_dispensed_value_{{@cid}}" class="form-control" placeholder="dose">
+    <div class="datetime-control">
+      <div>
+        <label for="dispense_date_{{@cid}}" class="sr-only">dispense date</label>
+        <input type="text" name="dispense_date" id="dispense_date_{{@cid}}" class="date-picker form-control" placeholder="mm/dd/yyyy" data-date-format="mm/dd/yyyy" data-date-autoclose="true">
       </div>
-      <div class="col-xs-4">
+      <div>
+        <label for="dispense_time_{{@cid}}" class="sr-only">dispense time</label>
+        <input type="text" name="dispense_time" id="dispense_time_{{@cid}}" class="time-picker form-control" placeholder="--:-- --" data-show-inputs="false" data-default-time="8:00 AM">
+      </div>
+    </div>
+  </div>
+  <div class="col-md-5">
+    <div class="form-inline">
+    <div class="input-group">
+      <label for="quantity_dispensed_value_{{@cid}}" class="sr-only">quantity dispensed value</label>
+      <input type="number" name="quantity_dispensed_value" id="quantity_dispensed_value_{{@cid}}" class="form-control" placeholder="dose">
+
+      <div class="input-group-addon">
         <label for="quantity_dispensed_unit_{{@cid}}" class="sr-only">quantity dispensed unit</label>
         <select id="quantity_dispensed_unit_{{@cid}}" name="quantity_dispensed_unit" class="form-control medications-control">
           <option value="mg">mg</option>
         </select>
       </div>
     </div>
+    </div>
   </div>
-  <div class="col-md-3">
-    <label for="dispense_date_{{@cid}}" class="sr-only">dispense date</label>
-    <input type="text" name="dispense_date" id="dispense_date_{{@cid}}" class="date-picker form-control" placeholder="mm/dd/yyyy" data-date-format="mm/dd/yyyy" data-date-autoclose="true">
-  </div>
-  <div class="col-md-2">
-    <label for="dispense_time_{{@cid}}" class="sr-only">dispense time</label>
-    <input type="text" name="dispense_time" id="dispense_time_{{@cid}}" class="time-picker form-control" placeholder="--:-- --" data-show-inputs="false" data-default-time="8:00 AM">
-  </div>
-  <div class="col-md-1">
+  <div class="col-xs-1">
     {{#button "addFulfillment" class="btn btn-primary pull-right" disabled="disabled"}}
       <i class="fa fa-plus"></i>
       <span class="sr-only">add fulfillment</span>

--- a/app/assets/stylesheets/builder.less
+++ b/app/assets/stylesheets/builder.less
@@ -292,6 +292,10 @@
               border-left: 0;
             }
           }
+          .input-group-addon {
+            padding: 0;
+            border: none;
+          }
           .existing-values {
             margin-bottom: 10px;
 


### PR DESCRIPTION
Updated the alignment and sizing of the medication: active dose input (grouped related input and select boxes, and expanded the dose/fulfillment select boxes) so they work better with "tablet(s)" and "capsule(s)" as units.

Added "tablet(s)" and "capsule(s)" as units for medication: active dose and fulfillment. This is to fulfill a request by Sharon Sebastian for these units in Bonnie, to be used with pre-coordinated medications (medications where the RXNorm code specifies a dose). This is the simplest solution for getting these units into the exported HTML for medication: active and medication: dispensed fulfillment events. These units will not show up in any exported QRDA documents, as the QRDA spec defines the dose and fulfillment values as unitless for pre-coordinated medications.
