### PR TITLE
Add QDM components

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem 'less-rails'
 # We want non-digest versions of our assets for font-awesome
 gem "non-stupid-digest-assets"
 
-gem 'health-data-standards', :git => 'https://github.com/projectcypress/health-data-standards.git', :branch => 'master'
+gem 'health-data-standards', :git => 'https://github.com/projectcypress/health-data-standards.git', :branch => 'bonnie_master_2016'
 gem 'simplexml_parser', :git => 'https://github.com/projecttacoma/simplexml_parser.git', :branch => 'master'
 gem 'hqmf2js', :git => 'https://github.com/projecttacoma/hqmf2js.git', :branch => 'master'
 gem 'bonnie_bundler', :git => 'https://github.com/projecttacoma/bonnie_bundler.git', :branch => 'master'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,8 +11,8 @@ GIT
 
 GIT
   remote: https://github.com/projectcypress/health-data-standards.git
-  revision: 9e827235a53cd6d2719b48d50bfe820a8f997b38
-  branch: master
+  revision: 8db65b4571e67fbcf7d61d6ab570643f2d69b270
+  branch: bonnie_master_2016
   specs:
     health-data-standards (3.6.1)
       activesupport (~> 4.1.1)
@@ -45,7 +45,7 @@ GIT
 
 GIT
   remote: https://github.com/projecttacoma/patientapi.git
-  revision: 8f6a7657cacb0ef27b6a495ba4e5d636d1edf694
+  revision: 10298520ee60416387ef1f9836bc351fc9a9e1c2
   branch: master
   specs:
     hquery-patient-api (1.0.4)

--- a/app/assets/javascripts/models/measure.js.coffee
+++ b/app/assets/javascripts/models/measure.js.coffee
@@ -70,10 +70,11 @@ class Thorax.Models.Measure extends Thorax.Model
   @logicFieldsFor: (criteriaType) ->
 
     # Define field values for all criteria types
-    globalInclusions = ['reason', 'source']
+    globalInclusions = ['reason', 'source', 'health_record_field']
 
     # Define criteria type-specific field values
     typeInclusions =
+      care_experiences: []
       care_goals: ['related_to', 'target_outcome']
       characteristics: []
       communications: []
@@ -87,12 +88,12 @@ class Thorax.Models.Measure extends Thorax.Model
       functional_statuses: []
       immunizations: ['route', 'dose', 'reaction']
       interventions: ['anatomical_structure']
-      laboratory_tests: ['reference_range_low', 'reference_range_high']
+      laboratory_tests: ['reference_range_low', 'reference_range_high', 'qdm_status']
       medications: ['route', 'dose', 'reaction']
       patient_care_experiences: []
       physical_exams: ['anatomical_structure']
       preferences: []
-      procedures: ['incision_time', 'anatomical_structure', 'ordinality']
+      procedures: ['incision_time', 'anatomical_structure', 'ordinality', 'qdm_status']
       provider_care_experiences: []
       provider_characteristics: []
       risk_category_assessments: ['severity']

--- a/app/assets/javascripts/models/measure.js.coffee
+++ b/app/assets/javascripts/models/measure.js.coffee
@@ -69,10 +69,14 @@ class Thorax.Models.Measure extends Thorax.Model
 
   @logicFieldsFor: (criteriaType) ->
 
-    # Define field values for all criteria types
+    # Defines what is included in the drop down menu in the Bonnie Patient Builder for all
+    # criteria. The name should correspond with what is the `coded_entry_method` in the `FIELDS`
+    # hash in health-data-standards:lib/health-model/data_criteria.rb.
     globalInclusions = ['reason', 'source', 'health_record_field']
 
-    # Define criteria type-specific field values
+    # Defines what is included in the drop down menu in the Bonnie Patient Builder for a particular
+    # criteria. The name should correspond with what is the `coded_entry_method` in the `FIELDS`
+    # hash in health-data-standards:lib/health-model/data_criteria.rb.
     typeInclusions =
       care_experiences: []
       care_goals: ['related_to', 'target_outcome']

--- a/lib/generation/generator.rb
+++ b/lib/generation/generator.rb
@@ -53,6 +53,8 @@ module HQMF
         "communications"
       when :family_history
         "family_history"
+      when :careExperiences
+        "care_experiences"
       else
         type.to_s
       end


### PR DESCRIPTION
Added several QDM components that were not previously included in Bonnie (although they are in QDM 4.2).
These include:
- Diagnostic Test, Recommended
- Care Experience (Patient and Provider)
- Status (for procedure, performed and laboratory results)
- Health Record Field (for all criterias)

This commit depends on commits in health-data-standards and patientapi with the same branch name.
