### PR TITLE
Changed empty expected value to 0 not X

### DIFF
--- a/lib/patient_export.rb
+++ b/lib/patient_export.rb
@@ -179,7 +179,7 @@ class PatientExport
         if patient['expected_values'] && patient['expected_values'][population_index] && patient['expected_values'][population_index][value]
           patient_row.push(patient['expected_values'][population_index][value])
         else
-          patient_row.push('X')
+          patient_row.push(0)
         end
       end
 


### PR DESCRIPTION
Bug in excel export. Causing patients to be highlighted as "Failed" because an empty value in "expected values" was being set to "X" instead of "0".   

Jira ticket is below.

https://jira.oncprojectracking.org/browse/BONNIE-129
