### PR TITLE
Refactors of lazy loaded measures

### DIFF
--- a/app/assets/javascripts/models/archived_measure.js.coffee
+++ b/app/assets/javascripts/models/archived_measure.js.coffee
@@ -1,3 +1,7 @@
+# This file needs the Measure model and DeferredCollection classes to be loaded first.
+#= require ./measure.js.coffee
+#= require ./deferred_model.js.coffee
+
 ###*
 # Model representing an archived measure. This is a previously upload version of a measure.
 ###
@@ -12,21 +16,21 @@ class Thorax.Models.ArchivedMeasure extends Thorax.Models.Measure
     @set 'patients', new Thorax.Collections.Patients [], _fetched: true
   
   ###*
-  # Deferred return version of the Backbone fetch function.
+  # Deferred return version of the Backbone fetch function. This fetches the entire model from the server.
   # @return {deferred} Deferred object that resolves when the model fetch is completed. Rejects on fail.
   ###
-  fetchDeferred: ->
-    fetchDeferred = $.Deferred()
+  loadModel: ->
+    loadDeferred = $.Deferred()
     if !@_fetched
       @fetch(
         success: (model) ->
           model._fetched = true
-          fetchDeferred.resolve(model)
-        error: (model) -> fetchDeferred.reject(model)
+          loadDeferred.resolve(model)
+        error: (model) -> loadDeferred.reject(model)
       )
     else
-      fetchDeferred.resolve(@)
-    return fetchDeferred
+      loadDeferred.resolve(@)
+    return loadDeferred
 
 
 ###*

--- a/app/assets/javascripts/models/deferred_model.js.coffee
+++ b/app/assets/javascripts/models/deferred_model.js.coffee
@@ -4,21 +4,21 @@
 class Thorax.Models.DeferredModel extends Thorax.Model
   
   ###*
-  # Deferred return version of the Backbone fetch function.
+  # Deferred return version of the Backbone fetch function. This fetches the entire model from the server.
   # @return {deferred} Deferred object that resolves when the model fetch is completed. Rejects on fail.
   ###
-  fetchDeferred: ->
-    fetchDeferred = $.Deferred()
+  loadModel: ->
+    loadDeferred = $.Deferred()
     if !@_fetched
       @fetch(
         success: (model) ->
           model._fetched = true
-          fetchDeferred.resolve(model)
-        error: (model) -> fetchDeferred.reject(model)
+          loadDeferred.resolve(model)
+        error: (model) -> loadDeferred.reject(model)
       )
     else
-      fetchDeferred.resolve(@)
-    return fetchDeferred
+      loadDeferred.resolve(@)
+    return loadDeferred
 
 
 ###*
@@ -28,32 +28,23 @@ class Thorax.Models.DeferredModel extends Thorax.Model
 class Thorax.Collections.DeferredCollection extends Thorax.Collection
   
   ###*
-  # Deferred return version of the Backbone fetch function. This does a shallow fetch. Collection members only have
-  # basic info and need to be fetched.
-  # @return {deferred} Deferred object that resolves when the collection fetch is completed. Rejects on fail.
+  # Load the collection from the server.
+  # @param {boolean} isDeepLoad - Optional. If true then a deep load will occur and all models will be fully loaded.
   ###
-  fetchDeferred: ->
-    fetchDeferred = $.Deferred()
-    if !@_fetched
-      @fetch(
-        success: (collection) -> fetchDeferred.resolve(collection)
-        error: (collection) -> fetchDeferred.reject(collection)
-      )
-    else
-      fetchDeferred.resolve(@)
-    return fetchDeferred
-  
-  ###*
-  # Deferred return 'deep' fetch. This does fetch of the collection then fetches all collection memebers. 
-  # @return {deferred} Deferred object. Resolves when the collection and model fetches are completed. Rejects on fail.
-  ###
-  fetchAll: ->
-    fetchAllDeferred = $.Deferred()
-    @fetchDeferred().then((collection) ->
-      $.when.apply(@, collection.map((model) -> model.fetchDeferred()))
-        .done( ->
-          fetchAllDeferred.resolve(collection))
-        .fail( ->
-          fetchAllDeferred.reject(collection))
-      )
-    return fetchAllDeferred
+  loadCollection: (isDeepLoad = false) ->
+    loadDeferred = $.Deferred()
+    
+    # Fetch the collection listing from the server.
+    @fetch(
+      success: (collection) ->
+        # if we are doing a deep load then load all the elements.
+        if isDeepLoad
+          $.when.apply(@, collection.map((model) -> model.loadModel()))
+            .done( -> loadDeferred.resolve(collection) )
+            .fail( -> loadDeferred.reject(collection) )
+        # if we are not doing a deep load we can resolve the deferred.
+        else
+          loadDeferred.resolve(collection)
+      error: (collection) -> loadDeferred.reject(collection)
+    )
+    return loadDeferred

--- a/app/assets/javascripts/models/measure.js.coffee
+++ b/app/assets/javascripts/models/measure.js.coffee
@@ -124,7 +124,16 @@ class Thorax.Models.Measure extends Thorax.Model
 
     # return field values sorted by title
     _(fields).sortBy (field) -> field.title
-    
+  
+  ###*
+  # Deferred returning function that fetches all the measure related models needed for showing the patient compare view
+  # at a specific measure upload. The deferred resolves with an object containing the following.
+  #  - uploadSummary - The thorax model for the upload summary.
+  #  - beforeMeasure - The ArchivedMeasure model for the before upload side of the compare.
+  #  - afterMeasure - The Measure or ArchivedMeasure model for the after upload side of the compare. 
+  # @param {string} uploadId - The ID of the upload summary we are comparing at.
+  # @return {deferred} Deferred object that resolves when all models are loaded. Rejects on fail.
+  ###
   loadModelsForCompareAtUpload: (uploadId) ->
     loadDeferred = $.Deferred()
     models = { uploadSummaries: @get('upload_summaries'), archivedMeasures: @get('archived_measures') }
@@ -147,6 +156,8 @@ class Thorax.Models.Measure extends Thorax.Model
       .done((afterMeasure) =>
         models.afterMeasure = afterMeasure
         loadDeferred.resolve(models) )
+      # If loading fails on any of these steps the deferred must be rejected.
+      .fail( -> loadDeferred.reject())
     return loadDeferred
 
 class Thorax.Collections.Measures extends Thorax.Collection

--- a/app/assets/javascripts/models/upload_summary.js.coffee
+++ b/app/assets/javascripts/models/upload_summary.js.coffee
@@ -1,3 +1,6 @@
+# This file needs the DeferredModel and DeferredCollection classes to be loaded first.
+#= require ./deferred_model.js.coffee
+
 ###*
 # Model representing an upload summary. This contains info about what changed during a measure upload. This is used in
 # the post upload summary dialog and the measure upload history page.

--- a/app/assets/javascripts/router.js.coffee
+++ b/app/assets/javascripts/router.js.coffee
@@ -87,12 +87,13 @@
 
   renderMeasureUploadHistory: (measureHqmfSetId) ->
     measure = @measures.findWhere(hqmf_set_id: measureHqmfSetId)
-    measure.get('upload_summaries').fetchAll().done( (uploadSummaries) =>
-      @navigationSetup "Measure Upload History - #{measure.get('cms_id')}", 'test-case-history'
-      # @collection = new Thorax.Collections.Patients
-      @mainView.setView new Thorax.Views.MeasureHistoryView model: measure, patients: measure.get('patients'), upload_summaries: uploadSummaries
-      @breadcrumb.viewMeasureHistory(measure)
-    )
+    measure.get('upload_summaries').loadCollection(true)
+      .done( (uploadSummaries) =>
+        @navigationSetup "Measure Upload History - #{measure.get('cms_id')}", 'test-case-history'
+        # @collection = new Thorax.Collections.Patients
+        @mainView.setView new Thorax.Views.MeasureHistoryView model: measure, patients: measure.get('patients'), upload_summaries: uploadSummaries
+        @breadcrumb.viewMeasureHistory(measure)
+        )
 
 
   renderHistoricPatientCompare: (measureHqmfSetId, patientId, uploadId) ->
@@ -101,25 +102,10 @@
     patient = if patientId? then @patients.get(patientId) else new Thorax.Models.Patient {measure_ids: [measure?.get('hqmf_set_id')]}, parse: true
     document.title += " - #{measure.get('cms_id')}" if measure?
     # Deal with getting the archived measure and the calculation snapshot for the patient at measure upload
-    uploadSummaries = measure.get('upload_summaries')
-    archivedMeasures = measure.get('archived_measures')
-    upload_summary = null
-    beforeMeasure = null
-    afterMeasure = null
-    $.when(uploadSummaries.fetchDeferred(), archivedMeasures.fetchDeferred())
-      .then( -> uploadSummaries.findWhere({_id: uploadId}).fetchDeferred() )
-      .then((upsum) ->
-        upload_summary = upsum
-        archivedMeasures.findWhere(_id: upload_summary.get('measure_db_id_pre_upload')).fetchDeferred())
-      .then((before) ->
-        beforeMeasure = before
-        if measure.id isnt upload_summary.get('measure_db_id_post_upload')
-          archivedMeasures.findWhere(_id: upload_summary.get('measure_db_id_post_upload')).fetchDeferred())
-      .then((afterMeasure) => 
-        patientBuilderView = new Thorax.Views.PatientBuilderCompare(model: patient, measure: measure, patients: @patients, measures: @measures, preUploadMeasureVersion: beforeMeasure, uploadSummary: upload_summary, postUploadMeasureVersion: afterMeasure)
-        @mainView.setView patientBuilderView
-        @breadcrumb.viewComparePatient(measure, patient)
-        )
+    measure.loadModelsForCompareAtUpload(uploadId).done( (models) => 
+      patientBuilderView = new Thorax.Views.PatientBuilderCompare(model: patient, measure: measure, patients: @patients, measures: @measures, preUploadMeasureVersion: models.beforeMeasure, uploadSummary: models.uploadSummary, postUploadMeasureVersion: models.afterMeasure)
+      @mainView.setView patientBuilderView
+      @breadcrumb.viewComparePatient(measure, patient) )
 
   # Common setup method used by all routes
   navigationSetup: (title, selectedNav) ->
@@ -148,15 +134,13 @@
     errorDialogView.appendTo('#bonnie')
     errorDialogView.display();
 
-  showMeasureUploadSummary: (summaryId, hqmfSetId) ->
+  showMeasureUploadSummary: (uploadId, hqmfSetId) ->
     measure = @measures.findWhere(hqmf_set_id: hqmfSetId)
-    measure_summaries = measure.get('upload_summaries')
-    measure_summaries.fetchDeferred()
-      .then( ->
-        measure_summaries.findWhere({_id: summaryId}).fetchDeferred()
-        )
-      .then( (upload_summary) ->
-        measureUploadSummaryDialogView = new Thorax.Views.MeasureUploadSummaryDialog model: upload_summary, measure: measure
+    
+    # Shallow load the upload summaries and load the one we need to show.
+    measure.get('upload_summaries').loadCollection()
+      .then( (uploadSummaries) -> uploadSummaries.findWhere({_id: uploadId}).loadModel() )
+      .done( (uploadSummary) ->
+        measureUploadSummaryDialogView = new Thorax.Views.MeasureUploadSummaryDialog model: uploadSummary, measure: measure
         measureUploadSummaryDialogView.appendTo('#bonnie')
-        measureUploadSummaryDialogView.display()
-        )
+        measureUploadSummaryDialogView.display() )

--- a/app/assets/javascripts/views/patient_builder/patient_builder.js.coffee
+++ b/app/assets/javascripts/views/patient_builder/patient_builder.js.coffee
@@ -272,9 +272,9 @@ class Thorax.Views.PatientBuilder extends Thorax.Views.BonnieView
 
   showCompare: ->
     uploadSummaries = @measure.get('upload_summaries')
-    $.when(uploadSummaries.fetchDeferred())
-      .then( -> uploadSummaries.at(0).fetchDeferred() )
-      .then(() => 
+    $.when(uploadSummaries.loadCollection())
+      .then( -> uploadSummaries.at(0).loadModel() )
+      .then( => 
         @patientCompareView = new Thorax.Views.PatientBuilderCompare(model: @model, measure: @measure, patients: @patients, measures: @measures, uploadSummary: uploadSummaries.at(0))
         @patientCompareView.appendTo('#patient-compare-content')
         @$('#patient-compare-dialog').modal('show')


### PR DESCRIPTION
- refacfored fetch methods to loadCollection and loadModel
- moved model fetching for patient compare view to measure class
- renamed xmeasure.js.coffee to archived_measures.js.coffee
  - figured out the asset pipline requires needed for this