### PR TITLE
Moved secret token to enviornment variable for production deployments

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,9 @@ gem 'less-rails'
 # We want non-digest versions of our assets for font-awesome
 gem "non-stupid-digest-assets"
 
+# Loads environment variables from the .env file
+gem 'dotenv-rails'
+
 gem 'health-data-standards', :git => 'https://github.com/projectcypress/health-data-standards.git', :branch => 'bonnie_master_2016'
 gem 'cql_qdm_patientapi', :git => 'https://github.com/projecttacoma/cql_qdm_patientapi.git', :branch => 'master'
 gem 'simplexml_parser', :git => 'https://github.com/projecttacoma/simplexml_parser.git', :branch => 'master'

--- a/config/initializers/secret_token.rb
+++ b/config/initializers/secret_token.rb
@@ -4,4 +4,8 @@
 # If you change this key, all old signed cookies will become invalid!
 # Make sure the secret is at least 30 characters and all random,
 # no regular words or you'll be exposed to dictionary attacks.
-Bonnie::Application.config.secret_token = '7a09b97def18280c460c386460713ded49b0f047476a5483cb340434f1777d95af03b58148b21f759c763ae0f8ec4e6f93ef14bfd36a2a8c8dec2e63dbed00c2'
+Bonnie::Application.config.secret_token = if Rails.env.development? or Rails.env.test?
+  ('x' * 30) # Bogus default for developent and testing purposes
+else
+  ENV['SECRET_TOKEN'] # Defer to environment for secret token on deployed systems
+end


### PR DESCRIPTION
For production deployments, set the secret token in the .env file, as such:

SECRET_TOKEN=<30+ character random string>

For testing and development deployments, this pull request will default to a secret token of 30 \* 'x'.
