### PR TITLE
Adding required and/or aria-required to all required fields in Bonnie

### DIFF
--- a/app/assets/javascripts/templates/import/import_measure.hbs
+++ b/app/assets/javascripts/templates/import/import_measure.hbs
@@ -43,13 +43,13 @@
             <div class="form-group">
               <label for="vsacUser" class="col-sm-{{titleSize}} control-label">VSAC Username</label>
               <div class="col-sm-{{dataSize}}">
-                <input type="text" class="form-control" id="vsacUser" name="vsac_username" placeholder="username">
+                <input type="text" class="form-control" id="vsacUser" name="vsac_username" placeholder="username" aria-required="true">
               </div>
             </div>
             <div class="form-group">
               <label for="vsacPassword" class="col-sm-{{titleSize}} control-label">VSAC Password</label>
               <div class="col-sm-{{dataSize}}">
-                <input type="password" class="form-control" id="vsacPassword" name="vsac_password" placeholder="password">
+                <input type="password" class="form-control" id="vsacPassword" name="vsac_password" placeholder="password" aria-required="true">
               </div>
               <div class="col-sm-offset-{{titleSize}} vsac-registration"><a href="https://uts.nlm.nih.gov/license.html" target="_blank"><i class="fa fa-plus-circle" aria-hidden="true"></i> Register for VSAC</a></div>
             </div>

--- a/app/assets/javascripts/templates/patient_builder/patient_builder.hbs
+++ b/app/assets/javascripts/templates/patient_builder/patient_builder.hbs
@@ -29,13 +29,13 @@
 <div class="row">
   <form class="col-left" role="form">
     <div class="form-group">
-      <label for="last" class="control-label">Last Name</label>
-      <input type="text" id="last" name="last" class="form-control" placeholder="Smith">
+      <label for="last" class="control-label">Last Name*</label>
+      <input type="text" id="last" name="last" class="form-control" placeholder="Smith" required aria-required="true">
     </div>
 
     <div class="form-group">
-      <label for="first" class="control-label">First Name</label>
-      <input type="text" id="first" name="first" class="form-control" placeholder="John">
+      <label for="first" class="control-label">First Name*</label>
+      <input type="text" id="first" name="first" class="form-control" placeholder="John" required aria-required="true">
     </div>
   </form>
 
@@ -50,14 +50,14 @@
 
       <div class="col-sm-6">
         <div class="form-group">
-          <label for="birthdate" class="control-label">Date of Birth</label>
+          <label for="birthdate" class="control-label">Date of Birth*</label>
           <div class="datetime-control">
             <div>
-              <input type="text" id="birthdate" name="birthdate" class="date-picker form-control" placeholder="mm/dd/yyyy" title="month/day/year" data-date-format="mm/dd/yyyy" data-date-keyboard-navigation="false" data-date-autoclose="true">
+              <input type="text" id="birthdate" name="birthdate" class="date-picker form-control" placeholder="mm/dd/yyyy" title="month/day/year" data-date-format="mm/dd/yyyy" data-date-keyboard-navigation="false" data-date-autoclose="true" required aria-required="true">
             </div>
             <div>
               <label for="birthtime" class="sr-only">Time of Birth</label>
-              <input type="text" id="birthtime" name="birthtime" class="time-picker form-control" placeholder="--:-- --" data-show-inputs="false" data-default-time="8:00 AM">
+              <input type="text" id="birthtime" name="birthtime" class="time-picker form-control" placeholder="--:-- --" data-show-inputs="false" data-default-time="8:00 AM" required aria-required="true">
             </div>
           </div>
         </div>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -7,10 +7,10 @@
   <h1>Everyone forgets.</h1>
   <p>Just enter your email address, and we'll send you a link to reset your password.</p>
   <%= form_for(resource, :as => resource_name, :url => password_path(resource_name), :html => {:name=>"forgot_password_form"}) do |f| %>
-    <div class="form-group input-group input-group-lg">
+    <div class="form-group input-group input-group-lg required">
       <span class="input-group-addon"><i class="fa fa-envelope fa-lg fa-fw" aria-hidden="true"></i></span>
       <label for="user_email" class="sr-only">Email: </label>
-      <%= f.email_field :email, class: "form-control", placeholder: "email@example.com" %>
+      <%= f.email_field :email, class: "form-control", placeholder: "email@example.com", required: true, 'aria-required': true %>
     </div>
 
     <% if resource.errors.present? %>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,4 +1,4 @@
-<h1>Account Information</h1>
+<h1>Change Account Information</h1>
 <%= form_for(resource, :as => resource_name, :url => registration_path(resource_name), :html => {:method => :put, :name=>"register_form", class: "registration"}) do |f| %>
 
   <% if resource.errors.present? %>
@@ -18,23 +18,23 @@
       <div class="input-group input-group-lg required">
         <label for="user_first_name" class="sr-only">First Name (required) </label>
         <span class="input-group-addon"><i class="fa fa-user fa-lg fa-fw" aria-hidden="true"></i></span>
-        <%= f.text_field :first_name, class: "form-control", placeholder: "first name*" %>
+        <%= f.text_field :first_name, class: "form-control", placeholder: "first name*", required: true, 'aria-required': true %>
       </div>
     </div>
     <div class="col-md-6">
       <div class="input-group input-group-lg required">
         <label for="user_last_name" class="sr-only">Last Name (required) </label>
         <span class="input-group-addon"><i class="fa fa-user fa-lg fa-fw" aria-hidden="true"></i></span>
-        <%= f.text_field :last_name, class: "form-control", placeholder: "last name*" %>
+        <%= f.text_field :last_name, class: "form-control", placeholder: "last name*", required: true, 'aria-required': true %>
       </div>
     </div>
   </div>
   <div class="form-group row">
     <div class="col-md-6">
-      <div class="input-group input-group-lg">
+      <div class="input-group input-group-lg required">
         <label for="user_email" class="sr-only">Email </label>
         <span class="input-group-addon"><i class="fa fa-envelope fa-lg fa-fw" aria-hidden="true"></i></span>
-        <%= f.email_field :email, class: "form-control", placeholder: "email@example.com" %>
+        <%= f.email_field :email, class: "form-control", placeholder: "email@example.com*", required: true, 'aria-required': true %>
       </div>
     </div>
     <div class="col-md-6">
@@ -59,20 +59,21 @@
     </div>
   <% end %>
 
+<h1>Change Password</h1>
   <div class="form-group row">
     <div class="col-md-6">
-      <div class="input-group input-group-lg required">
+      <div class="input-group input-group-lg">
         <label for="user_password" class="sr-only">Password (required) </label>
         <span class="input-group-addon"><i class="fa fa-lock fa-lg fa-fw" aria-hidden="true"></i></span>
-        <%= f.password_field :password, class: "form-control", placeholder: "password*" %>
+        <%= f.password_field :password, class: "form-control", placeholder: "new password" %>
       </div>
       Must be at least 8 characters long and contain characters from at least two of: lowercase letters, uppercase letters, numbers, and special characters (leave blank if you don't want to change it).
     </div>
     <div class="col-md-6">
-      <div class="input-group input-group-lg required">
+      <div class="input-group input-group-lg">
         <label for="user_password_confirmation" class="sr-only">confirm password (required) </label>
         <span class="input-group-addon"><i class="fa fa-lock fa-lg fa-fw" aria-hidden="true"></i></span>
-        <%= f.password_field :password_confirmation, class: "form-control", placeholder: "confirm password*" %>
+        <%= f.password_field :password_confirmation, class: "form-control", placeholder: "confirm new password" %>
       </div>
     </div>
   </div>
@@ -82,7 +83,7 @@
       <div class="input-group input-group-lg required">
         <label for="user_current_password" class="sr-only">current password (required: </label>
         <span class="input-group-addon"><i class="fa fa-lock fa-lg fa-fw" aria-hidden="true"></i></span>
-        <%= f.password_field :current_password, class: "form-control", placeholder: "current password*" %>
+        <%= f.password_field :current_password, class: "form-control", placeholder: "current password*", required: true, 'aria-required': true %>
       </div>
       Your current password is needed to confirm your changes.
     </div>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -14,17 +14,17 @@
 
   <div class="form-group row">
     <div class="col-md-6">
-      <div class="input-group input-group-lg">
+      <div class="input-group input-group-lg required">
         <label for="user_first_name" class="sr-only">First Name </label>
         <span class="input-group-addon"><i class="fa fa-user fa-lg fa-fw" aria-hidden="true"></i></span>
-        <%= f.text_field :first_name, class: "form-control", placeholder: "first name" %>
+        <%= f.text_field :first_name, class: "form-control", placeholder: "first name", required: true, 'aria-required': true %>
       </div>
     </div>
     <div class="col-md-6">
-      <div class="input-group input-group-lg">
+      <div class="input-group input-group-lg required">
         <label for="user_last_name" class="sr-only">Last Name </label>
         <span class="input-group-addon"><i class="fa fa-user fa-lg fa-fw" aria-hidden="true"></i></span>
-        <%= f.text_field :last_name, class: "form-control", placeholder: "last name" %>
+        <%= f.text_field :last_name, class: "form-control", placeholder: "last name", required: true, 'aria-required': true %>
       </div>
     </div>
   </div>
@@ -33,7 +33,7 @@
       <div class="input-group input-group-lg required">
         <label for="user_email" class="sr-only">Email </label>
         <span class="input-group-addon"><i class="fa fa-envelope fa-lg fa-fw" aria-hidden="true"></i></span>
-        <%= f.email_field :email, class: "form-control", placeholder: "email@example.com" %>
+        <%= f.email_field :email, class: "form-control", placeholder: "email@example.com*", required: true, 'aria-required': true %>
       </div>
     </div>
     <div class="col-md-6">
@@ -49,7 +49,7 @@
       <div class="input-group input-group-lg required">
         <label for="user_password" class="sr-only">Password (required) </label>
         <span class="input-group-addon"><i class="fa fa-lock fa-lg fa-fw" aria-hidden="true"></i></span>
-        <%= f.password_field :password, class: "form-control", placeholder: "password*" %>
+        <%= f.password_field :password, class: "form-control", placeholder: "password*", required: true, 'aria-required': true %>
       </div>
       Must be at least 8 characters long and contain characters from at least two of: lowercase letters, uppercase letters, numbers, and special characters.
     </div>
@@ -57,7 +57,7 @@
       <div class="input-group input-group-lg required">
         <label for="user_password_confirmation" class="sr-only">Password Confirmation (required) </label>
         <span class="input-group-addon"><i class="fa fa-lock fa-lg fa-fw" aria-hidden="true"></i></span>
-        <%= f.password_field :password_confirmation, class: "form-control", placeholder: "confirm password*" %>
+        <%= f.password_field :password_confirmation, class: "form-control", placeholder: "confirm password*", required: true, 'aria-required': true %>
       </div>
     </div>
   </div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -8,15 +8,15 @@
   </header>
 
   <%= form_for(resource, :as => resource_name, :url => session_path(resource_name), :html => {:name=>"login_form"}) do |f| %>
-    <div class="form-group input-group input-group-lg">
+    <div class="form-group input-group input-group-lg required">
       <span class="input-group-addon"><i class="fa fa-envelope fa-lg fa-fw" aria-hidden="true"></i></span>
       <label for="user_email" class="sr-only">Email </label>
-      <%= f.email_field :email, class: "form-control", placeholder: "email@example.com" %>
+      <%= f.email_field :email, class: "form-control", placeholder: "email@example.com", required: true, 'aria-required': true %>
     </div>
-    <div class="form-group input-group input-group-lg">
+    <div class="form-group input-group input-group-lg required">
       <span class="input-group-addon"><i class="fa fa-lock fa-lg fa-fw" aria-hidden="true"></i></span>
       <label for="user_password" class="sr-only">Password </label>
-      <%= f.password_field :password, class: "form-control", placeholder: "password" %>
+      <%= f.password_field :password, class: "form-control", placeholder: "password", required: true, 'aria-required': true %>
     </div>
 
     <% if resource.errors.present? %>


### PR DESCRIPTION
- `devise` doesn't automatically add required/aria-required indicators, so I added them there.  Also, email is now required for new users.
- On the measure upload modal, the only inputs that need some kind of input and are empty by default are the VSAC username and password.  Since they're persistent but hidden, I left out the required attribute and just used aria-required.
- For the patient builder, I added the required/aria-required attributes and an asterisk on first name, last name, and date of birth, since they are the only required fields.
