### PR TITLE
Remove extra padding from list inside a set operator nested within a …

### DIFF
--- a/app/assets/stylesheets/measure.less
+++ b/app/assets/stylesheets/measure.less
@@ -210,6 +210,10 @@
       li {
         .set-op-item {
           list-style-type: square;
+
+          .set-op-group > ul {
+            padding-left: 0; // addresses overly-nested list markup
+          }
         }
       }
     }

--- a/app/assets/stylesheets/measure.less
+++ b/app/assets/stylesheets/measure.less
@@ -210,14 +210,14 @@
       li {
         .set-op-item {
           list-style-type: square;
-
-          .set-op-group > ul {
-            padding-left: 0; // addresses overly-nested list markup
-          }
         }
       }
     }
   }
+}
+
+li .set-op-item .set-op-group > ul {
+  padding-left: 0; // addresses overly-nested list markup
 }
 
 .d3-measure-viz {


### PR DESCRIPTION
…listed set operator.

Yeah!

This is a fix for JIRA issue 166 that affects several measures - CMS171v6, CMS185v5, CMS105v5, and CMS190v5 (bad indenting seen below with red for emphasis). 

![image](https://cloud.githubusercontent.com/assets/2136286/15906480/03900426-2d87-11e6-97d3-c82cc40b4c9e.png)

This is caused by an extraneous `<ul>` element. The approach taken was to use CSS to target the extraneous element and remove the left padding.
