### PR TITLE
Ignores specific variables in measure view

### DIFF
--- a/app/assets/javascripts/views/logic/variable_logic_view.js.coffee
+++ b/app/assets/javascripts/views/logic/variable_logic_view.js.coffee
@@ -4,5 +4,5 @@ class Thorax.Views.VariablesLogic extends Thorax.Views.BonnieView
     'click .panel-population' : -> @$('.toggle-icon').toggleClass('fa-angle-right fa-angle-down')
 
   initialize: ->
-    @variables = new Thorax.Collections.MeasureDataCriteria this.measure.get('source_data_criteria').select (dc) -> dc.get('variable')
+    @variables = new Thorax.Collections.MeasureDataCriteria this.measure.get('source_data_criteria').select (dc) -> dc.get('variable') && !dc.get('specific_occurrence')
     @hasVariables = @variables.length > 0


### PR DESCRIPTION
Only uses the base variable for the measure view. The front-end portion of the solution to the problem described here:
https://jira.oncprojectracking.org/browse/BONNIE-70
