### PR TITLE
Adding a test case number field, per end user request

### DIFF
--- a/app/assets/javascripts/templates/patient_bank/patient_bank.hbs
+++ b/app/assets/javascripts/templates/patient_bank/patient_bank.hbs
@@ -26,7 +26,7 @@
             <div class="patient">
               <div class="patient-checkbox">
                 <label>
-                  <span class="sr-only">Select {{patient.last}} {{patient.first}}</span>
+                  <span class="sr-only">Select {{#if patient.caseNumber}}test case {{patient.caseNumber}}: {{/if}}{{patient.last}}, {{patient.first}}</span>
                   <input type="checkbox" class="select-patient">
                 </label>
               </div>
@@ -35,16 +35,16 @@
                   <i class="fa fa-fw fa-circle fa-stack-2x" aria-hidden="true"></i>
                   <i class="fa fa-fw {{#if alreadyCloned}}fa-user-plus{{else}}fa-user{{/if}} fa-stack-1x" aria-hidden="true"></i>
                 </span>
-                <span class="sr-only">{{patient.last}} {{patient.first}}, patient result</span>
+                <span class="sr-only">{{#if patient.caseNumber}}test case {{patient.caseNumber}}: {{/if}}{{patient.last}}, {{patient.first}}, patient result</span>
               </div>
               <div class="patient-btn">
                 <a data-toggle="collapse" data-parent="#sharedResults" href="#toggle{{@cid}}" class="close collapsed">
                   <i class="fa fa-lg panel-chevron fa-angle-right expand-result-icon expand-result-icon-{{patient._id}}" aria-hidden="true"></i>
-                  <span class="sr-only">{{patient.last}} {{patient.first}}, Toggle Logic Pass/Fail</span>
+                  <span class="sr-only">{{#if patient.caseNumber}}test case {{patient.caseNumber}}: {{/if}}{{patient.last}}, {{patient.first}}, Toggle Logic Pass/Fail</span>
                 </a>
               </div>
               <div class="patient-status status status-{{status}}">
-                <span class="sr-only">{{patient.last}} {{patient.first}}, status </span>
+                <span class="sr-only">{{#if patient.caseNumber}}test case {{patient.caseNumber}}: {{/if}}{{patient.last}}, {{patient.first}}, status </span>
                 {{#if status}}
                   {{status}}
                 {{else}}
@@ -52,7 +52,7 @@
                 {{/if}}
               </div>
               <div class="patient-name">
-                <span class="sr-only">patient name: </span>{{patient.last}} {{patient.first}}
+                <span class="sr-only">{{#if patient.caseNumber}}test case {{patient.caseNumber}}: {{/if}}patient name: </span>{{patient.last}}, {{patient.first}}
               </div>
 
             </div>
@@ -63,7 +63,7 @@
             <p><i class="fa fa-fw fa-tasks" aria-hidden="true"></i> {{patient.cms_id}}</p>
             <p>{{patient.notes}}</p>
             {{template "population_calculation_results"}}
-            {{#button "cloneOnePatient" class="btn btn-primary" data-cloning-text="Cloning..." data-cloned-text="Cloned"}}Clone <span class="sr-only">patient {{patient.last}} {{patient.first}}</span> {{#if alreadyCloned}}again{{/if}} into {{cms_id}} {{/button}}
+            {{#button "cloneOnePatient" class="btn btn-primary" data-cloning-text="Cloning..." data-cloned-text="Cloned"}}Clone <span class="sr-only">{{#if patient.caseNumber}}test case {{patient.caseNumber}}: {{/if}}patient {{patient.last}}, {{patient.first}}</span> {{#if alreadyCloned}}again{{/if}} into {{cms_id}} {{/button}}
           </div>
         </div>
       </div>

--- a/app/assets/javascripts/templates/patient_builder/patient_builder.hbs
+++ b/app/assets/javascripts/templates/patient_builder/patient_builder.hbs
@@ -29,6 +29,11 @@
 <div class="row">
   <form class="col-left" role="form">
     <div class="form-group">
+      <label for="caseNumber" class="control-label">Test Case Number</label>
+      <input type="text" id="caseNumber" name="caseNumber" class="form-control" placeholder="#">
+    </div>
+    
+    <div class="form-group">
       <label for="last" class="control-label">Last Name</label>
       <input type="text" id="last" name="last" class="form-control" placeholder="Smith">
     </div>

--- a/app/assets/javascripts/templates/patients/record_header.hbs
+++ b/app/assets/javascripts/templates/patients/record_header.hbs
@@ -3,7 +3,7 @@
   <tbody>
     <tr class="record">
       <td class="record" width="20%" bgcolor="#3399ff"><span class="td_label">Patient</span></td>
-      <td class="record" witdh="30%">{{first}} {{last}}</td>
+      <td class="record" witdh="30%">{{#if patient.caseNumber}}test case {{patient.caseNumber}}: {{/if}}{{first}} {{last}}</td>
       <td class="record" width="15%" bgcolor="#3399ff"><span class="td_label">Sex</span></td>
       <td class="record">{{patientGender}}</td>
     </tr>

--- a/app/assets/javascripts/templates/population_calculation.hbs
+++ b/app/assets/javascripts/templates/population_calculation.hbs
@@ -24,47 +24,47 @@
           <div class="patient-status-icon status status-{{status}}">
             {{#if ../patientsListing}}
               <label>
-                <span class="sr-only">Select {{patient.last}} {{patient.first}}</span>
+                <span class="sr-only">Select {{#if patient.caseNumber}}test case {{patient.caseNumber}}: {{/if}}{{patient.last}} {{patient.first}}</span>
                 <input type="checkbox" class="select-patient">
               </label>
             {{else}}
               {{#if done}}
                 {{#if match}}
-                  <i class="fa fa-check" aria-hidden="true"></i><span class="sr-only">{{patient.last}} {{patient.first}}, patient passing</span>
+                  <i class="fa fa-check" aria-hidden="true"></i><span class="sr-only">{{#if patient.caseNumber}}test case {{patient.caseNumber}}: {{/if}}{{patient.last}} {{patient.first}}, patient passing</span>
                 {{else}}
-                  <i class="fa fa-times" aria-hidden="true"></i><span class="sr-only">{{patient.last}} {{patient.first}}, patient failing</span>
+                  <i class="fa fa-times" aria-hidden="true"></i><span class="sr-only">{{#if patient.caseNumber}}test case {{patient.caseNumber}}: {{/if}}{{patient.last}} {{patient.first}}, patient failing</span>
                 {{/if}}
               {{/if}}
             {{/if}}
           </div>
           <div class="patient-user-icon">
-            <i class="fa fa-user" aria-hidden="true"></i><span class="sr-only">{{patient.last}} {{patient.first}}, patient result</span>
+            <i class="fa fa-user" aria-hidden="true"></i><span class="sr-only">{{#if patient.caseNumber}}test case {{patient.caseNumber}}: {{/if}}{{patient.last}} {{patient.first}} patient result</span>
           </div>
           <div class="patient-btn">
-            {{#button "expandResult" class="close"}}<i class="fa fa-lg fa-angle-right expand-result-icon expand-result-icon-{{patient._id}}" aria-hidden="true"></i> <span class="sr-only">{{patient.last}} {{patient.first}}, Toggle Logic Pass/Fail</span>{{/button}}
+            {{#button "expandResult" class="close"}}<i class="fa fa-lg fa-angle-right expand-result-icon expand-result-icon-{{patient._id}}" aria-hidden="true"></i> <span class="sr-only">{{#if patient.caseNumber}}test case {{patient.caseNumber}}: {{/if}}{{patient.last}} {{patient.first}}, Toggle Logic Pass/Fail</span>{{/button}}
           </div>
           <div class="patient-status status status-{{status}}">
-            <span class="sr-only">{{patient.last}} {{patient.first}}, status </span>{{status}}
+            <span class="sr-only">{{#if patient.caseNumber}}test case {{patient.caseNumber}}: {{/if}}{{patient.last}} {{patient.first}}, status </span>{{status}}
           </div>
           <div class="patient-name">
-            <span class="sr-only">patient name: </span>{{patient.last}} {{patient.first}}
+            {{#if patient.caseNumber}}<span class="sr-only">test case </span>{{patient.caseNumber}}: {{/if}}<span class="sr-only">patient name: </span>{{patient.last}} {{patient.first}}
           </div>
         </div>
       </div>
     </div>
     <div class="panel-body toggle-result toggle-result-{{patient._id}} patient" style="display: none;">
       {{template "population_calculation_results"}}
-      {{#link "measures/{{measure_id}}/patients/{{patient._id}}/edit" class="btn btn-primary" expand-tokens=true}}<i class="fa fa-pencil" aria-hidden="true"></i><span class="sr-only">edit patient {{patient.last}} {{patient.first}}</span>{{/link}}
-      {{#button "clonePatient" class="btn btn-primary"}}CLONE<span class="sr-only"> patient {{patient.last}} {{patient.first}}</span>{{/button}}
+      {{#link "measures/{{measure_id}}/patients/{{patient._id}}/edit" class="btn btn-primary" expand-tokens=true}}<i class="fa fa-pencil" aria-hidden="true"></i><span class="sr-only">edit {{#if patient.caseNumber}}test case {{patient.caseNumber}}: {{/if}}patient {{patient.last}} {{patient.first}}</span>{{/link}}
+      {{#button "clonePatient" class="btn btn-primary"}}CLONE<span class="sr-only"> {{#if patient.caseNumber}}test case {{patient.caseNumber}}: {{/if}}patient {{patient.last}} {{patient.first}}</span>{{/button}}
       {{#button "showDelete" class="btn btn-danger-inverse"}}
         <i class="fa fa-minus-circle" aria-hidden="true"></i>
-        <span class="sr-only">{{patient.last}} {{patient.first}}, Show Delete</span>
+        <span class="sr-only">{{#if patient.caseNumber}}test case {{patient.caseNumber}}: {{/if}}{{patient.last}} {{patient.first}}, Show Delete</span>
       {{/button}}
-      {{#button "deletePatient" class="btn btn-danger delete-{{patient._id}}" style="display: none;" expand-tokens=true}}Delete<span class="sr-only"> patient {{patient.last}} {{patient.first}}</span>{{/button}}
+      {{#button "deletePatient" class="btn btn-danger delete-{{patient._id}}" style="display: none;" expand-tokens=true}}Delete<span class="sr-only">{{#if patient.caseNumber}}test case {{patient.caseNumber}}: {{/if}} patient {{patient.last}} {{patient.first}}</span>{{/button}}
 
       <button class="btn btn-primary{{#if patient.is_shared}}-inverse{{/if}} pull-right share-{{patient._id}}" data-call-method="togglePatient">
         <span class="btn-label">{{#if patient.is_shared}}Shared{{else}}Share{{/if}}</span>
-        <span class="sr-only"> patient {{patient.last}} {{patient.first}}</span>&nbsp;
+        <span class="sr-only">{{#if patient.caseNumber}}test case {{patient.caseNumber}}: {{/if}}patient {{patient.last}} {{patient.first}}</span>&nbsp;
         <i class="fa {{#if patient.is_shared}}fa-minus{{else}}fa-plus{{/if}} share-icon" aria-hidden="true"></i>
       </button>
     </div>

--- a/app/assets/javascripts/templates/test_case_history.hbs
+++ b/app/assets/javascripts/templates/test_case_history.hbs
@@ -1,0 +1,269 @@
+<style type="text/css">
+  .timeline-label {
+    font-size: 12px;
+    font-weight: bold;
+  }
+  .patientUpdateIndicator {
+    cursor: pointer;
+  }
+  .measureUpdateLabel {
+    font-size: 12px;
+    text-decoration: underline;
+    cursor: pointer;
+  }
+  #patientHistory {
+    overflow-x:scroll;
+  }
+
+  .d3-tip {
+    line-height: 1;
+    padding: 6px;
+    background: rgba(0, 0, 0, 0.8);
+    color: #fff;
+    border-radius: 2px;
+  }
+
+  /* Creates a small triangle extender for the tooltip */
+  .d3-tip:after {
+    box-sizing: border-box;
+    display: inline;
+    font-size: 10px;
+    width: 100%;
+    line-height: 1;
+    color: rgba(0, 0, 0, 0.8);
+    content: "\25BC";
+    position: absolute;
+    text-align: center;
+  }
+  #measureDiff {
+    padding:10px;
+  }
+
+  /* Style northward tooltips differently */
+  .d3-tip.n:after {
+    margin: -1px 0 0 0;
+    top: 100%;
+    left: 0;
+  }
+</style>
+
+<script type="text/javascript">
+  window.onload = function() {
+
+    var patientData = [
+      {label: "Jack Sparrow", times: [{result:"pass", updateTime: 1451606400000}, 
+                                  {result:"pass", updateTime: 1451952000000, changed: "Measure Updated"}, 
+                                  {result:"fail", updateTime: 1452556800000, changed: "Encounter Added, Name Changed"}, 
+                                  {result:"pass", updateTime: 1453075200000, changed: "Measure Updated"}
+                                  ]},
+      {label: "Jack Skellington", times: [{result:"fail", updateTime: 1451692800000}, 
+                                  {result:"fail", updateTime: 1451952000000, changed: "Measure Updated"},
+                                  {result:"fail", updateTime: 1452384000000, changed: "Name Changed"}, 
+                                  {result:"pass", updateTime: 1453075200000, changed: "Measure Updated"},
+                                  {result:"pass", updateTime: 1453079200000, changed: "Medication Removed"}
+                                  ]},
+      {label: "Jack Sprat", times: [{result:"pass", updateTime: 1451865600000}, 
+                                  {result:"pass", updateTime: 1451952000000, changed: "Measure Updated"}, 
+                                  {result:"pass", updateTime: 1453075200000, changed: "Measure Updated"}
+                                  ]}
+    ];
+    
+    var measureData = [
+      {updateTime: 1451952000000, oldVersion: "40280581-50F8-D482-0151-91FEDE0601F9", newVersion: "40280381-3D61-56A7-013E-5CC8AA6D6290"},
+      {updateTime: 1453075200000, oldVersion: "40280381-3D61-56A7-013E-5CC8AA6D6290", newVersion: "40280381-75JH-JH9I-IJ8U-887JHUYHGD67"},
+    ];
+    
+    function prettyDate(UnixDate) {
+      d = new Date(UnixDate)
+      return d.getMonth() + 1 + "/" + d.getDate() + "/" + d.getFullYear();
+    };
+    
+    function patientHistory () {
+    // Get all the unique patient and measure dates to use for the ordinal xScale
+      patientDates = [];
+      $.each(patientData, function (index,value){
+        $.each(value.times, function (index, value) {
+          patientDates.push(value.updateTime)
+        })
+      });
+      measureDates = []
+      $.each(measureData, function (index,value){
+          measureDates.push(value.updateTime)
+      });
+      var uniqueDates = jQuery.unique( patientDates.concat(measureDates) ).sort();
+      
+      // Set up the height, width, margins, and ordinal x axis scale
+      var bubbleRadius = 12
+      var bubbleMargin = 15
+      var gutter = 40 // For the measure update label at the bottom of the timeline
+      var width = uniqueDates.length * 50 // 50px per event
+      var height = patientData.length * (bubbleRadius + bubbleMargin)*2
+      var margin = {top: 10, right: 30, bottom: 10, left: 30}
+          
+      var x = d3.scale.ordinal()
+                .domain(uniqueDates)
+                .rangePoints([0, width]);
+                
+      // Set up the Tooltip for each bubble
+      var tip = d3.tip()
+                  .attr('class', 'd3-tip')
+                  .offset([-10, 0])
+                  .html(function(d) {
+                      if (d.changed) {
+                        return "<span>" + d.changed + "</span>";
+                      }
+                      else {return "Patient Created"}
+                  })
+      
+      // Draw the chart
+      var chart = d3.select("#patientHistory")
+                    .append("svg")
+                    .attr("width", width + margin.left + margin.right)
+                    .attr("height", height + gutter);
+                    
+      // Call the tooltip library
+      chart.call(tip);
+                    
+      // Draw the measure update lines
+      chart.selectAll("line")
+          .data(measureData)
+        .enter().append("line")
+          .attr("x1", function(d) {return x(d.updateTime) + margin.left;} )
+          .attr("y1", 0)
+          .attr("x2", function(d) {return x(d.updateTime) + margin.left;} )
+          .attr("y2", height)
+          .attr("stroke-width", 6)
+          .attr("stroke", "gray")
+          .attr("stroke-dasharray", "2,1");
+                                    
+      // Draw the measure update labels
+      chart.selectAll("text")
+          .data(measureData)
+        .enter().append("text")
+          .attr("x", function(d) {return x(d.updateTime) + margin.left;} )
+          .attr("y", height + 11 )
+          .attr("text-anchor", "middle")
+          .attr("fill", "blue")
+          .text("MEASURE") // TODO: add the date on which the measure was updated
+          .attr("class","measureUpdateLabel")
+          .on("click", function(d) {alert("Set up diff between " + d.oldVersion + " and " + d.newVersion)})
+          .append('svg:tspan')
+            .attr("x", function(d) {return x(d.updateTime) + margin.left;} )
+            .attr('dy', 13)
+            .text("UPDATED")
+            .append('svg:tspan')
+              .attr("x", function(d) {return x(d.updateTime) + margin.left;} )
+              .attr('dy', 13)
+              .text(function(d) {return prettyDate(d.updateTime);});
+                      
+      // Draw the patient update bubbles
+      patientData.forEach( function(datum, index){
+        var data = datum.times;
+        var minTime = 999999999999999,
+            maxTime = 0;
+        $.each(data, function (index,value){
+            if (value.updateTime < minTime) {minTime = value.updateTime};
+            if (value.updateTime > maxTime) {maxTime = value.updateTime};
+        });
+        
+        // Background for each patient
+        chart.append("line")
+          .attr("x1", x(minTime) + margin.left )
+          .attr("y1", (index + 1) * (bubbleRadius + bubbleMargin)*2 - (bubbleRadius*2 + bubbleMargin) + bubbleRadius)
+          .attr("x2", x(maxTime) + margin.left )
+          .attr("y2", (index + 1) * (bubbleRadius + bubbleMargin)*2 - (bubbleRadius*2 + bubbleMargin) + bubbleRadius)
+          .attr("stroke-width", 2)
+          .attr("stroke", "gray");
+            
+        // Patient labels              
+        chart.append("text")
+          .attr("x", x(minTime) )
+          .attr("y", (index + 1) * (bubbleRadius + bubbleMargin)*2 - (bubbleRadius*2 + bubbleMargin) - bubbleMargin/4 )
+          .text(datum.label)
+          .attr("class","timeline-label");
+                          
+        // Create a group for the bubble and icon
+        var bubbles = chart.append("g").selectAll("circle")
+                          .data(data)
+                        .enter().append("g");
+                        
+        // Add all the relevant actions to the group
+        bubbles.attr("class", "patientUpdateIndicator")
+              .on('mouseover', tip.show)
+              .on('mouseout', tip.hide)
+              .on("click", function (d, i) {
+                alert("Redirect to the version of " + datum.label + " updated on " + new Date(d.updateTime))
+              })
+              .attr("id", function(d, i) {
+                return d.id ? d.id : "timelineItem_"+index+"_"+i;
+              });
+        
+        // Add a backing to the bubbles so none of the background shows through   
+        bubbles.append("circle")
+              .attr("cx", function(d) {return x(d.updateTime) + margin.left;} )
+              .attr("cy", (index + 1) * (bubbleRadius + bubbleMargin)*2 - (bubbleRadius + bubbleMargin))
+              .attr("r", bubbleRadius)
+              .style("fill", "white")
+              .style("stroke", "white")
+              .style("stroke-width",2);
+              
+        // Add icons to the bubbles
+        bubbles.append("text")
+              .attr("x", function(d) {return x(d.updateTime) + margin.left;} )
+              .attr("y", (index + 1) * (bubbleRadius + bubbleMargin)*2 - (bubbleRadius + bubbleMargin))
+              .text(function(d) { if (d.result == "pass") {return "\uf00c"}
+                                    else { return "\uf00d" }
+                                })
+              .style("fill", function(d) { if (d.result == "pass") {return "#004119"}
+                                            else { return "#730800" }
+                                        })
+              .style('font-family','FontAwesome')
+              .attr('text-anchor', 'middle')
+              .attr('dominant-baseline', 'central')
+              .attr('font-size', bubbleRadius * 1.5 + 'px');
+        
+        // Add the bubbles in the correct place with fill and stroke    
+        bubbles.append("circle")
+              .attr("cx", function(d) {return x(d.updateTime) + margin.left;} )
+              .attr("cy", (index + 1) * (bubbleRadius + bubbleMargin)*2 - (bubbleRadius + bubbleMargin))
+              .attr("r", bubbleRadius)
+              .style("fill", function(d) { if (d.result == "pass") {return "#20744c"}
+                                            else { return "#a63b12" }
+                                        })
+              .style("fill-opacity",0.5)
+              .style("stroke", function(d) { if (d.result == "pass") {return "#004119"}
+                                            else { return "#730800" }
+                                        })
+              .style("stroke-width",2);
+        
+      });
+    } // patientHistory
+    
+    patientHistory();
+    
+  } // window.onLoad
+</script>
+
+<div class="row">
+  <div class="measure-title">
+    <h1 class="short-title"><i class="fa fa-fw fa-clock-o" aria-hidden="true"></i> {{cms_id}} - TEST CASE HISTORY</h1>
+  </div>
+  <div class="measure-dsp">
+    <h2 class="full-title">{{title}}</h2>
+    {{#if episode_of_care}}
+      <div class="measure-dsp-title">
+        Episode(s) of Care:
+      </div>
+        {{#each episodesOfCare tag="ul"}}
+          {{#with attributes}}
+            <li>{{description}}</li>
+          {{/with}}
+        {{/each}}
+      <p></p>
+    {{/if}}
+
+    <p>{{description}}</p>
+  </div>
+  <div id="patientHistory"></div>
+  <div id="measureDiff"></div>
+</div>

--- a/app/assets/javascripts/views/patient_builder/patient_builder.js.coffee
+++ b/app/assets/javascripts/views/patient_builder/patient_builder.js.coffee
@@ -173,7 +173,7 @@ class Thorax.Views.PatientBuilder extends Thorax.Views.BonnieView
       $(e.target).button('reset').prop('disabled', false)
       messages = []
       for [cid, field, message] in @originalModel.validationError
-        # Location holds the cid of the model with the error, either toplevel or a data criteria, from whcih we get the view
+        # Location holds the cid of the model with the error, either toplevel or a data criteria, from which we get the view
         if cid == @originalModel.cid
           @$(":input[name=#{field}]").closest('.form-group').addClass('has-error')
         else

--- a/app/assets/javascripts/views/population_calculation_view.js.coffee
+++ b/app/assets/javascripts/views/population_calculation_view.js.coffee
@@ -9,8 +9,13 @@ class Thorax.Views.PopulationCalculation extends Thorax.Views.BonnieView
     @listenTo @coverageView, 'logicView:clearCoverage', -> @trigger 'logicView:clearCoverage'
     @measure = @model.measure()
     @differences = @model.differencesFromExpected()
-    # We want to display the results sorted by 1) failures first, then 2) last name, then 3) first name
-    @differences.comparator = (d) -> [!d.get('done'), d.get('match'), d.result.patient.get('last'), d.result.patient.get('first')]
+    # We want to display the results sorted by 1) failures first, then 2) test case number, then 3) last name, then 4) first name
+    @differences.comparator = (d) -> [!d.get('done'), 
+                                      d.get('match'),
+                                      # caseNumber is not a required field
+                                      d.result.patient.get('caseNumber') || '000',
+                                      d.result.patient.get('last'),
+                                      d.result.patient.get('first')]
     @differences.sort()
     # Make sure the sort order updates as results come in
     @differences.on 'change', @differences.sort, @differences

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -121,7 +121,7 @@ private
     patient['measure_ids'] ||= params['measure_ids'] || []
     patient['measure_ids'] << params['measure_id'] unless patient['measure_ids'].include? params['measure_id'] || params['measure_id'].nil?
 
-    ['first', 'last', 'gender', 'expired', 'birthdate', 'description', 'description_category', 'deathdate', 'notes', 'is_shared'].each {|param| patient[param] = params[param]}
+    ['caseNumber', 'first', 'last', 'gender', 'expired', 'birthdate', 'description', 'description_category', 'deathdate', 'notes', 'is_shared'].each {|param| patient[param] = params[param]}
 
     patient['ethnicity'] = {'code' => params['ethnicity'], 'name'=>ETHNICITY_NAME_MAP[params['ethnicity']], 'codeSystem' => 'CDC Race'}
     patient['race'] = {'code' => params['race'], 'name'=>RACE_NAME_MAP[params['race']], 'codeSystem' => 'CDC Race'}


### PR DESCRIPTION
<img width="319" alt="screen shot 2016-02-18 at 4 18 44 pm" src="https://cloud.githubusercontent.com/assets/1328955/13158540/5f71160a-d65b-11e5-89da-bf67a5e5ab4c.png">

This came up in the last end user group session I sat in on.  Since measure developers generally use test case numbers (rather than patient names) in submissions for NQF endorsement, they would like to be able to create patients with test case numbers.

I left it as an optional field to avoid breaking any current patients in Bonnie, and I'm sure there will be situations where a test case number isn't necessary/wanted.

<img width="396" alt="screen shot 2016-02-18 at 4 19 05 pm" src="https://cloud.githubusercontent.com/assets/1328955/13158547/666f889c-d65b-11e5-921a-2ac411797759.png">

Sorting will be a bit interesting, since it's currently done using an array of fail/pass status, first name, and last name.  Since test case number is optional, I'm adding "000" if it doesn't exist, since the measure developers seemed to be using 3-digit zero-padded numbers for their current test cases.
