### PR TITLE
sort patient results by status and name

### DIFF
--- a/app/assets/javascripts/views/patient_bank/patient_bank_view.js.coffee
+++ b/app/assets/javascripts/views/patient_bank/patient_bank_view.js.coffee
@@ -46,6 +46,7 @@ class Thorax.Views.PatientBankView extends Thorax.Views.BonnieView
 
     # wait so everything calculates
     @listenTo @differences, 'complete', =>
+      @differences.sort()
       @bankFilterView.enableFiltering()
       @showFilteredPatientCount()
       @showSelectedCoverage()

--- a/app/assets/javascripts/views/patient_bank/patient_bank_view.js.coffee
+++ b/app/assets/javascripts/views/patient_bank/patient_bank_view.js.coffee
@@ -39,6 +39,11 @@ class Thorax.Views.PatientBankView extends Thorax.Views.BonnieView
 
     @allDifferences = new Thorax.Collection
 
+    # We want to display the results sorted by 1) existence of defined expectations 2) passing status 3) last name 4) first name
+    @differences.comparator = (d) -> [-!!d.expected.get('measure_id'), !d.get('match'), d.result.patient.get('last'), d.result.patient.get('first')]
+    # Make sure the sort order updates as the collection completes
+    @differences.on 'complete, reset', @differences.sort, @differences
+
     # wait so everything calculates
     @listenTo @differences, 'complete', =>
       @bankFilterView.enableFiltering()


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/91736798

Should list results in the patient bank first by presence of expectations (all patients made for the measure, then all patients not made for the measure), then by match (passing patients then failing patients), then by last name and first name.
