### PR TITLE
Default patient MRN source

### DIFF
--- a/lib/generation/randomizer.rb
+++ b/lib/generation/randomizer.rb
@@ -18,6 +18,7 @@ module HQMF
       patient.first = randomize_first_name(patient.gender) unless patient.first
       patient.last = randomize_last_name unless patient.last
       patient.medical_record_number = Digest::MD5.hexdigest("#{patient.first} #{patient.last} #{Time.now}")
+      patient.medical_record_assigner = "Bonnie"
       patient.addresses ||= []
       patient.addresses << randomize_address if patient.addresses.empty?
       

--- a/lib/measures/patient_builder.rb
+++ b/lib/measures/patient_builder.rb
@@ -23,6 +23,7 @@ module Measures
     def self.rebuild_patient(patient)
 
       patient.medical_record_number ||= Digest::MD5.hexdigest("#{patient.first} #{patient.last} #{Time.now}")
+      patient.medical_record_assigner ||= "Bonnie"
       vs_oids = patient.source_data_criteria.collect{|dc| get_vs_oids(dc)}.flatten.uniq
 
       value_sets =  Hash[*HealthDataStandards::SVS::ValueSet.in({oid: vs_oids, user_id: patient.user_id}).collect{|vs| [vs.oid,vs]}.flatten]

--- a/test/unit/generator_test.rb
+++ b/test/unit/generator_test.rb
@@ -26,16 +26,18 @@ class GeneratorTest < ActiveSupport::TestCase
     assert_equal 2, p.ethnicity.keys.length
     assert_equal 2, p.ethnicity.values.length
     assert !p.medical_record_number.nil?
+    assert !p.medical_record_assigner.nil?
     assert !p.addresses.nil?
     assert_equal 1, p.addresses.length
     assert !p.birthdate.nil?
 
-    p = HQMF::Generator.create_base_patient({first: 'John', last: 'Smith'})
+    p2 = HQMF::Generator.create_base_patient({first: 'John', last: 'Smith'})
 
-    assert_equal 'John', p.first
-    assert_equal 'Smith', p.last
-    assert !p.gender.nil?
-    assert !p.birthdate.nil?
+    assert_equal 'John', p2.first
+    assert_equal 'Smith', p2.last
+    assert !p2.gender.nil?
+    assert !p2.birthdate.nil?
+    assert_not_equal p.medical_record_number, p2.medical_record_number  # Should differ each time generated
 
   end
 


### PR DESCRIPTION
Provide a default MRN source of "Bonnie" for generated patients.  Otherwise, when exporting they all come out with the same (default) MRN of "12345".
