### PR TITLE
If a measure load fails, delete the (likely broken) measure

### DIFF
--- a/app/controllers/measures_controller.rb
+++ b/app/controllers/measures_controller.rb
@@ -116,11 +116,12 @@ class MeasuresController < ApplicationController
         redirect_to "#{root_path}##{params[:redirect_route]}"
         return
       end
-      
 
       existing.delete if (existing && is_update)
+
     rescue Exception => e
       if params[:measure_file]
+        measure.delete if measure
         errors_dir = Rails.root.join('log', 'load_errors')
         FileUtils.mkdir_p(errors_dir)
         clean_email = File.basename(current_user.email) # Prevent path traversal


### PR DESCRIPTION
When a measure upload fails, we typically ensure that the measure is not saved in the database, often by deleting it after the error is detected. There are some upload paths where a failure could occur and the measure would not be deleted; this pull request addresses that issue.

(Note: an odd choice of line feed directly above the code change was also tweaked to improve readability)
