### PR TITLE
Undo limiting number of results to 1

### DIFF
--- a/app/assets/javascripts/templates/patient_builder/edit_value.hbs
+++ b/app/assets/javascripts/templates/patient_builder/edit_value.hbs
@@ -1,5 +1,3 @@
-
-{{#unless fieldValue}}<div class="edit_value_view {{#if hideEditValueView}}hide{{/if}}">{{/unless}}
 {{#if fieldValue}}
 <p>
   <label for="key_{{@cid}}" class="sr-only">field value type</label>
@@ -65,4 +63,3 @@
     {{/button}}
   </div>
 </div>
-{{#unless fieldValue}}</div>{{/unless}}

--- a/app/assets/javascripts/views/patient_builder/data_criteria.js.coffee
+++ b/app/assets/javascripts/views/patient_builder/data_criteria.js.coffee
@@ -2,7 +2,6 @@
 class Thorax.Views.BuilderChildView extends Thorax.Views.BonnieView
   events:
     ready: -> @patientBuilder().registerChild this
-    
   patientBuilder: ->
     parent = @parent
     until parent instanceof Thorax.Views.PatientBuilder
@@ -183,7 +182,6 @@ class Thorax.Views.EditCriteriaView extends Thorax.Views.BuilderChildView
     e.preventDefault()
     $(e.target).model().destroy()
     @triggerMaterialize()
-    @editValueView.render()
 
   highlightError: (e, field) ->
     @toggleDetails(e) unless @isExpanded()
@@ -309,7 +307,6 @@ class Thorax.Views.EditCriteriaValueView extends Thorax.Views.BuilderChildView
     _(super).extend
       codes: @measure?.valueSets().map((vs) -> vs.toJSON()) or []
       fields: Thorax.Models.Measure.logicFieldsFor(@criteriaType)
-      hideEditValueView: @values.models.length > 0
 
   # When we serialize the form, we want to put the description for any CD codes into the submission
   events:


### PR DESCRIPTION
There are several criteria that can have multiple results. This gets rid of the requirement that you can only enter a single result (originally in commit https://github.com/projecttacoma/bonnie/commit/51fa175c2b96f11bd161a1c786c9136535b63c71).
