### PR TITLE
Allow non-measure patients to be hidden in debug view

### DIFF
--- a/app/assets/javascripts/templates/measure_debug.hbs
+++ b/app/assets/javascripts/templates/measure_debug.hbs
@@ -19,6 +19,8 @@
 {{#button 'selectAll' class='btn btn-primary'}}Select All{{/button}}
 {{#button 'selectMeasurePatients' class='btn btn-primary'}}Select Measure Patients{{/button}}
 {{#button 'selectNone' class='btn btn-primary'}}Select None{{/button}}
+{{#button 'hideNonMeasurePatients' class='btn btn-default'}}Hide Non-Measure Patients{{/button}}
+{{#button 'showNonMeasurePatients' class='btn btn-default'}}Show Non-Measure Patients{{/button}}
 
 <br>
 <br>

--- a/app/assets/javascripts/views/measure_debug_view.js.coffee
+++ b/app/assets/javascripts/views/measure_debug_view.js.coffee
@@ -42,3 +42,10 @@ class Thorax.Views.MeasureDebug extends Thorax.Views.BonnieView
     for p in @model.get('patients').select((p) => _(p.get('measure_ids')).contains @model.get('hqmf_set_id'))
       @results.add @population.calculate(p) unless @results.findWhere(patient_id: p.id)
       @$("button[data-model-cid='#{p.cid}']").addClass('active')
+
+  hideNonMeasurePatients: ->
+    @model.get('patients').each (p) =>
+      @$("button[data-model-cid='#{p.cid}']").hide() unless _(p.get('measure_ids')).contains @model.get('hqmf_set_id')
+
+  showNonMeasurePatients: ->
+    @$('button.toggle-patient').show()


### PR DESCRIPTION
There are lots and lots of buttons in many cases, and usually most of them aren't of interest. This at least lets you hide the non-measure patient buttons.
