### PR TITLE
Correctly set up initial or-counts based on logical result of each child

### DIFF
--- a/app/assets/javascripts/models/result.js.coffee
+++ b/app/assets/javascripts/models/result.js.coffee
@@ -190,7 +190,7 @@ class Thorax.Models.Result extends Thorax.Model
     orCounts = {}
     for key, dc of @measure.get('data_criteria') when dc.derivation_operator == 'UNION' && key.indexOf('UNION') != -1
       for child in dc.children_criteria
-        orCounts[key] = (orCounts[key] || 0) + 1 if rationale[key]
+        orCounts[key] = (orCounts[key] || 0) + 1 if rationale[child] # Only add to orCount for logically true branches
     orCounts
 
   codedEntriesForDataCriteria: (dataCriteriaKey) ->


### PR DESCRIPTION
This fixes

https://jira.oncprojectracking.org/browse/BONNIE-118
(https://www.pivotaltracker.com/story/show/108792030 in pivotal)

and

https://www.pivotaltracker.com/story/show/107837526
(which is a duplicate)
