### PR TITLE
Made "Medication, Order" cumulative medication duration calculate correctly.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,7 +11,7 @@ GIT
 
 GIT
   remote: https://github.com/projectcypress/health-data-standards.git
-  revision: 041cfaa68a8bc8cda67bec0bc04e7fb5d35e86c5
+  revision: 7b11d9021be6c7f9eb7a87cbe77b87a385ef65aa
   branch: bonnie_master_2016
   specs:
     health-data-standards (3.6.1)
@@ -45,14 +45,14 @@ GIT
 
 GIT
   remote: https://github.com/projecttacoma/hqmf2js.git
-  revision: 8722ce23ade6b32d56e8fde425895cf3a9c37df5
+  revision: 0c79fe34b54488de259dfecc33cb46294a4cd0f7
   branch: master
   specs:
     hqmf2js (1.3.0)
 
 GIT
   remote: https://github.com/projecttacoma/patientapi.git
-  revision: d187a78c24a67adeb2e6dcb642487d8e85c24d70
+  revision: f56ba28452ab4b2ef4f2f6dbc585cd4e7f64f045
   branch: master
   specs:
     hquery-patient-api (1.0.4)
@@ -162,7 +162,7 @@ GEM
     highline (1.7.8)
     hike (1.2.3)
     htmlentities (4.3.4)
-    http-cookie (1.0.2)
+    http-cookie (1.0.3)
       domain_name (~> 0.5)
     i18n (0.7.0)
     jquery-rails (3.1.3)

--- a/app/assets/javascripts/templates/patient_builder/edit_criteria.hbs
+++ b/app/assets/javascripts/templates/patient_builder/edit_criteria.hbs
@@ -112,11 +112,9 @@
         <div class="row">
           {{#ifCond status "==" "ordered"}}
           <div class="form-group col-md-6">
-            <label for="administrations_value_{{@cid}}" class="control-label"><i class="fa fa-medkit" aria-hidden="true"></i> Allowed Administrations<span class="sr-only"> value</span></label>
+            <label for="administrations_value_{{@cid}}" class="control-label"><i class="fa fa-medkit" aria-hidden="true"></i> Number of Doses<span class="sr-only"> value</span></label>
             <div class="form-inline">
-              <div class="input-group">
-                <input type="text" name="administrations_value" id="adminstrations_value_{{@cid}}" class="form-control" placeholder="# of administrations">
-              </div>
+              <input type="number" min="0" name="administrations_value" id="adminstrations_value_{{@cid}}" class="form-control" placeholder="number of doses">
             </div>
           </div>
           {{else}}
@@ -146,7 +144,7 @@
             <label for="frequency_value_{{@cid}}" class="control-label"><i class="fa fa-spinner" aria-hidden="true"></i> Regimen<span class="sr-only"> value</span></label>
             <div class="form-inline">
               <div class="input-group">
-                <input type="text" name="frequency_value" id="frequency_value_{{@cid}}" class="form-control" placeholder="frequency">
+                <input type="number" min="0" name="frequency_value" id="frequency_value_{{@cid}}" class="form-control" placeholder="frequency">
                 <div class="input-group-addon">
                   <label for="frequency_unit_{{@cid}}" class="sr-only">frequency unit</label>
                   <select id="frequency_unit_{{@cid}}" name="frequency_unit" class="form-control medications-control">

--- a/app/assets/javascripts/templates/patient_builder/edit_criteria.hbs
+++ b/app/assets/javascripts/templates/patient_builder/edit_criteria.hbs
@@ -110,6 +110,16 @@
 
       {{#ifCond definition "==" "medication"}}
         <div class="row">
+          {{#ifCond status "==" "ordered"}}
+          <div class="form-group col-md-6">
+            <label for="administrations_value_{{@cid}}" class="control-label"><i class="fa fa-medkit" aria-hidden="true"></i> Allowed Administrations<span class="sr-only"> value</span></label>
+            <div class="form-inline">
+              <div class="input-group">
+                <input type="text" name="administrations_value" id="adminstrations_value_{{@cid}}" class="form-control" placeholder="# of administrations">
+              </div>
+            </div>
+          </div>
+          {{else}}
           <div class="form-group col-md-6">
             <label for="dose_value_{{@cid}}" class="control-label"><i class="fa fa-medkit" aria-hidden="true"></i> Prescription<span class="sr-only"> value</span></label>
             <div class="form-inline">
@@ -131,6 +141,7 @@
               </div>
             </div>
           </div>
+          {{/ifCond}}
           <div class="form-group col-md-6">
             <label for="frequency_value_{{@cid}}" class="control-label"><i class="fa fa-spinner" aria-hidden="true"></i> Regimen<span class="sr-only"> value</span></label>
             <div class="form-inline">
@@ -148,6 +159,7 @@
             </div>
           </div>
         </div>
+        {{#ifCond status "!=" "ordered"}}
         <div class="form-group">
           <label class="control-label"><i class="fa fa-medkit" aria-hidden="true"></i> Filled<input class="sr-only" disabled></label>
 
@@ -162,6 +174,7 @@
           {{view editFulfillmentHistoryView}}
 
         </div>
+        {{/ifCond}}
       {{/ifCond}}
 
       <div class="form-group">

--- a/app/assets/javascripts/views/patient_builder/data_criteria.js.coffee
+++ b/app/assets/javascripts/views/patient_builder/data_criteria.js.coffee
@@ -139,6 +139,7 @@ class Thorax.Views.EditCriteriaView extends Thorax.Views.BuilderChildView
     'change .negation-select':                    'toggleNegationSelect'
     'change :input[name=end_date_is_undefined]':  'toggleEndDateDefinition'
     'blur :text':                                 'triggerMaterialize'
+    'blur :input[type=number]':                   'triggerMaterialize'
     'change select':                              'triggerMaterialize'
     # hide date-picker if it's still visible and focus is not on a .date-picker input (occurs with JAWS SR arrow-key navigation)
     'focus .form-control': (e) -> if not @$(e.target).hasClass('date-picker') and $('.datepicker').is(':visible') then @$('.date-picker').datepicker('hide')

--- a/lib/measures/patient_builder.rb
+++ b/lib/measures/patient_builder.rb
@@ -74,6 +74,9 @@ module Measures
             if !source_criteria[:frequency_value].blank? && !source_criteria[:frequency_unit].blank?
               entry[:administrationTiming] = { "period" => { "value" => source_criteria[:frequency_value], "unit" => source_criteria[:frequency_unit] } }
             end
+            if !source_criteria[:administrations_value].blank?
+              entry[:allowedAdministrations] = source_criteria[:administrations_value]
+            end
             if !source_criteria[:fulfillments].blank?
               source_criteria[:fulfillments].each do |fulfillment|
                 fulfillments.push(FulfillmentHistory.new({:dispenseDate => fulfillment[:dispense_datetime], :quantityDispensed => {:value => fulfillment[:quantity_dispensed_value], :unit => fulfillment[:quantity_dispensed_unit]}}))


### PR DESCRIPTION
This addresses https://oncprojectracking.healthit.gov/support/browse/BONNIE-172.

Usually, cumulative medication duration is calculated based off of the fulfillment history, dose, and regimen. However, for "Medication, Order", the medication has not yet been filled, so fulfillment history and dose don't make sense. Maybe more importantly, these fields are not available in the QRDA for the "Medication, Order" template.

Instead, cumulative medication duration should be calculated based on the maximum allowed administrations (`repeatNumber` in the QRDA) and the regimen (`effectiveTime` with `period` subelement in the QRDA).

Additionally, fulfillment information should not be allowed to be entered for "Medication, Order".

Specific changes for this repository include GUI changes so the appropriate fields are shown for "Medication, Order" data criteria and so that proper fields are populated in the patient model.

This pull request depends on the `medication_order_cmd` branches in **patient-api, hqmf2js, and health-data-standards.**
