### PR TITLE
Emergency and proactive fix for VSAC changing profiles.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,7 +31,7 @@ GIT
 
 GIT
   remote: https://github.com/projecttacoma/bonnie_bundler.git
-  revision: b75299843a0b7e3d9eed8fa769872551971c7e70
+  revision: d9c6044b3a12aa3e4d37f2f19de8c5a478a8802f
   branch: master
   specs:
     bonnie_bundler (1.0.0)

--- a/config/bonnie.yml
+++ b/config/bonnie.yml
@@ -8,6 +8,8 @@ defaults: &defaults
   nlm:
     ticket_url: https://vsac.nlm.nih.gov/vsac/ws/Ticket
     api_url: https://vsac.nlm.nih.gov/vsac/svs/RetrieveMultipleValueSets
+    profiles_url: https://vsac.nlm.nih.gov/vsac/profiles
+    profile: MU2 Update 2016-04-01
 
 development:
   <<: *defaults

--- a/lib/tasks/vsac.rake
+++ b/lib/tasks/vsac.rake
@@ -12,7 +12,7 @@ namespace :bonnie do
       
       # We are using V2 API:
       api = HealthDataStandards::Util::VSApiV2.new(config["ticket_url"], config["api_url"], ENV['USERNAME'], ENV['PASSWORD'])
-      result = api.get_valueset(ENV['OID'], effective_date: effective_date, include_draft: include_draft)
+      result = api.get_valueset(ENV['OID'], effective_date: effective_date, include_draft: include_draft, profile: config["profile"])
       doc = Nokogiri::XML(result)
       doc.root.add_namespace_definition("vs","urn:ihe:iti:svs:2008")
       vs_element = doc.at_xpath("/vs:RetrieveValueSetResponse/vs:ValueSet|/vs:RetrieveMultipleValueSetsResponse/vs:DescribedValueSet")
@@ -20,6 +20,32 @@ namespace :bonnie do
       puts "Value set #{vs_element['ID']} codes"
       vs_element.xpath("//vs:Concept").each do |concept|
         puts "  #{concept['codeSystemName']} #{concept['code']} (#{concept['codeSystemVersion']})"
+      end
+    end
+    
+    
+    desc 'Retrieve list of VSAC Profiles'
+    task :get_profiles => :environment do
+      raise "No USERNAME supplied" unless ENV['USERNAME']
+      raise "No PASSWORD supplied" unless ENV['PASSWORD']
+      config = APP_CONFIG["nlm"].clone
+      
+      # TODO: This is a temporary thing we should make it so HDS VSApiV2 has a call to get profiles and 
+      # so it can be configued with profiles_url
+      config["api_url"] = APP_CONFIG["nlm"]["profiles_url"]
+      
+      # We are using V2 API:
+      api = HealthDataStandards::Util::VSApiV2.new(config["ticket_url"], config["api_url"], ENV['USERNAME'], ENV['PASSWORD'])
+      
+      # TODO: This is a temporary thing. This call is actually calling the profiles url. HDS VSApiV2 
+      # should have a get_profiles call added.
+      result = api.get_valueset("0")
+      
+      doc = Nokogiri::XML(result)
+      profile_list_element = doc.at_xpath("/ProfileList")
+      
+      profile_list_element.xpath("//profile").each do |profile|
+        puts "  #{profile.text}"
       end
     end
   end


### PR DESCRIPTION
- Added profile to the nlm part of the bonnie configuration.
  - This makes it so we can change the VSAC profile that bonnie uses without changing HDS.
- Added a rake task (bonnie:vsac:get_profiles) to get the profiles from the API. Useful for debugging if this happens again.
- Updates gemfile.lock for bonnie_bundler version that needs this config addition.
