### PR TITLE
Fixed patient bank record cms_id to tie to correct measure

### DIFF
--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -4,17 +4,21 @@ class PatientsController < ApplicationController
   RACE_NAME_MAP={'1002-5' => 'American Indian or Alaska Native','2028-9' => 'Asian','2054-5' => 'Black or African American','2076-8' => 'Native Hawaiian or Other Pacific Islander','2106-3' => 'White','2131-1' => 'Other'}
   ETHNICITY_NAME_MAP={'2186-5'=>'Not Hispanic or Latino', '2135-2'=>'Hispanic Or Latino'}
 
+  # Index method used for patient bank, returning all shared patient records
   def index
-    # We go through some gymnastics to deal with a 1+N problem, so we don't need additional queries for each
-    # record for cms_id and user_email: prepoulate these values using lookup tables
     records = Record.where(is_shared: true).to_a
-    users = User.only(:_id, :email).find(records.map(&:user_id).uniq)
-    email_by_user_id = users.each_with_object({}) { |u, h| h[u.id] = u.email }
-    measures = Measure.only(:_id, :hqmf_set_id, :cms_id).where(:hqmf_set_id.in => records.map { |r| r.measure_ids.first }.uniq)
-    cms_id_by_measure_id = measures.each_with_object({}) { |m, h| h[m.hqmf_set_id] = m.cms_id }
+    # Some gymnastics to deal with a 1+N problem, so we don't need additional queries for each
+    # record for cms_id and user_email; prepopulate these values using lookup tables, with lookups
+    # for email by user_id and cms_id by user_id and measure_id
+    user_ids = records.map(&:user_id).uniq
+    users = User.only(:_id, :email).find(user_ids)
+    email_lookup = users.each_with_object({}) { |u, h| h[u.id] = u.email }
+    measure_ids = records.map { |r| r.measure_ids.first }.uniq
+    measures = Measure.only(:_id, :hqmf_set_id, :user_id, :cms_id).where(:hqmf_set_id.in => measure_ids, :user_id.in => user_ids)
+    cms_lookup = measures.each_with_object(Hash.new { |h, k| h[k] = {} }) { |m, h| h[m.user_id][m.hqmf_set_id] = m.cms_id }
     records.each do |record|
-      record.user_email = email_by_user_id[record.user_id]
-      record.cms_id = cms_id_by_measure_id[record.measure_ids.first]
+      record.user_email = email_lookup[record.user_id]
+      record.cms_id = cms_lookup[record.user_id][record.measure_ids.first]
     end
     render :json => MultiJson.encode(records.as_json(methods: [:cms_id, :user_email]))
   end

--- a/lib/ext/record.rb
+++ b/lib/ext/record.rb
@@ -21,7 +21,7 @@ class Record
   def cms_id
     @cms_id || begin
                  measure_id = measure_ids.first # gets the primary measure ID
-                 measure = Measure.where(hqmf_set_id: measure_id).first # gets corresponding measure
+                 measure = Measure.where(hqmf_set_id: measure_id, user_id: user_id).first # gets corresponding measure, for this user
                  measure.try(:cms_id)
                end
   end


### PR DESCRIPTION
The previous code would tie the patient record cms_id to any random measure in the system that had the same hqmf_set_id, whatever versions of the record it might have been. This fix makes sure the cms_id comes from the measure that the patient record is actually connected to by making user it has the same user_id.
