### PR TITLE
made it so the query for code concepts will return an empty array if …

### DIFF
--- a/app/assets/javascripts/views/measure_value_sets.js.coffee
+++ b/app/assets/javascripts/views/measure_value_sets.js.coffee
@@ -38,7 +38,7 @@ class Thorax.Views.MeasureValueSets extends Thorax.Views.BonnieView
           version = bonnie.valueSetsByOid[oid].version
           # if it's a date (rather than "Draft"), format the version
           version = moment(version, "YYYYMMDD").format("MM/DD/YYYY") if moment(version, "YYYYMMDD").isValid()
-          codeConcepts = bonnie.valueSetsByOid[oid].concepts
+          codeConcepts = bonnie.valueSetsByOid[oid].concepts ? []
           for code in codeConcepts
             code.hasLongDisplayName = code.display_name.length > 160
         else


### PR DESCRIPTION
…no code concepts exist.

This is related to a bug seen in dogpark related to CMS172. When tested locally, if this measure was loaded using "Published", the code broke because of the empty concept list. This addresses that issue.
