### PR TITLE
Updated a rake task to make the name of an argument match the assigned one

### DIFF
--- a/lib/tasks/loading/sources.rake
+++ b/lib/tasks/loading/sources.rake
@@ -16,7 +16,7 @@ namespace :bonnie do
 
       measures_yml = args.measures_yml
 
-      if (args.clear_vs_cache == 'true')
+      if (args.clear_vs_cache? == 'true')
         puts "Clearing value set cache"
         FileUtils.rm_r Measures::Loader::VALUE_SET_PATH
       else


### PR DESCRIPTION
In the task definition, the argument `clear_vs_cache?` has a question mark, but when it was used in the task, the question mark was missing. This updates the method so the argument name has a question mark.
