### PR TITLE
Remembering VSAC credentials

### DIFF
--- a/app/assets/javascripts/templates/import/import_measure.hbs
+++ b/app/assets/javascripts/templates/import/import_measure.hbs
@@ -31,6 +31,14 @@
              </div>
           </div>
          
+          <div class="hidden" id="vsacCachedMsg">
+            <div class="form-group">
+              <label class="col-sm-{{titleSize}} control-label">VSAC Credentials</label>
+              <div class="col-sm-{{dataSize}} vsac-logged-in">
+                You are currently authenticated with VSAC. <a href="#" id="clearVSACCreds">Log out?</a>
+              </div>
+            </div>
+          </div>
           <div class="hidden" id="vsacSignIn">
             <div class="form-group">
               <label for="vsacUser" class="col-sm-{{titleSize}} control-label">VSAC Username</label>

--- a/app/assets/stylesheets/measures.less
+++ b/app/assets/stylesheets/measures.less
@@ -167,6 +167,12 @@
   padding-left: 15px;
 }
 
+.vsac-logged-in {
+  padding-top: 6px;
+  vertical-align: middle;
+  text-align: left;
+}
+
 .effective-date {
   padding-left: 0;
   .effective-date-picker {

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,8 @@ Bonnie::Application.routes.draw do
     collection do
       get 'value_sets'
       post 'finalize'
+      get 'vsac_auth_valid'
+      post 'vsac_auth_expire'
     end
     member do
       get 'debug', defaults: { format: :html }


### PR DESCRIPTION
After the user enters their VSAC credentials when importing a measure, the resulting VSAC API ticket granting ticket will be stored in the users session storage for future use. For the next 7.5hrs, this ticket granting ticket will be used to retrieve service tickets for VSAC API calls made by this user (rather than retrieving a new ticket granting ticket every single time a VSAC API call is made, which requires the user to renter their VSAC username/password each time). The user can optionally "log out" of an active VSAC API session (the ticket granting ticket is thrown out).
