### PR TITLE
Fix for nested SATISFIES descriptions; Tweak for SATISFIES logic view

### DIFF
--- a/app/assets/javascripts/templates/logic/satisfies.hbs
+++ b/app/assets/javascripts/templates/logic/satisfies.hbs
@@ -1,5 +1,7 @@
   <span class="criteria-title">
-    {{#if rootCriteria.specific_occurrence}}Occurrence {{rootCriteria.specific_occurrence}}: {{/if}}{{#if rootCriteria.variable}}${{/if}}{{rootCriteria.description}}
+    {{#unless dataCriteria.has_parent}}
+      {{#if rootCriteria.specific_occurrence}}Occurrence {{rootCriteria.specific_occurrence}}: {{/if}}{{#if rootCriteria.variable}}${{/if}}{{rootCriteria.description}}
+    {{/unless}}
     <span class="sr-only sr-highlight-status"></span>
     {{translate_operator dataCriteria.definition}}
     <ul class="multi-statement">

--- a/app/assets/javascripts/views/logic/satisfies_logic_view.js.coffee
+++ b/app/assets/javascripts/views/logic/satisfies_logic_view.js.coffee
@@ -13,6 +13,14 @@ class Thorax.Views.SatisfiesLogic extends Thorax.Views.BonnieView
   initialize: ->
     @dataCriteria = @measure.get('data_criteria')[@reference]
     @rootCriteria = @measure.get('data_criteria')[@dataCriteria.children_criteria[0]]
+    # Sometimes SATISFIES blocks are nested, so make sure the rootCriteria points
+    # to the first non-SATISFIES nested child criteria.
+    while @rootCriteria.children_criteria && @rootCriteria.definition.indexOf("satisfies") > -1
+      @rootCriteria = @measure.get('data_criteria')[@rootCriteria.children_criteria[0]]
+    # For each child criteria of this data criteria, record the fact that the
+    # child criteria is nested.
+    for cc in @dataCriteria.children_criteria
+      @measure.get('data_criteria')[cc]['has_parent'] = true
 
   translate_operator: (definition) =>
     @operator_map[definition]


### PR DESCRIPTION
This pull request addresses two issues. The first issue deals with SATISFIES blocks displaying incorrect descriptions (https://jira.oncprojectracking.org/browse/BONNIE-157, https://jira.oncprojectracking.org/browse/BONNIE-158). This issue was caused by SATISFIES data criteria inheriting the first of their child criteria's description. When SATISFIES blocks are nested, this results in an incorrect description. The second addressed issue involves how nested SATISFIES blocks are displayed. Previously, every SATISFIES line included the description of the relevant data criteria. This behavior has been modified such that only the top most SATISFIES line includes the relevant description, and all subsequent nested SATISFIES do not - such as how this logic is displayed in the HQMF human readable.

Example 1, Before:

![1_before](https://cloud.githubusercontent.com/assets/14923551/13707141/47a814e8-e776-11e5-9e57-d30b75026ec6.png)

Example 1, After:

![1_after](https://cloud.githubusercontent.com/assets/14923551/13707143/4c002760-e776-11e5-87ab-e74d822e3c23.png)

Example 2, Before:

![2_before](https://cloud.githubusercontent.com/assets/14923551/13707152/525f52fc-e776-11e5-9134-1cd2e14ff502.png)

Example 2, After:

![2_after](https://cloud.githubusercontent.com/assets/14923551/13707158/56b9e22c-e776-11e5-80ae-8049cb0a6a50.png)
