### PR TITLE
add some new icons for some new categories of data criteria

### DIFF
--- a/app/assets/javascripts/models/data_criteria.js.coffee
+++ b/app/assets/javascripts/models/data_criteria.js.coffee
@@ -86,6 +86,16 @@ class Thorax.Models.PatientDataCriteria extends Thorax.Model
       procedures:                'fa-scissors'
       risk_category_assessments: 'fa-user'
       care_goals:                'fa-sliders'
+      assessments:               'fa-eye'
+      care_experiences:          'fa-heartbeat'
+      family_history:            'fa-sitemap'
+      immunizations:             'fa-medkit'
+      preferences:               'fa-comment'
+      provider_characteristics:  'fa-user-md'
+      substances:                'fa-medkit'
+      symptoms:                  'fa-bug'
+      system_characteristics:    'fa-tachometer'
+      transfers:                 'fa-random'
     icons[@get('type')] || 'fa-question'
   canHaveResult: ->
     criteriaType = @get('definition')


### PR DESCRIPTION
These icons are what the user sees in the patient builder when selecting data criteria to add to a patient.

Here's an illustrated before/after of the icons in use:

![image](https://cloud.githubusercontent.com/assets/2136286/18794905/d742a952-818f-11e6-90fc-027f78a05665.png)
