### PR TITLE
Removes any repeat variables without occurrences

### DIFF
--- a/app/assets/javascripts/views/logic/variable_logic_view.js.coffee
+++ b/app/assets/javascripts/views/logic/variable_logic_view.js.coffee
@@ -4,5 +4,5 @@ class Thorax.Views.VariablesLogic extends Thorax.Views.BonnieView
     'click .panel-population' : -> @$('.toggle-icon').toggleClass('fa-angle-right fa-angle-down')
 
   initialize: ->
-    @variables = new Thorax.Collections.MeasureDataCriteria this.measure.get('source_data_criteria').select (dc) -> dc.get('variable')
+    @variables = new Thorax.Collections.MeasureDataCriteria this.measure.get('source_data_criteria').select (dc) -> dc.get('variable') && !dc.get('specific_occurrence')
     @hasVariables = @variables.length > 0


### PR DESCRIPTION
Addresses
https://jira.oncprojectracking.org/browse/BONNIE-70

If there are two variables, one with an occurrence, and the other without,
keep the criteria containing the specific occurrence (and one copy of it).
If there are two occurrences with different occurrence markers (A, B, etc.)
it won't remove either.
