### PR TITLE
Fix materialization

### DIFF
--- a/lib/measures/patient_builder.rb
+++ b/lib/measures/patient_builder.rb
@@ -158,7 +158,7 @@ module Measures
       # If there are no source criteria codes or a white list is used, select new codes, otherwise use existing codes
       if source_criteria['codes'].blank? ||
          (Measures::PatientBuilder.white_list_black_list?(source_criteria['code_list_id'], value_sets) &&
-          !source_criteria['code_source'] == CODE_SOURCE[:USER_DEFINED])
+          source_criteria['code_source'] != CODE_SOURCE[:USER_DEFINED])
         entry.codes = Measures::PatientBuilder.select_codes(source_criteria['code_list_id'], value_sets)
       else
         entry.codes = source_criteria['codes']

--- a/lib/measures/patient_builder.rb
+++ b/lib/measures/patient_builder.rb
@@ -56,12 +56,12 @@ module Measures
           source_criteria['coded_entry_id'] = entry.id
 
           source_criteria['codes'] = entry['codes']
-          if source_criteria['code_source'] != Measures::PatientBuilder::CODE_SOURCE[:USER_DEFINED]
-            source_criteria['code_source'] = if Measures::PatientBuilder.white_list?(source_criteria['code_list_id'], value_sets)
-              Measures::PatientBuilder::CODE_SOURCE[:WHITE_LIST]
-            else
-              Measures::PatientBuilder::CODE_SOURCE[:DEFAULT]
-            end
+          if source_criteria['code_source'] != CODE_SOURCE[:USER_DEFINED]
+            source_criteria['code_source'] = if Measures::PatientBuilder.white_list_black_list?(source_criteria['code_list_id'], value_sets)
+                                               CODE_SOURCE[:WHITE_LIST]
+                                             else
+                                               CODE_SOURCE[:DEFAULT]
+                                             end
           end
 
 
@@ -156,7 +156,9 @@ module Measures
       entry.end_time = time.high.to_seconds if time.high
       entry.status = source_criteria['status']
       # If there are no source criteria codes or a white list is used, select new codes, otherwise use existing codes
-      if source_criteria['codes'].blank? || source_criteria['code_source'] == Measures::PatientBuilder::CODE_SOURCE[:WHITE_LIST]
+      if source_criteria['codes'].blank? ||
+         (Measures::PatientBuilder.white_list_black_list?(source_criteria['code_list_id'], value_sets) &&
+          !source_criteria['code_source'] == CODE_SOURCE[:USER_DEFINED])
         entry.codes = Measures::PatientBuilder.select_codes(source_criteria['code_list_id'], value_sets)
       else
         entry.codes = source_criteria['codes']
@@ -286,9 +288,9 @@ module Measures
       (listed_sets.empty? ? default_code_sets : listed_sets)
     end
 
-    def self.white_list?(oid, value_sets)
+    def self.white_list_black_list?(oid, value_sets)
       if value_sets[oid]
-        value_sets[oid].concepts.any? {|x| x.white_list}
+        value_sets[oid].concepts.any? { |x| x.white_list || x.black_list }
       end
     end
 

--- a/lib/measures/patient_builder.rb
+++ b/lib/measures/patient_builder.rb
@@ -155,10 +155,11 @@ module Measures
       entry.start_time = time.low.to_seconds if time.low
       entry.end_time = time.high.to_seconds if time.high
       entry.status = source_criteria['status']
-      if (source_criteria['code_source'] == Measures::PatientBuilder::CODE_SOURCE[:USER_DEFINED])
-        entry.codes = source_criteria['codes']
-      else
+      # If there are no source criteria codes or a white list is used, select new codes, otherwise use existing codes
+      if source_criteria['codes'].blank? || source_criteria['code_source'] == Measures::PatientBuilder::CODE_SOURCE[:WHITE_LIST]
         entry.codes = Measures::PatientBuilder.select_codes(source_criteria['code_list_id'], value_sets)
+      else
+        entry.codes = source_criteria['codes']
       end
       entry.oid = HQMF::DataCriteria.template_id_for_definition(source_criteria['definition'], source_criteria['status'], source_criteria['negation'])
       entry

--- a/lib/tasks/bonnie.rake
+++ b/lib/tasks/bonnie.rake
@@ -383,18 +383,20 @@ namespace :bonnie do
     end
 
     desc "Materialize all patients"
-    task :materialize_all=> :environment do
-      pt_count = Record.all.inject(0) do |total, r|
+    task :materialize_all => :environment do
+      user = User.find_by email: ENV["EMAIL"] if ENV["EMAIL"]
+      records = user ? user.records : Record.all
+      count = 0
+      records.each do |r|
         puts "Materializing #{r.last} #{r.first}"
         begin
           r.rebuild!
-          total + 1
-        rescue Exception => e
+          count += 1
+        rescue => e
           puts "Error materializing #{r.first} #{r.last}: #{e.message}"
-          total
         end
       end
-      puts "Materialized #{pt_count} of #{Record.count} patients"
+      puts "Materialized #{count} of #{records.count} patients"
     end
 
     desc "Updated source_data_criteria to include title and description from measure(s)"


### PR DESCRIPTION
The is issue is that codes are being reselected on re-materialization when they were originally auto-picked, and this is probably a bad idea; we want to keep codes that were originally picked regardless of   how, unless a white list is used (a cypress specific scenario, which lets a white list change impact all cypress patients with a simple re-materialization).

This addresses the cause of https://jira.oncprojectracking.org/browse/BONNIE-114, though does not actually correct the data issue.
