### PR TITLE
Allow subsequent colons in patient builder elements descriptions

### DIFF
--- a/app/assets/javascripts/views/patient_builder/data_criteria.js.coffee
+++ b/app/assets/javascripts/views/patient_builder/data_criteria.js.coffee
@@ -32,8 +32,8 @@ class Thorax.Views.SelectCriteriaItemView extends Thorax.Views.BuilderChildView
     desc = @model.get('description').split(/, (.*)/)?[1] or @model.get('description')
     _(super).extend
       type: desc.split(": ")[0]
-      # replace first ':' with '#' and split on that to allow subsequent colons
-      detail: desc.replace(': ', '#').split('#')[1]
+      # everything after the data criteria type is the detailed description
+      detail: desc.substring(desc.indexOf(':')+2)
 
 class Thorax.Views.EditCriteriaView extends Thorax.Views.BuilderChildView
   className: 'patient-criteria'

--- a/app/assets/javascripts/views/patient_builder/data_criteria.js.coffee
+++ b/app/assets/javascripts/views/patient_builder/data_criteria.js.coffee
@@ -32,8 +32,8 @@ class Thorax.Views.SelectCriteriaItemView extends Thorax.Views.BuilderChildView
     desc = @model.get('description').split(/, (.*)/)?[1] or @model.get('description')
     _(super).extend
       type: desc.split(": ")[0]
-      detail: desc.split(": ")[1]
-
+      # replace first ':' with '#' and split on that to allow subsequent colons
+      detail: desc.replace(': ', '#').split('#')[1]
 
 class Thorax.Views.EditCriteriaView extends Thorax.Views.BuilderChildView
   className: 'patient-criteria'
@@ -70,7 +70,7 @@ class Thorax.Views.EditCriteriaView extends Thorax.Views.BuilderChildView
       criteriaType: @model.get('type')
       vals: JSON.stringify(@model.get('references'))
     @editCodeSelectionView = new Thorax.Views.CodeSelectionView criteria: @model
-    @editFulfillmentHistoryView = new Thorax.Views.MedicationFulfillmentsView 
+    @editFulfillmentHistoryView = new Thorax.Views.MedicationFulfillmentsView
       model: new Thorax.Model
       criteria: @model
 
@@ -308,7 +308,7 @@ class Thorax.Views.EditCriteriaValueView extends Thorax.Views.BuilderChildView
       @model.set type: $(e.target).val()
       @validateForAddition()
       @advanceFocusToInput()
-    'change select': -> 
+    'change select': ->
       @validateForAddition()
       @advanceFocusToInput()
     'keyup input': 'validateForAddition'


### PR DESCRIPTION
### Story
- [CMS344 Communication elements does not display specific element info in titles](https://www.pivotaltracker.com/story/show/95241960)
### Notes
- updated data criteria description parsing to only split on the first `:`
### Screenshot

![screen shot 2015-05-22 at 7 37 33 pm](https://cloud.githubusercontent.com/assets/456952/7781301/241d8a38-00ba-11e5-8c85-04bd5ee853cd.png)
