### PR TITLE
Navigation improvements and UI tweaks

### DIFF
--- a/app/assets/javascripts/router.js.coffee
+++ b/app/assets/javascripts/router.js.coffee
@@ -12,7 +12,7 @@ class BonnieRouter extends Backbone.Router
     # FIXME deprecated, use measure.get('patients') to get patients for individual measure
     @patients = new Thorax.Collections.Patients()
 
-    @breadcrumb = new Thorax.Views.Breadcrumb(el: '.breadcrumb')
+    @breadcrumb = new Thorax.Views.Breadcrumb()
 
     @on 'route', -> window.scrollTo(0, 0)
 
@@ -43,13 +43,12 @@ class BonnieRouter extends Backbone.Router
     @mainView.setView(complexityView)
 
   renderMeasure: (hqmfSetId) ->
-    @navigationSetup "Measure View", "measure"
+    @navigationSetup "Measure View", "dashboard"
     measure = @measures.findWhere({hqmf_set_id: hqmfSetId})
     document.title += " - #{measure.get('cms_id')}" if measure?
     measureView = new Thorax.Views.Measure(model: measure, patients: @patients)
     @mainView.setView(measureView)
     @breadcrumb.addMeasure(measure)
-    $('.navbar-nav > li').removeClass('active').filter('.nav-dashboard').addClass('active')
 
   renderUsers: ->
     @navigationSetup "Admin", "admin"

--- a/app/assets/javascripts/router.js.coffee
+++ b/app/assets/javascripts/router.js.coffee
@@ -33,29 +33,35 @@ class BonnieRouter extends Backbone.Router
     else
       dashboardView = new Thorax.Views.Measures(collection: @measures.sort(), patients: @patients)
     @mainView.setView(dashboardView)
+    @breadcrumbSetup "dashboard"
 
   renderComplexity: (measureSet1, measureSet2) ->
     @navigationSetup "Complexity Dashboard", "complexity"
     complexityView = new Thorax.Views.Dashboard(measureSet1, measureSet2)
     @mainView.setView(complexityView)
+    @breadcrumbSetup "complexity"
 
   renderMeasure: (hqmfSetId) ->
     @navigationSetup "Measure View", "measure"
     measure = @measures.findWhere({hqmf_set_id: hqmfSetId})
+    @breadcrumbSetup "measure", measure
     document.title += " - #{measure.get('cms_id')}" if measure?
     measureView = new Thorax.Views.Measure(model: measure, patients: @patients)
     @mainView.setView(measureView)
+    $('.navbar-nav > li').removeClass('active').filter('.nav-dashboard').addClass('active')
 
   renderUsers: ->
     @navigationSetup "Admin", "admin"
     @users = new Thorax.Collections.Users()
     usersView = new Thorax.Views.Users(collection: @users)
     @mainView.setView(usersView)
+    @breadcrumbSetup "admin"
 
   renderPatientBuilder: (measureHqmfSetId, patientId) ->
     @navigationSetup "Patient Builder", "patient-builder"
     measure = @measures.findWhere({hqmf_set_id: measureHqmfSetId}) if measureHqmfSetId
     patient = if patientId? then @patients.get(patientId) else new Thorax.Models.Patient {measure_ids: [measure?.get('hqmf_set_id')]}, parse: true
+    @breadcrumbSetup "patient builder", measure, patient
     document.title += " - #{measure.get('cms_id')}" if measure?
     patientBuilderView = new Thorax.Views.PatientBuilder(model: patient, measure: measure, patients: @patients, measures: @measures)
     @mainView.setView patientBuilderView
@@ -65,21 +71,33 @@ class BonnieRouter extends Backbone.Router
     valueSets = new Thorax.Collections.ValueSetsCollection(_(bonnie.valueSetsByOid).values())
     valueSetsBuilderView = new Thorax.Views.ValueSetsBuilder(collection: valueSets, measures: @measures.sort(), patients: @patients)
     @mainView.setView(valueSetsBuilderView)
+    @breadcrumbSetup "value sets"
 
   renderPatientBank: (measureHqmfSetId) ->
     measure = @measures.findWhere(hqmf_set_id: measureHqmfSetId)
     @navigationSetup "Patient Bank - #{measure.get('cms_id')}", 'patient-bank'
     @mainView.setView new Thorax.Views.PatientBankView model: measure, patients: @patients
+    @breadcrumbSetup "patient bank", measure
 
   # Common setup method used by all routes
   navigationSetup: (title, selectedNav) ->
     @calculator.cancelCalculations()
     document.title = "Bonnie v#{bonnie.applicationVersion}: #{title}"
     if selectedNav?
-      $('ul.nav > li, .indicator-circle').removeClass('active').filter(".nav-#{selectedNav}, .indicator-#{selectedNav}").addClass('active')
-    switch selectedNav
-      when 'complexity', 'admin' then $('.nav-context').addClass('hidden')
-      else $('.nav-context').removeClass('hidden')
+      $('ul.nav > li').removeClass('active').filter(".nav-#{selectedNav}").addClass('active')
+
+  breadcrumbSetup: (title, measure, patient) ->
+    b = $('ol.breadcrumb')
+    b.empty()
+    b.append "<li><a href='/#'><i class='fa fa-fw fa-clock-o' aria-hidden='true'></i> Measure Period: #{bonnie.measurePeriod}</a></li>" if title is "dashboard"
+    if measure?
+      b.append "<li><a href='/#'><i class='fa fa-fw fa-clock-o' aria-hidden='true'></i> Measure Period: #{bonnie.measurePeriod}</a></li>"
+      b.append "<li><a href='#measures/#{measure.get('hqmf_set_id')}'><i class='fa fa-fw fa-tasks' aria-hidden='true'></i> #{measure.get('cms_id')}</a></li>"
+      if title is "patient builder" and patient?
+        patient_name = if patient.get('first') then "#{patient.get('last')} #{patient.get('first')}" else "Create new patient"
+        b.append "<li><i class='fa fa-fw fa-user' aria-hidden='true'></i> #{patient_name}</li>"
+      else if title is "patient bank"
+        b.append "<li><i class='fa fa-fw fa-group' aria-hidden='true'></i> Import patients from the patient bank</li>"
 
   # This method is to be called directly, and not triggered via a
   # route; it allows the patient builder to be used in new patient

--- a/app/assets/javascripts/router.js.coffee
+++ b/app/assets/javascripts/router.js.coffee
@@ -35,7 +35,7 @@ class BonnieRouter extends Backbone.Router
     else
       dashboardView = new Thorax.Views.Measures(collection: @measures.sort(), patients: @patients)
     @mainView.setView(dashboardView)
-    @breadcrumb.setup "dashboard"
+    @breadcrumb.addMeasurePeriod()
 
   renderComplexity: (measureSet1, measureSet2) ->
     @navigationSetup "Complexity Dashboard", "complexity"
@@ -48,7 +48,7 @@ class BonnieRouter extends Backbone.Router
     document.title += " - #{measure.get('cms_id')}" if measure?
     measureView = new Thorax.Views.Measure(model: measure, patients: @patients)
     @mainView.setView(measureView)
-    @breadcrumb.setup "measure", measure
+    @breadcrumb.addMeasure(measure)
     $('.navbar-nav > li').removeClass('active').filter('.nav-dashboard').addClass('active')
 
   renderUsers: ->
@@ -64,7 +64,7 @@ class BonnieRouter extends Backbone.Router
     document.title += " - #{measure.get('cms_id')}" if measure?
     patientBuilderView = new Thorax.Views.PatientBuilder(model: patient, measure: measure, patients: @patients, measures: @measures)
     @mainView.setView patientBuilderView
-    @breadcrumb.setup "patient builder", measure, patient
+    @breadcrumb.addPatient(measure, patient)
 
   renderValueSetsBuilder: ->
     @navigationSetup "Value Sets Builder", "value-sets-builder"
@@ -76,7 +76,7 @@ class BonnieRouter extends Backbone.Router
     measure = @measures.findWhere(hqmf_set_id: measureHqmfSetId)
     @navigationSetup "Patient Bank - #{measure.get('cms_id')}", 'patient-bank'
     @mainView.setView new Thorax.Views.PatientBankView model: measure, patients: @patients
-    @breadcrumb.setup "patient bank", measure
+    @breadcrumb.addBank(measure)
 
   # Common setup method used by all routes
   navigationSetup: (title, selectedNav) ->
@@ -93,6 +93,7 @@ class BonnieRouter extends Backbone.Router
     # FIXME: Remove this when the Patients View is removed; select the first measure if a measure isn't passed in
     measure ?= @measures.findWhere {hqmf_set_id: patient.get('measure_ids')[0]}
     @mainView.setView new Thorax.Views.PatientBuilder(model: patient, measure: measure, patients: @patients, measures: @measures)
+    @breadcrumb.addPatient(measure, patient)
     @navigate "measures/#{measure.get('hqmf_set_id')}/patients/new"
 
   showError: (error) ->

--- a/app/assets/javascripts/router.js.coffee
+++ b/app/assets/javascripts/router.js.coffee
@@ -12,6 +12,8 @@ class BonnieRouter extends Backbone.Router
     # FIXME deprecated, use measure.get('patients') to get patients for individual measure
     @patients = new Thorax.Collections.Patients()
 
+    @breadcrumb = new Thorax.Views.Breadcrumb(el: '.breadcrumb')
+
     @on 'route', -> window.scrollTo(0, 0)
 
   routes:
@@ -33,21 +35,20 @@ class BonnieRouter extends Backbone.Router
     else
       dashboardView = new Thorax.Views.Measures(collection: @measures.sort(), patients: @patients)
     @mainView.setView(dashboardView)
-    @breadcrumbSetup "dashboard"
+    @breadcrumb.setup "dashboard"
 
   renderComplexity: (measureSet1, measureSet2) ->
     @navigationSetup "Complexity Dashboard", "complexity"
     complexityView = new Thorax.Views.Dashboard(measureSet1, measureSet2)
     @mainView.setView(complexityView)
-    @breadcrumbSetup "complexity"
 
   renderMeasure: (hqmfSetId) ->
     @navigationSetup "Measure View", "measure"
     measure = @measures.findWhere({hqmf_set_id: hqmfSetId})
-    @breadcrumbSetup "measure", measure
     document.title += " - #{measure.get('cms_id')}" if measure?
     measureView = new Thorax.Views.Measure(model: measure, patients: @patients)
     @mainView.setView(measureView)
+    @breadcrumb.setup "measure", measure
     $('.navbar-nav > li').removeClass('active').filter('.nav-dashboard').addClass('active')
 
   renderUsers: ->
@@ -55,49 +56,35 @@ class BonnieRouter extends Backbone.Router
     @users = new Thorax.Collections.Users()
     usersView = new Thorax.Views.Users(collection: @users)
     @mainView.setView(usersView)
-    @breadcrumbSetup "admin"
 
   renderPatientBuilder: (measureHqmfSetId, patientId) ->
     @navigationSetup "Patient Builder", "patient-builder"
     measure = @measures.findWhere({hqmf_set_id: measureHqmfSetId}) if measureHqmfSetId
     patient = if patientId? then @patients.get(patientId) else new Thorax.Models.Patient {measure_ids: [measure?.get('hqmf_set_id')]}, parse: true
-    @breadcrumbSetup "patient builder", measure, patient
     document.title += " - #{measure.get('cms_id')}" if measure?
     patientBuilderView = new Thorax.Views.PatientBuilder(model: patient, measure: measure, patients: @patients, measures: @measures)
     @mainView.setView patientBuilderView
+    @breadcrumb.setup "patient builder", measure, patient
 
   renderValueSetsBuilder: ->
     @navigationSetup "Value Sets Builder", "value-sets-builder"
     valueSets = new Thorax.Collections.ValueSetsCollection(_(bonnie.valueSetsByOid).values())
     valueSetsBuilderView = new Thorax.Views.ValueSetsBuilder(collection: valueSets, measures: @measures.sort(), patients: @patients)
     @mainView.setView(valueSetsBuilderView)
-    @breadcrumbSetup "value sets"
 
   renderPatientBank: (measureHqmfSetId) ->
     measure = @measures.findWhere(hqmf_set_id: measureHqmfSetId)
     @navigationSetup "Patient Bank - #{measure.get('cms_id')}", 'patient-bank'
     @mainView.setView new Thorax.Views.PatientBankView model: measure, patients: @patients
-    @breadcrumbSetup "patient bank", measure
+    @breadcrumb.setup "patient bank", measure
 
   # Common setup method used by all routes
   navigationSetup: (title, selectedNav) ->
     @calculator.cancelCalculations()
+    @breadcrumb.clear()
     document.title = "Bonnie v#{bonnie.applicationVersion}: #{title}"
     if selectedNav?
       $('ul.nav > li').removeClass('active').filter(".nav-#{selectedNav}").addClass('active')
-
-  breadcrumbSetup: (title, measure, patient) ->
-    b = $('ol.breadcrumb')
-    b.empty()
-    b.append "<li><a href='/#'><i class='fa fa-fw fa-clock-o' aria-hidden='true'></i> Measure Period: #{bonnie.measurePeriod}</a></li>" if title is "dashboard"
-    if measure?
-      b.append "<li><a href='/#'><i class='fa fa-fw fa-clock-o' aria-hidden='true'></i> Measure Period: #{bonnie.measurePeriod}</a></li>"
-      b.append "<li><a href='#measures/#{measure.get('hqmf_set_id')}'><i class='fa fa-fw fa-tasks' aria-hidden='true'></i> #{measure.get('cms_id')}</a></li>"
-      if title is "patient builder" and patient?
-        patient_name = if patient.get('first') then "#{patient.get('last')} #{patient.get('first')}" else "Create new patient"
-        b.append "<li><i class='fa fa-fw fa-user' aria-hidden='true'></i> #{patient_name}</li>"
-      else if title is "patient bank"
-        b.append "<li><i class='fa fa-fw fa-group' aria-hidden='true'></i> Import patients from the patient bank</li>"
 
   # This method is to be called directly, and not triggered via a
   # route; it allows the patient builder to be used in new patient

--- a/app/assets/javascripts/templates/breadcrumb.hbs
+++ b/app/assets/javascripts/templates/breadcrumb.hbs
@@ -1,0 +1,21 @@
+{{#if period}}
+
+  <li>{{#link "/"}}<i class='fa fa-fw fa-clock-o' aria-hidden='true'></i> Measure Period: {{period}} {{/link}}</li>
+
+  {{#if measure}}
+
+    <li>{{#link "measures/{{measure.hqmf_set_id}}" expand-tokens=true}}<i class='fa fa-fw fa-tasks' aria-hidden='true'></i> {{measure.cms_id}} {{/link}}</li>
+
+    {{#if patientName}}
+      <li><i class='fa fa-fw fa-user' aria-hidden='true'></i> {{patientName}}</li>
+    {{/if}}
+
+    {{#if bankView}}
+      <li><i class='fa fa-fw fa-group' aria-hidden='true'></i> Import patients from the patient bank</li>
+    {{/if}}
+
+  {{/if}}
+
+{{/if}}
+
+

--- a/app/assets/javascripts/templates/measure.hbs
+++ b/app/assets/javascripts/templates/measure.hbs
@@ -1,55 +1,55 @@
- <div class="main col-sm-8">
-  <div class="measure-title">
-    <div class="short-title"><i class="fa fa-tasks" aria-hidden="true"></i> {{cms_id}}: </div>
-    <div class="full-title">{{title}}</div>
-    <span class="settings-container">
-      <div class="measure-settings">
-        {{#button "toggleVisualization" class="btn btn-default btn-measure-viz btn-viz-chords"}}<i class="fa fa-sitemap" aria-hidden="true"></i> Chords View{{/button}}
-        {{#button "toggleVisualization" class="btn btn-default btn-measure-viz btn-viz-text"}}<i class="fa fa-list" aria-hidden="true"></i> Text View{{/button}}
-        {{#button "updateMeasure" class="btn btn-default update-measure"}}<i class="fa fa-upload" aria-hidden="true"></i> Update{{/button}}
-        {{#button "deleteMeasure" class="btn btn-danger delete-measure hide"}}<i class="fa fa-times" aria-hidden="true"></i> Delete{{/button}}
-        {{#button "showDelete" class="btn btn-danger-inverse delete-icon"}}<i class="fa fa-minus-circle" aria-hidden="true"></i> <span class="sr-only">Show Delete</span>{{/button}}
-      </div>
-      {{#button "measureSettings" tag="a" class="btn-settings" href=""}}<i class="fa fa-cog" aria-hidden="true"></i> <span class="sr-only">Measure Settings</span>{{/button}}
-    </span>
-  </div>
-  <div class="measure-dsp">
-    {{#if episode_of_care}}
-      <div class="measure-dsp-title">
-        Episode(s) of Care:
-      </div>
-        {{#each episodesOfCare tag="ul"}}
-          {{#with attributes}}
-            <li>{{description}}</li>
-          {{/with}}
-        {{/each}}
-      <p></p>
-    {{/if}}
-    <div class="measure-dsp-title">
-      Description:
+<div class="row">
+  <div class="main">
+    <div class="measure-title">
+      <h1 class="short-title"><i class="fa fa-fw fa-tasks" aria-hidden="true"></i> {{cms_id}}</h1>
+      <span class="settings-container">
+        <div class="measure-settings">
+          {{#button "toggleVisualization" class="btn btn-default btn-measure-viz btn-viz-chords"}}<i class="fa fa-sitemap" aria-hidden="true"></i> Chords View{{/button}}
+          {{#button "toggleVisualization" class="btn btn-default btn-measure-viz btn-viz-text"}}<i class="fa fa-list" aria-hidden="true"></i> Text View{{/button}}
+          {{#button "updateMeasure" class="btn btn-default update-measure"}}<i class="fa fa-upload" aria-hidden="true"></i> Update{{/button}}
+          {{#button "deleteMeasure" class="btn btn-danger delete-measure hide"}}<i class="fa fa-times" aria-hidden="true"></i> Delete{{/button}}
+          {{#button "showDelete" class="btn btn-danger-inverse delete-icon"}}<i class="fa fa-minus-circle" aria-hidden="true"></i> <span class="sr-only">Show Delete</span>{{/button}}
+        </div>
+        {{#button "measureSettings" tag="a" class="btn-settings" href=""}}<i class="fa fa-cog" aria-hidden="true"></i> <span class="sr-only">Measure Settings</span>{{/button}}
+      </span>
     </div>
-    <p>{{description}}</p>
+    <div class="measure-dsp">
+      <h2 class="full-title">{{title}}</h2>
+      {{#if episode_of_care}}
+        <div class="measure-dsp-title">
+          Episode(s) of Care:
+        </div>
+          {{#each episodesOfCare tag="ul"}}
+            {{#with attributes}}
+              <li>{{description}}</li>
+            {{/with}}
+          {{/each}}
+        <p></p>
+      {{/if}}
 
-    {{view complexityView}}
+      <p>{{description}}</p>
 
-    {{#ifAdmin}}
-      <a href="/measures/{{_id}}/debug" class="btn btn-danger">Debug</a>
-    {{/ifAdmin}}
+      {{view complexityView}}
+
+      {{#ifAdmin}}
+        <a href="/measures/{{_id}}/debug" class="btn btn-danger">Debug</a>
+      {{/ifAdmin}}
+    </div>
+
+    {{view logicView}}
   </div>
 
-  {{view logicView}}
-</div>
-
-<div class="right-sidebar">
-  <div class="patients-title">
-    <span class="short-title pull-left"><i class="fa fa-user fa-fw" aria-hidden="true"></i>Test Patients</span>
-    <span class="settings-container">
-      <div class="patients-settings">
-        {{#button "exportPatients" class="btn btn-default export-patients"}}<i class="fa fa-download" aria-hidden="true"></i> Export{{/button}}
-        {{#link "measures/{{hqmf_set_id}}/patient_bank" expand-tokens=true class="btn btn-primary import-patients"}}<i class="fa fa-group" aria-hidden="true"></i> <i class="fa fa-plus" aria-hidden="true"></i><span class="sr-only">Import patients from patient bank</span>{{/link}}
-      </div>
-      {{#button "patientsSettings" tag="a" class="btn-settings" href=""}}<i class="fa fa-cog" aria-hidden="true"></i> <span class="sr-only">Patient Options</span>{{/button}}
-    </span>
+  <div class="right-sidebar">
+    <div class="patients-title">
+      <h1><i class="fa fa-user fa-fw" aria-hidden="true"></i> Patients</h1>
+      <span class="settings-container">
+        <div class="patients-settings">
+          {{#button "exportPatients" class="btn btn-default export-patients"}}<i class="fa fa-download" aria-hidden="true"></i> Export{{/button}}
+          {{#link "measures/{{hqmf_set_id}}/patient_bank" expand-tokens=true class="btn btn-primary import-patients"}}<i class="fa fa-group" aria-hidden="true"></i> <i class="fa fa-plus" aria-hidden="true"></i><span class="sr-only">Import patients from patient bank</span>{{/link}}
+        </div>
+        {{#button "patientsSettings" tag="a" class="btn-settings" href=""}}<i class="fa fa-cog" aria-hidden="true"></i> <span class="sr-only">Patient Options</span>{{/button}}
+      </span>
+    </div>
+    {{view populationCalculation}}
   </div>
-  {{view populationCalculation}}
 </div>

--- a/app/assets/javascripts/templates/measure.hbs
+++ b/app/assets/javascripts/templates/measure.hbs
@@ -41,7 +41,7 @@
 
   <div class="right-sidebar">
     <div class="patients-title">
-      <h1><i class="fa fa-user fa-fw" aria-hidden="true"></i> Patients</h1>
+      <h1><i class="fa fa-user fa-fw" aria-hidden="true"></i> Test Patients</h1>
       <span class="settings-container">
         <div class="patients-settings">
           {{#button "exportPatients" class="btn btn-default export-patients"}}<i class="fa fa-download" aria-hidden="true"></i> Export{{/button}}

--- a/app/assets/javascripts/templates/measures.hbs
+++ b/app/assets/javascripts/templates/measures.hbs
@@ -21,7 +21,7 @@
     <h2 aria-hidden="true">Status</h2>
   </div>
   <div class="patient-listing-col">
-    <h2 aria-hidden="true">Patients</h2>
+    <h2 aria-hidden="true">Test Patients</h2>
   </div>
 </div>
 

--- a/app/assets/javascripts/templates/measures.hbs
+++ b/app/assets/javascripts/templates/measures.hbs
@@ -1,6 +1,6 @@
 {{!-- <p>Total measures: {{measures.length}}</p> --}}
 
-<div class="dashboard-heading row">
+<div class="dashboard-heading">
   <div class="measure-col">
     <div class="dashboard-title">
       <h1><i class="fa fa-tasks" aria-hidden="true"></i> Measures</h1>
@@ -21,13 +21,13 @@
     <h2 aria-hidden="true">Status</h2>
   </div>
   <div class="patient-listing-col">
-    <h2 aria-hidden="true">Test Patients</h2>
+    <h2 aria-hidden="true">Patients</h2>
   </div>
 </div>
 
 {{#collection class="dashboard-data" item-view='MeasureRowView'}}
 
-  <div class="measure row">
+  <div class="measure">
     <div class="measure-col">
       <div class="measure-title">
         {{#link "measures/{{hqmf_set_id}}" expand-tokens=true}}<span class="sr-only">{{cms_id}}, Measure Title: </span>{{title}}{{/link}}
@@ -66,7 +66,7 @@
 
   {{#if multiplePopulations}}
     {{#collection populations item-view='PopulationView'}}
-      <div class="row population">
+      <div class="population">
         <div class="population-col">
           <div class="population-title">
             {{view "PopulationTitle" model=this.model}}

--- a/app/assets/javascripts/templates/patient_bank/patient_bank.hbs
+++ b/app/assets/javascripts/templates/patient_bank/patient_bank.hbs
@@ -1,7 +1,6 @@
 <div class="patient-bank">
 
   <div class="bank-measure">
-    <h1>{{#link "measures/{{hqmf_set_id}}" expand-tokens=true}}<i class="fa fa-tasks" aria-hidden="true"></i> {{cms_id}}{{/link}}</h1>
     <h2>{{title}}</h2>
     <p>{{description}}</p>
     {{view measurePatientsCount}}

--- a/app/assets/javascripts/templates/patient_bank/patient_bank.hbs
+++ b/app/assets/javascripts/templates/patient_bank/patient_bank.hbs
@@ -11,7 +11,7 @@
     {{view bankFilterView}}
 
     <div class="patients-results">
-      <h1 class="pull-left"><i class="fa fa-group" aria-hidden="true"></i> Results <span class="patient-count"></span></h1>
+      <h1 class="pull-left"><i class="fa fa-group" aria-hidden="true"></i> Test Patients <span class="patient-count"></span></h1>
       <div class="pull-right">
         {{view selectedPatientsView}}
         {{#button "cloneBankPatients" class="btn btn-primary bank-actions" data-cloning-text="Cloning..." data-cloned-text="Cloned successfully" disabled="true"}}Clone into {{cms_id}}<span class="sr-only"> patients selected from patient bank</span>{{/button}}

--- a/app/assets/javascripts/templates/patient_builder/patient_builder.hbs
+++ b/app/assets/javascripts/templates/patient_builder/patient_builder.hbs
@@ -8,7 +8,7 @@
 
 <div class="row">
   <div class="col-md-2">
-    <h1>Patient</h1>
+    <h1>Test Patient</h1>
   </div>
 
   <div class="col-md-6">

--- a/app/assets/javascripts/views/breadcrumb.js.coffee
+++ b/app/assets/javascripts/views/breadcrumb.js.coffee
@@ -1,0 +1,25 @@
+class Thorax.Views.Breadcrumb extends Thorax.Views.BonnieView
+
+  clear: -> @$el.empty()
+
+  setup: (title, measure, patient) ->
+    @addMeasurePeriod()
+    if measure?
+      @addMeasure(measure)
+      if title is "patient builder" and patient?
+        @addPatient(patient)
+      else if title is "patient bank"
+        @addBank()
+
+  addMeasurePeriod: ->
+    @$el.append "<li><a href='/#'><i class='fa fa-fw fa-clock-o' aria-hidden='true'></i> Measure Period: #{bonnie.measurePeriod}</a></li>"
+
+  addMeasure: (measure) ->
+    @$el.append "<li><a href='#measures/#{measure.get('hqmf_set_id')}'><i class='fa fa-fw fa-tasks' aria-hidden='true'></i> #{measure.get('cms_id')}</a></li>"
+
+  addPatient: (patient) ->
+    patient_name = if patient.get('first') then "#{patient.get('last')} #{patient.get('first')}" else "Create new patient"
+    @$el.append "<li><i class='fa fa-fw fa-user' aria-hidden='true'></i> #{patient_name}</li>"
+
+  addBank: ->
+    @$el.append "<li><i class='fa fa-fw fa-group' aria-hidden='true'></i> Import patients from the patient bank</li>"

--- a/app/assets/javascripts/views/breadcrumb.js.coffee
+++ b/app/assets/javascripts/views/breadcrumb.js.coffee
@@ -1,9 +1,14 @@
 class Thorax.Views.Breadcrumb extends Thorax.Views.BonnieView
 
+  className: 'breadcrumb'
+
+  tagName: 'ol'
+
   template: JST['breadcrumb']
 
   initialize: ->
-    @setModel new Thorax.Model, render: true
+    @setModel new Thorax.Model
+    @appendTo('.navbar.breadcrumb-container')
 
   clear: -> @model.clear()
 

--- a/app/assets/javascripts/views/breadcrumb.js.coffee
+++ b/app/assets/javascripts/views/breadcrumb.js.coffee
@@ -3,10 +3,9 @@ class Thorax.Views.Breadcrumb extends Thorax.Views.BonnieView
   template: JST['breadcrumb']
 
   initialize: ->
-    @setModel new Thorax.Model
-    @model.on 'change', => @render()
+    @setModel new Thorax.Model, render: true
 
-  clear: -> @model.clear
+  clear: -> @model.clear()
 
   addMeasurePeriod: ->
     @model.clear silent: true

--- a/app/assets/javascripts/views/breadcrumb.js.coffee
+++ b/app/assets/javascripts/views/breadcrumb.js.coffee
@@ -1,25 +1,35 @@
 class Thorax.Views.Breadcrumb extends Thorax.Views.BonnieView
 
-  clear: -> @$el.empty()
+  template: JST['breadcrumb']
 
-  setup: (title, measure, patient) ->
-    @addMeasurePeriod()
-    if measure?
-      @addMeasure(measure)
-      if title is "patient builder" and patient?
-        @addPatient(patient)
-      else if title is "patient bank"
-        @addBank()
+  initialize: ->
+    @setModel new Thorax.Model
+    @model.on 'change', => @render()
+
+  clear: -> @model.clear
 
   addMeasurePeriod: ->
-    @$el.append "<li><a href='/#'><i class='fa fa-fw fa-clock-o' aria-hidden='true'></i> Measure Period: #{bonnie.measurePeriod}</a></li>"
+    @model.clear silent: true
+    @model.set
+      period: bonnie.measurePeriod
 
   addMeasure: (measure) ->
-    @$el.append "<li><a href='#measures/#{measure.get('hqmf_set_id')}'><i class='fa fa-fw fa-tasks' aria-hidden='true'></i> #{measure.get('cms_id')}</a></li>"
+    @model.clear silent: true
+    @model.set
+      period: bonnie.measurePeriod
+      measure: measure.toJSON()
 
-  addPatient: (patient) ->
+  addPatient: (measure, patient) ->
     patient_name = if patient.get('first') then "#{patient.get('last')} #{patient.get('first')}" else "Create new patient"
-    @$el.append "<li><i class='fa fa-fw fa-user' aria-hidden='true'></i> #{patient_name}</li>"
+    @model.clear silent: true
+    @model.set
+      period: bonnie.measurePeriod
+      patientName: patient_name
+      measure: measure.toJSON()
 
-  addBank: ->
-    @$el.append "<li><i class='fa fa-fw fa-group' aria-hidden='true'></i> Import patients from the patient bank</li>"
+  addBank: (measure) ->
+    @model.clear silent: true
+    @model.set
+      period: bonnie.measurePeriod
+      bankView: true
+      measure: measure.toJSON()

--- a/app/assets/stylesheets/bootstrap3.less
+++ b/app/assets/stylesheets/bootstrap3.less
@@ -110,6 +110,7 @@ h2 {
   }
   .nav {
     font-size: 1.5em;
+    li { border-bottom: 4px solid white; }
     a { color: @brand-primary; }
     .active {
       border-bottom: 4px solid @brand-primary;
@@ -202,4 +203,34 @@ h1.modal-title {
 .modal-footer {
   margin-top: 0px;
   padding: 20px 20px 10px 0px;
+}
+
+.breadcrumb {
+  font-size: 16px;
+  background: white;
+  > li {
+    display: table-cell;
+    padding: 12px;
+    background-color: @gray-lighter;
+    color: @gray-darker;
+    a {
+      padding: 12px 0px;
+      color: @gray-darker;
+    }
+    + li:before {
+      content: @fa-var-caret-right;
+      font-family: FontAwesome;
+      padding: 0 10px 0 0;
+      margin-left: -12px;
+      color: @gray-lighter;
+    }
+    &:hover {
+      background-color: @gray-light;
+      + li:before {
+        color: @gray-light;
+      }
+      & > a:hover { text-decoration: none; }
+    }
+    &:last-child:not(:first-child) { background-color: white; }
+  }
 }

--- a/app/assets/stylesheets/bootstrap3.less
+++ b/app/assets/stylesheets/bootstrap3.less
@@ -206,22 +206,23 @@ h1.modal-title {
 }
 
 .breadcrumb {
-  font-size: 16px;
+  font-size: 14px;
   background: white;
+  padding: 0px 15px;
   > li {
     display: table-cell;
-    padding: 12px;
+    padding: 10px;
     background-color: @gray-lighter;
     color: @gray-darker;
     a {
-      padding: 12px 0px;
+      padding: 10px 0px;
       color: @gray-darker;
     }
     + li:before {
       content: @fa-var-caret-right;
       font-family: FontAwesome;
-      padding: 0 10px 0 0;
-      margin-left: -12px;
+      padding: 0 8px 0 0;
+      margin-left: -10px;
       color: @gray-lighter;
     }
     &:hover {

--- a/app/assets/stylesheets/bootstrap3.less
+++ b/app/assets/stylesheets/bootstrap3.less
@@ -112,11 +112,14 @@ h2 {
     font-size: 1.5em;
     li { border-bottom: 4px solid white; }
     a { color: @brand-primary; }
+    & > li > a {
+      font-size: 18px;
+      padding: 12px 16px;
+    }
     .active {
       border-bottom: 4px solid @brand-primary;
       a {
         color: @gray-darker;
-        padding-top: 16px;
       }
       font-weight: bold;
     }

--- a/app/assets/stylesheets/dashboard.less
+++ b/app/assets/stylesheets/dashboard.less
@@ -1,7 +1,5 @@
 .dashboard {
 
-  margin-top: 50px;
-
   p.instruction {
     font-size: 1.2em;
     width: 620px;

--- a/app/assets/stylesheets/measure.less
+++ b/app/assets/stylesheets/measure.less
@@ -12,40 +12,8 @@
   }
 }
 
-.measure-listing-sidebar {
-  .make-sm-column(2.5);
-  .measures-title {
-    .make-sm-column(12);
-    .title-bar;
-    margin-bottom: 10px;
-    .short-title {
-      font-size: 1.4em;
-      line-height: 2.15;
-      margin-top: 0;
-      color: black;
-      text-transform: uppercase;
-    }
-    .fa {
-      color: black;
-    }
-  }
-  .list-group {
-    padding-top: 30px;
-    a.disabled  {
-      color: @nav-disabled-link-color;
-      &:hover,
-      &:focus {
-        color: @nav-disabled-link-hover-color;
-        text-decoration: none;
-        background-color: transparent;
-        cursor: not-allowed;
-      }
-    }
-  }
-}
-
 .right-sidebar {
-  .make-sm-column(3.5);
+  .make-sm-column(4);
   .patient-row {
     .make-sm-column(12);
     font-size: 1.6em;
@@ -57,13 +25,10 @@
     .make-sm-column(12);
     .title-bar;
     margin-bottom: 10px;
-    .short-title {
+    h1 {
       font-size: 1.8em;
       line-height: 1.75;
-      padding-right: 15px;
-      margin-top: 0;
-      color: black;
-      text-transform: uppercase;
+      margin-bottom: 0;
     }
     .fa {
       color: black;
@@ -110,6 +75,7 @@
 }
 
 .main {
+  .make-sm-column(8);
   > * {
     padding: 0 15px;
   }
@@ -118,12 +84,11 @@
   }
 
   .measure-title {
-    display:table;
+    // display:table;
     > div {
       display: table-cell;
       vertical-align: middle;
     }
-    .make-sm-column(12);
     .title-bar;
     .short-title {
       white-space: nowrap;
@@ -132,14 +97,17 @@
       padding-right: .5em;
     }
     .full-title {
-      line-height: 1.6;
+      font-size: 0.6em;
+      font-weight: normal;
+      line-height: 1;
       padding: .25em 0;
       padding-right: 1.8em;
+      text-transform: none;
     }
     .settings-container {
       position: absolute;
       top: 0;
-      right: 15px;
+      right: 30px;
     }
     .btn-settings {
       font-size: 1.8em;
@@ -182,7 +150,6 @@
   }
 
   .measure-dsp {
-    .make-sm-column(12);
     padding-top: 15px;
     padding-bottom: 30px;
     .measure-dsp-title {
@@ -200,6 +167,7 @@
       font-size: 1.2em;
       .exclamation {
         color: @grey;
+        font-size: 1.5em;
       }
       .good {
         color: @green;
@@ -230,7 +198,6 @@
   }
 
   .measure-viz {
-    .make-sm-column(12);
     padding-top: 15px;
     padding-left: 0px;
     .conjunction {
@@ -247,22 +214,6 @@
       }
     }
   }
-  // .d3-measure-viz {
-  //   .precondition {
-  //     fill: @gray-light;
-  //   }
-  //   .coverage {
-  //     fill: @brand-primary;
-  //   }
-  //   .eval-true {
-  //     //for measure viz
-  //     fill: #449d44;
-  //   }
-  //   .eval-false, .eval-bad-specifics {
-  //     //for measure viz
-  //     fill: #c9302c;
-  //   }
-  // }
 }
 
 .d3-measure-viz {

--- a/app/assets/stylesheets/measure_calculation.less
+++ b/app/assets/stylesheets/measure_calculation.less
@@ -1,5 +1,5 @@
 .measure-calculation {
-  padding-top: 10px;
+  padding-top: 68px;
 
   .summary {
     > * {

--- a/app/assets/stylesheets/measures.less
+++ b/app/assets/stylesheets/measures.less
@@ -1,41 +1,5 @@
 // Dashboard - Measures View
 
-// measurement period header
-.measure-period {
-  display: inline-block;
-  padding-top: 1px;
-  padding-bottom: 1px;
-  font-weight: bold;
-  color: @gray-darker;
-
-  .year {
-    font-size: 1.4em;
-    font-weight: 100;
-  }
-}
-
-// navigation indicator
-.indicator {
-  .indicator-circle {
-    float: left;
-    background: @gray-lighter;
-    width: @indicator-size;
-    height: @indicator-size;
-    border-radius: 50%;
-    border: 2px solid @gray-lighter;
-  }
-  .indicator-bar {
-    float: left;
-    background: @gray-lighter;
-    width: @indicator-size / 2;
-    height: @indicator-size / 4;
-    margin-top: @indicator-size / 2 - @indicator-size / 8;
-  }
-  .active {
-    background: @brand-primary;
-  }
-}
-
 // For entire page
 .measure-col {
   .make-xs-column(7);

--- a/app/assets/stylesheets/variables.less
+++ b/app/assets/stylesheets/variables.less
@@ -21,4 +21,4 @@
 
 @header-font: 86px;
 @form-width: 285px;
-@indicator-size: 30px;
+

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -35,7 +35,7 @@
       </ul>
     </li>
 
-    <li><%= link_to 'Logout', destroy_user_session_path, :method => :delete %></li>
+    <li><%= link_to '<i class="fa fa-sign-out"></i> Logout'.html_safe, destroy_user_session_path, :method => :delete %></li>
 
   </ul>
 </div>
@@ -44,4 +44,3 @@
   <ol class="breadcrumb">
   </ol>
 </div>
-

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -40,7 +40,4 @@
   </ul>
 </div>
 
-<div class="navbar row">
-  <ol class="breadcrumb">
-  </ol>
-</div>
+<div class="navbar row breadcrumb-container"></div>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -5,28 +5,28 @@
   <ul class="nav navbar-nav pull-right">
 
     <% if current_page?(controller: 'home', action: 'index') %>
-      <li class="nav-dashboard active"><a href="/#">Dashboard</a></li>
+      <li class="nav-dashboard active"><a href="/#"><i class="fa fa-bolt" aria-hidden="true"></i> Dashboard</a></li>
     <% else %>
-      <li><a href="/#">Dashboard</a></li>
+      <li><a href="/#"><i class="fa fa-bolt" aria-hidden="true"></i> Dashboard</a></li>
     <% end %>
 
     <% if current_user.is_dashboard? %>
       <li class="nav-complexity">
-        <a href="/#complexity">Complexity</a>
+        <a href="/#complexity"><i class="fa fa-warning" aria-hidden="true"></i> Complexity</a>
       </li>
     <% end %>
 
     <% if current_page?(controller: 'registrations', action: 'edit') %>
-      <li class="nav-account active"><a href="/users/edit">Account</a></li>
+      <li class="nav-account active"><a href="/users/edit"><i class="fa fa-magic" aria-hidden="true"></i> Account</a></li>
     <% else %>
-      <li><a href="/users/edit">Account</a></li>
+      <li><a href="/users/edit"><i class="fa fa-magic" aria-hidden="true"></i> Account</a></li>
     <% end %>
 
-    <% if (current_user.is_admin?)%><li class="nav-admin"><a href="/#admin/users">Admin</a></li><% end %>
+    <% if (current_user.is_admin?)%><li class="nav-admin"><a href="/#admin/users"><i class="fa fa-gears" aria-hidden="true"></i> Admin</a></li><% end %>
 
     <li class="dropdown">
       <a class="dropdown-toggle" data-toggle="dropdown" href="">
-        Help <b class="caret"></b>
+         <i class="fa fa-question-circle" aria-hidden="true"></i> Help <b class="caret"></b>
       </a>
       <ul class="dropdown-menu">
         <li><a href="mailto:bonnie-feedback-list@lists.mitre.org">Contact</a></li>
@@ -39,22 +39,9 @@
 
   </ul>
 </div>
-<div class="navbar row nav-context">
-  <% if current_page?(controller: 'home', action: 'index') %>
-  <div class="col-md-4">
-    <span class="measure-period">
-      <i class="fa fa-tasks" aria-hidden="true"></i> measure period:
-      <span class="year"><%= Time.zone.at(APP_CONFIG['measure_period_start']).year %></span>
-    </span>
-  </div>
-  <div class="col-md-8">
-    <div class="indicator">
-      <div class="indicator-circle indicator-dashboard"></div>
-      <div class="indicator-bar "></div>
-      <div class="indicator-circle indicator-patient-builder"></div>
-      <div class="indicator-bar"></div>
-      <div class="indicator-circle indicator-measure"></div>
-    </div>
-  </div>
-  <% end %>
+
+<div class="navbar row">
+  <ol class="breadcrumb">
+  </ol>
 </div>
+


### PR DESCRIPTION
## Stories

None! As my last hurrah before the 1.3 release I wanted to replace the 3 indicator circles with something a little more dynamic and useful that acknowledges the increased complexity of Bonnie. I did like having the measure period visible, so I kept that. Now if you go through a measure or a patient or the patient bank you will see a breadcrumb that shows where you are in that process. It's styled to be unobtrusive, and contains links to the expected places to be more useful. It doesn't take significantly more vertical space than was used before. 
And if you're on a different page (complexity, admin, account) the breadcrumb doesn't show at all.

I also cleaned up some markup in a few places, streamlined some headings, adjusted some widths, added some icons, and overall just tried to smooth over some rough edges. By happenstance [this story](https://www.pivotaltracker.com/story/show/70891450) is rendered obsolete.
## Screenshot parade
### Dashboard

![image](https://cloud.githubusercontent.com/assets/2136286/5941024/7276f562-a6dc-11e4-96c3-4aa6f2052dc6.png)
### Measure

![image](https://cloud.githubusercontent.com/assets/2136286/5941145/e8677670-a6dc-11e4-8ee8-38b84969ac42.png)
### New patient

![image](https://cloud.githubusercontent.com/assets/2136286/5941167/01cb607c-a6dd-11e4-9288-951833b1152f.png)
### Existing patient

![image](https://cloud.githubusercontent.com/assets/2136286/5941177/19b3f5d2-a6dd-11e4-9c33-22b361838c07.png)
### Patient bank

![image](https://cloud.githubusercontent.com/assets/2136286/5941189/2be42eb6-a6dd-11e4-83ce-bd0bafbb0b47.png)
### Random other page!

![image](https://cloud.githubusercontent.com/assets/2136286/5941232/880a5ddc-a6dd-11e4-8fee-038babfbda78.png)
