### PR TITLE
allow 'eval-coverage' to check parameters that aren't necessarily dat…

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,7 +38,7 @@ GIT
 
 GIT
   remote: https://github.com/projecttacoma/hqmf2js.git
-  revision: e75435ccb026e15da529be8b0afca90e97f127ff
+  revision: 1b1e8b9f04801a342c73263c97b6067cadef35dd
   branch: master
   specs:
     hqmf2js (1.3.0)

--- a/app/assets/javascripts/models/coverage.js.coffee
+++ b/app/assets/javascripts/models/coverage.js.coffee
@@ -14,7 +14,7 @@ class Thorax.Model.Coverage extends Thorax.Model
       result = difference.result
       rationale = result.get('rationale')
       @rationaleCriteria.push(criteria) for criteria, result of rationale when result
-    @rationaleCriteria = _(@rationaleCriteria).intersection(@measureCriteria)
+    @rationaleCriteria = _.unique(@rationaleCriteria)
 
     # Set coverage to the fraction of measure criteria that were true in the rationale
     @set coverage: ( @rationaleCriteria.length * 100 / @measureCriteria.length ).toFixed()

--- a/app/assets/javascripts/views/logic/variable_logic_view.js.coffee
+++ b/app/assets/javascripts/views/logic/variable_logic_view.js.coffee
@@ -4,5 +4,5 @@ class Thorax.Views.VariablesLogic extends Thorax.Views.BonnieView
     'click .panel-population' : -> @$('.toggle-icon').toggleClass('fa-angle-right fa-angle-down')
 
   initialize: ->
-    @variables = new Thorax.Collections.MeasureDataCriteria this.measure.get('source_data_criteria').select (dc) -> dc.get('variable')
+    @variables = new Thorax.Collections.MeasureDataCriteria this.measure.get('source_data_criteria').select (dc) -> dc.get('variable') && !dc.get('specific_occurrence')
     @hasVariables = @variables.length > 0


### PR DESCRIPTION
…a criteria (part of the computation). now colors general variables (non-specific occurrence variables) in the evaluation coloring.

See the hqmf2js related pull request.
