### PR TITLE
Patient notes + patient builder UI improvements

### DIFF
--- a/app/assets/javascripts/templates/patient_builder/patient_builder.hbs
+++ b/app/assets/javascripts/templates/patient_builder/patient_builder.hbs
@@ -8,11 +8,11 @@
 
 <div class="row">
   <div class="col-md-2">
-    <h1>Test Patient</h1>
+    <h1>Patient</h1>
   </div>
 
   <div class="col-md-6">
-    <div class="timeline-icon pull-left"><i class="fa fa-user fa-fw fa-4x" aria-hidden="true"></i></div>
+    <div class="timeline-icon pull-left"><i class="fa fa-user fa-fw fa-3x" aria-hidden="true"></i></div>
     <div class="validation-alerts"><div class="alert alert-danger hidden"></div></div>
   </div>
 
@@ -147,7 +147,7 @@
     </div>
   </div>
   <div class="col-center criteria-container droppable">
-    <h1 class="heading-primary">Patient History Relative To Measures</h1>
+    <h1 class="heading-primary">Patient History</h1>
     {{view editCriteriaCollectionView}}
   </div>
   {{#button "cancel" class="sr-only"}}CANCEL{{/button}}

--- a/app/assets/javascripts/templates/patient_builder/patient_builder.hbs
+++ b/app/assets/javascripts/templates/patient_builder/patient_builder.hbs
@@ -41,13 +41,12 @@
     <form class="row form-data" role="form">
       <div class="col-sm-12">
         <div class="form-group">
-          <label for="payer" class="control-label">Payer</label>
-          <select id="payer" name="payer" class="form-control">
-            <option value="MA">Medicare</option>
-            <option value="MC">Medicaid</option>
-            <option value="OT">Other</option>
-          </select>
+          <label for="notes" class="control-label">Patient Description</label>
+          <textarea id="notes" name="notes"class="form-control" placeholder="Patient is..." rows="2" maxlength="250"></textarea>
         </div>
+      </div>
+
+      <div class="col-sm-6">
 
         <div class="form-group">
           <label for="birthdate" class="control-label">Date of Birth</label>
@@ -75,16 +74,17 @@
             <option value="2131-1">Other</option>
           </select>
         </div>
-      </div>
 
-      <div class="col-md-6 col-sm-6">
         <div class="form-group">
-          <label for="gender" class="control-label">Gender</label>
-          <select id="gender" name="gender" class="form-control">
-            <option value="M">Male</option>
-            <option value="F">Female</option>
+          <label for="ethnicity" class="control-label">Ethnicity</label>
+          <select id="ethnicity" name="ethnicity" class="form-control">
+            <option value="2186-5">Not Hispanic or Latino</option>
+            <option value="2135-2">Hispanic Or Latino</option>
           </select>
         </div>
+      </div>
+
+      <div class="col-sm-6">
 
         <div class="form-group">
           <label for="{{#if expired}}deathdate{{else}}expired{{/if}}" class="control-label">{{#if expired}}Date of Death{{else}}Living Status{{/if}}</label>
@@ -113,10 +113,19 @@
         </div>
 
         <div class="form-group">
-          <label for="ethnicity" class="control-label">Ethnicity</label>
-          <select id="ethnicity" name="ethnicity" class="form-control">
-            <option value="2186-5">Not Hispanic or Latino</option>
-            <option value="2135-2">Hispanic Or Latino</option>
+          <label for="gender" class="control-label">Gender</label>
+          <select id="gender" name="gender" class="form-control">
+            <option value="M">Male</option>
+            <option value="F">Female</option>
+          </select>
+        </div>
+
+        <div class="form-group">
+          <label for="payer" class="control-label">Payer</label>
+          <select id="payer" name="payer" class="form-control">
+            <option value="MA">Medicare</option>
+            <option value="MC">Medicaid</option>
+            <option value="OT">Other</option>
           </select>
         </div>
       </div>

--- a/app/assets/javascripts/templates/patient_builder/patient_builder.hbs
+++ b/app/assets/javascripts/templates/patient_builder/patient_builder.hbs
@@ -39,7 +39,7 @@
 
   <div class="col-center">
     <form class="row form-data" role="form">
-      <div class="col-md-6 col-sm-6">
+      <div class="col-sm-12">
         <div class="form-group">
           <label for="payer" class="control-label">Payer</label>
           <select id="payer" name="payer" class="form-control">
@@ -53,11 +53,11 @@
           <label for="birthdate" class="control-label">Date of Birth</label>
 
           <div class="row">
-            <div class="col-md-6 col-sm-6">
+            <div class="col-sm-6">
               <input type="text" id="birthdate" name="birthdate" class="date-picker form-control" placeholder="mm/dd/yyyy" title="month/day/year" data-date-format="mm/dd/yyyy" data-date-keyboard-navigation="false" data-date-autoclose="true">
             </div>
 
-            <div class="col-md-6 col-sm-6">
+            <div class="col-sm-6">
               <label for="birthtime" class="sr-only">Time of Birth</label>
               <input type="text" id="birthtime" name="birthtime" class="time-picker form-control" placeholder="--:-- --" data-show-inputs="false" data-default-time="8:00 AM">
             </div>
@@ -94,7 +94,7 @@
                 <input type="text" id="deathdate" name="deathdate" class="date-picker form-control" placeholder="mm/dd/yyyy" title="month/date/year" data-date-format="mm/dd/yyyy" data-date-keyboard-navigation="false" data-date-autoclose="true">
               </div>
 
-              <div class="col-md-5 col-sm-5">
+              <div class="col-sm-5">
                 <label for="deathtime" class="sr-only">Time of Death</label>
                 <input type="text" id="deathtime" name="deathtime" class="time-picker form-control" placeholder="--:-- --" data-show-inputs="false" data-default-time="8:00 AM">
               </div>

--- a/app/assets/javascripts/templates/patient_builder/patient_builder.hbs
+++ b/app/assets/javascripts/templates/patient_builder/patient_builder.hbs
@@ -47,16 +47,13 @@
       </div>
 
       <div class="col-sm-6">
-
         <div class="form-group">
           <label for="birthdate" class="control-label">Date of Birth</label>
-
-          <div class="row">
-            <div class="col-sm-6">
+          <div class="datetime-control">
+            <div>
               <input type="text" id="birthdate" name="birthdate" class="date-picker form-control" placeholder="mm/dd/yyyy" title="month/day/year" data-date-format="mm/dd/yyyy" data-date-keyboard-navigation="false" data-date-autoclose="true">
             </div>
-
-            <div class="col-sm-6">
+            <div>
               <label for="birthtime" class="sr-only">Time of Birth</label>
               <input type="text" id="birthtime" name="birthtime" class="time-picker form-control" placeholder="--:-- --" data-show-inputs="false" data-default-time="8:00 AM">
             </div>
@@ -89,19 +86,18 @@
         <div class="form-group">
           <label for="{{#if expired}}deathdate{{else}}expired{{/if}}" class="control-label">{{#if expired}}Date of Death{{else}}Living Status{{/if}}</label>
           {{#if expired}}
-            <div class="row">
-              <div class="col-md-6 col-sm-6">
+            {{#button "removeDeathDate" class="btn btn-link remove-death-date"}}
+              <i class="fa fa-times-circle" aria-hidden="true"></i>
+              <span class="sr-only">remove date of death</span>
+            {{/button}}
+            <div class="datetime-control">
+              <div>
                 <input type="text" id="deathdate" name="deathdate" class="date-picker form-control" placeholder="mm/dd/yyyy" title="month/date/year" data-date-format="mm/dd/yyyy" data-date-keyboard-navigation="false" data-date-autoclose="true">
               </div>
-
-              <div class="col-sm-5">
+              <div>
                 <label for="deathtime" class="sr-only">Time of Death</label>
                 <input type="text" id="deathtime" name="deathtime" class="time-picker form-control" placeholder="--:-- --" data-show-inputs="false" data-default-time="8:00 AM">
               </div>
-              {{#button "removeDeathDate" class="btn btn-link remove-death-date"}}
-                <i class="fa fa-times-circle" aria-hidden="true"></i>
-                <span class="sr-only">remove date of death</span>
-              {{/button}}
             </div>
           {{else}}
             <div class="checkbox deceased-checkbox">

--- a/app/assets/javascripts/templates/patient_builder/patient_builder.hbs
+++ b/app/assets/javascripts/templates/patient_builder/patient_builder.hbs
@@ -130,8 +130,8 @@
 
 
   <div class="col-right expected-values">
-    <h2>Measure Associated</h2>
-    <p>{{measureTitle}}</p>
+    <h2>{{measureTitle}}</h2>
+    <p>{{measureDescription}}</p>
 
     {{view expectedValuesView}}
   </div>

--- a/app/assets/stylesheets/bootstrap3.less
+++ b/app/assets/stylesheets/bootstrap3.less
@@ -161,6 +161,10 @@ h1.modal-title {
   margin-bottom: .5em;
 }
 
+.form-control {
+  padding: 6px 8px;
+}
+
 //link css-toggle-switch height to text size and line height and padding
 .switch-toggle {
   height: @padding-base-vertical*2 + @line-height-base*@font-size-base;

--- a/app/assets/stylesheets/builder.less
+++ b/app/assets/stylesheets/builder.less
@@ -57,17 +57,24 @@
         margin-left: -@offset;
         padding-right: (@grid-gutter-width / 2); // leave out @time-bar-width to account for parent's border-right
       }
+      & .heading-muted {
+        margin-right: -@grid-gutter-width;
+      }
     }
   }
 
   .col-center {
-    .make-md-column(6);
     .make-sm-column(6);
+    padding-bottom: @grid-gutter-width;
     .form-data {
       .time-bar();
-      // FIXME this border is attached here because this column is taller, but really belongs on .col-right
-      border-right: 4px solid @brand-primary;
       margin-left: 0;
+      margin-top: -5px;
+      padding-top: 5px;
+      // FIXME: hack to get the grey bar to extend to next row
+      margin-bottom: -450px;
+      padding-bottom: 450px;
+      padding-right: (@grid-gutter-width / 2);
       padding-left: (@grid-gutter-width / 2);
     }
     .deceased-checkbox {
@@ -92,7 +99,7 @@
 
   .timeline-icon {
     color: @brand-primary;
-    margin-left: -32px;
+    margin-left: -23px;
   }
 
   .validation-alerts {
@@ -107,14 +114,16 @@
       background-color: @gray-lighter;
     }
     .tab-content {
-      padding-bottom: 10px;
+      padding: @grid-gutter-width/2;
+      padding-bottom: @grid-gutter-width * 1.5;
       h2, h3 {
         &:extend(h2);
         margin-top: 0;
-        padding-top: 6px;
       }
-
       .form-inline {
+        .checkbox-inline:first-child {
+          padding-left: 0px;
+        }
         .form-group {
           padding-right: 10px;
           label {
@@ -137,7 +146,7 @@
 
   .heading-muted {
     background-color: @gray-lighter;
-    padding-left: 3px;
+    padding-left: 8px;
   }
   .submeasure {
     text-transform: lowercase;
@@ -152,6 +161,7 @@
     background-color: @blue-lighter;
     color: white;
     padding-left: @grid-gutter-width;
+    margin-right: -@grid-gutter-width;
   }
 
   .panel {

--- a/app/assets/stylesheets/builder.less
+++ b/app/assets/stylesheets/builder.less
@@ -219,7 +219,7 @@
     .patient-criteria {
       .time-bar();
       &.during-measurement-period {
-        .time-bar(@blue-lightest);
+        .time-bar(@blue-lighter);
       }
       .criteria-type-marker {
         @radius: 18px;

--- a/app/assets/stylesheets/builder.less
+++ b/app/assets/stylesheets/builder.less
@@ -78,7 +78,7 @@
     }
     .remove-death-date {
       float: right;
-      padding-top: 8px;
+      padding-top: 0px;
       padding-right: 8px;
       padding-left: 0;
       padding-bottom: 0;
@@ -283,15 +283,6 @@
           .control-label {
             color: @brand-primary;
           }
-          .datetime-control {
-            .make-row(0);
-            &> * {
-              .make-md-column(6; 0);
-            }
-            &> :last-child input {
-              border-left: 0;
-            }
-          }
           .input-group-addon {
             padding: 0;
             border: none;
@@ -321,6 +312,15 @@
           }
         }
       }
+    }
+  }
+  .datetime-control {
+    .make-row(0);
+    &> * {
+      .make-md-column(6; 0);
+    }
+    &> :last-child input {
+      border-left: 0;
     }
   }
 }

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -83,7 +83,7 @@ private
     patient['measure_ids'] ||= params['measure_ids'] || []
     patient['measure_ids'] << params['measure_id'] unless patient['measure_ids'].include? params['measure_id'] || params['measure_id'].nil?
 
-    ['first', 'last', 'gender', 'expired', 'birthdate', 'description', 'description_category', 'deathdate'].each {|param| patient[param] = params[param]}
+    ['first', 'last', 'gender', 'expired', 'birthdate', 'description', 'description_category', 'deathdate', 'notes'].each {|param| patient[param] = params[param]}
 
     patient['ethnicity'] = {'code' => params['ethnicity'], 'name'=>ETHNICITY_NAME_MAP[params['ethnicity']], 'codeSystem' => 'CDC Race'}
     patient['race'] = {'code' => params['race'], 'name'=>RACE_NAME_MAP[params['race']], 'codeSystem' => 'CDC Race'}

--- a/lib/ext/record.rb
+++ b/lib/ext/record.rb
@@ -4,6 +4,7 @@ class Record
   field :measure_ids, type: Array
   field :source_data_criteria, type: Array
   field :expected_values, type: Array
+  field :notes, type: String
 
   belongs_to :user
   belongs_to :bundle, class_name: "HealthDataStandards::CQM::Bundle"


### PR DESCRIPTION
## Stories
- https://www.pivotaltracker.com/story/show/77661176 (allow adding notes)
- https://www.pivotaltracker.com/story/show/68459344 (more whitespace needed)
- https://www.pivotaltracker.com/story/show/68459032 (timeline bar should extend to connect)
## Screenshot

![image](https://cloud.githubusercontent.com/assets/2136286/5912975/a3155332-a5a9-11e4-8e29-f1697f654292.png)
## Notes
- Moved a few things around to accommodate a new textarea for patient notes.
- There's a `.datetime-control` used elsewhere in the patient builder. So I'm using that now for birthdate and death date entry. Also edited the padding on that input so you can see the whole date typed.
- Added the measure title and measure description above expected value. Having more information about the measure readily available was actually something that came up in user sessions, as it would be helpful when composing patient names and now patient notes.
- Some more tweaks to the markup and css to clean up the patient builder (e.g. see screenshot).
