### PR TITLE
Add expected values to the fields exported in the QRDA file.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,7 +11,7 @@ GIT
 
 GIT
   remote: https://github.com/projectcypress/health-data-standards.git
-  revision: 80551e5326937769d68dac5b3176ea79b60ce8f9
+  revision: 9e827235a53cd6d2719b48d50bfe820a8f997b38
   branch: master
   specs:
     health-data-standards (3.6.1)
@@ -23,7 +23,7 @@ GIT
       memoist (~> 0.9.1)
       mongoid (~> 4.0.0)
       mongoid-tree (~> 1.0.4)
-      nokogiri (~> 1.6.7.1)
+      nokogiri (~> 1.6.8)
       protected_attributes (~> 1.0.5)
       rest-client (~> 1.8.0)
       rubyzip (= 0.9.9)
@@ -133,7 +133,7 @@ GEM
       warden (~> 1.2.3)
     diffy (3.0.7)
     docile (1.1.5)
-    domain_name (0.5.20160310)
+    domain_name (0.5.20160615)
       unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
     eventmachine (1.0.7)
@@ -181,7 +181,7 @@ GEM
     memoist (0.9.3)
     method_source (0.8.2)
     mime-types (2.99)
-    mini_portile2 (2.0.0)
+    mini_portile2 (2.1.0)
     minitest (5.8.3)
     mongoid (4.0.0)
       activemodel (~> 4.0)
@@ -200,14 +200,16 @@ GEM
     net-ssh (2.9.2)
     netrc (0.11.0)
     newrelic_rpm (3.14.3.313)
-    nokogiri (1.6.7.1)
-      mini_portile2 (~> 2.0.0.rc2)
+    nokogiri (1.6.8)
+      mini_portile2 (~> 2.1.0)
+      pkg-config (~> 1.1.7)
     non-stupid-digest-assets (1.0.4)
     oj (2.12.11)
     optionable (0.2.0)
     origin (2.1.1)
     orm_adapter (0.5.0)
     phantomjs (1.9.8.0)
+    pkg-config (1.1.7)
     protected_attributes (1.0.9)
       activemodel (>= 4.0.1, < 5.0)
     pry (0.10.1)

--- a/lib/ext/record.rb
+++ b/lib/ext/record.rb
@@ -43,4 +43,30 @@ class Record
     end
   end
 
+  # Supports the exporting of the expected values in the QRDA export of the patients
+  # Note: There is logic in health-data-standards _measures.cat1.erb for further formatting.
+  # The special handling of the key 'DENEX' is do to the fact that the description of this population
+  #  stored in many of the measures is incorrect (it is often just 'Denominator' instead of
+  #  'Denominator Exclusion').
+  def expected_values_for_qrda_export(measure)
+    qrda_expected_values = []
+    expected_pop_names = HQMF::PopulationCriteria::ALL_POPULATION_CODES - %w{STRAT OBSERV}
+    measure.populations.each_with_index do |pop, idx|
+      pop.each do |pkey, pvalue|
+        next unless expected_pop_names.include?(pkey)
+        this_ev = {}
+        this_ev[:hqmf_id] = measure.population_criteria[pvalue.to_s]['hqmf_id']
+        if pkey == 'DENEX'
+          this_ev[:display_name] = 'Denominator Exclusions'
+        else
+          this_ev[:display_name] = measure.population_criteria[pvalue.to_s]['title']
+        end
+        this_ev[:code] = pkey
+        this_ev[:expected_value] = self.expected_values[idx][pkey].to_s
+        qrda_expected_values << this_ev
+      end
+    end
+    qrda_expected_values
+  end
+
 end


### PR DESCRIPTION
This request came from a Bonnie user via Rute asking for the ability to include the expected values in QRDA export.  

I was able to get all but the continuous variables into the export.  I could not find anywhere in the QRDA spec to include them.

There is a companion pull request in Health Data Standards ([#386](https://github.com/projectcypress/health-data-standards/pull/386)) that needs to be accepted first.
