### PR TITLE
Any type of union will now be considered like an 'or'

### DIFF
--- a/app/assets/javascripts/models/result.js.coffee
+++ b/app/assets/javascripts/models/result.js.coffee
@@ -163,7 +163,7 @@ class Thorax.Models.Result extends Thorax.Model
   # walk through data criteria to account for specific occurrences within a UNION
   calculateDataCriteriaOrCounts: (rationale) ->
     orCounts = {}
-    for key, dc of @measure.get('data_criteria') when dc.derivation_operator == 'UNION' && key.indexOf('UNION') != -1
+    for key, dc of @measure.get('data_criteria') when dc.derivation_operator == 'UNION'
       for child in dc.children_criteria
         orCounts[key] = (orCounts[key] || 0) + 1 if rationale[key]
     orCounts


### PR DESCRIPTION
Before, only criteria with `UNION` as the operator and with `UNION` included in the name would be added to the `orCounts` structure. There are instances where criteria have `UNION` as the operator, but the name includes `union` or `GROUP`. These will now also be included in the `orCounts` structure.
