### PR TITLE
Fix issue with overlapping valuesets feature due to use of paged collections

### DIFF
--- a/app/assets/javascripts/views/measure_value_sets.js.coffee
+++ b/app/assets/javascripts/views/measure_value_sets.js.coffee
@@ -85,8 +85,9 @@ class Thorax.Views.MeasureValueSets extends Thorax.Views.BonnieView
       for valueSet2 in _(summaryValueSets).without(valueSet1)
         matchedCodes = []
 
-        valueSet1.codes.each (code1) =>
-          hasOverlap = valueSet2.codes.models.some (code2) ->
+        # Because codes are pageable, we need to reference the fullCollection to compare all codes
+        valueSet1.codes.fullCollection.each (code1) =>
+          hasOverlap = valueSet2.codes.fullCollection.some (code2) ->
             overlapsCode = code2.get('code') == code1.get('code')
             overlapsCodeSystem = code2.get('code_system_name') == code1.get('code_system_name')
             return overlapsCode && overlapsCodeSystem


### PR DESCRIPTION
The value set debugging features that appear on the measure page use paged collections in order to allow users to view codes in a convenient paginated way; when these collections are used to compare two value sets for common codes, only the first 10 codes from each value set were compared due to the pagination (which happens at the collection level); a small change allows all the codes in the collections to be compared.
