### PR TITLE
in the patient editor, only one result can be added. 

### DIFF
--- a/app/assets/javascripts/templates/patient_builder/edit_value.hbs
+++ b/app/assets/javascripts/templates/patient_builder/edit_value.hbs
@@ -1,3 +1,5 @@
+
+{{#unless fieldValue}}<div class="edit_value_view {{#if hideEditValueView}}hide{{/if}}">{{/unless}}
 {{#if fieldValue}}
 <p>
   <label for="key_{{@cid}}" class="sr-only">field value type</label>
@@ -63,3 +65,4 @@
     {{/button}}
   </div>
 </div>
+{{#unless fieldValue}}</div>{{/unless}}

--- a/app/assets/javascripts/views/patient_builder/data_criteria.js.coffee
+++ b/app/assets/javascripts/views/patient_builder/data_criteria.js.coffee
@@ -2,6 +2,7 @@
 class Thorax.Views.BuilderChildView extends Thorax.Views.BonnieView
   events:
     ready: -> @patientBuilder().registerChild this
+    
   patientBuilder: ->
     parent = @parent
     until parent instanceof Thorax.Views.PatientBuilder
@@ -182,6 +183,7 @@ class Thorax.Views.EditCriteriaView extends Thorax.Views.BuilderChildView
     e.preventDefault()
     $(e.target).model().destroy()
     @triggerMaterialize()
+    @editValueView.render()
 
   highlightError: (e, field) ->
     @toggleDetails(e) unless @isExpanded()
@@ -293,6 +295,7 @@ class Thorax.Views.EditCriteriaValueView extends Thorax.Views.BuilderChildView
     _(super).extend
       codes: @measure?.valueSets().map((vs) -> vs.toJSON()) or []
       fields: Thorax.Models.Measure.logicFieldsFor(@criteriaType)
+      hideEditValueView: @values.models.length > 0
 
   # When we serialize the form, we want to put the description for any CD codes into the submission
   events:


### PR DESCRIPTION
makes it so the view for adding more results goes away when a result is present. this does not take into account the data criteria type. it is possible we will need to revisit this and make specific to data criteria types.
