### PR TITLE
restructure Measure History Timeline table

### DIFF
--- a/app/assets/javascripts/templates/measure_history_timeline.hbs
+++ b/app/assets/javascripts/templates/measure_history_timeline.hbs
@@ -3,8 +3,8 @@
     <table class="table measure-history-table">
       <thead>
       <tr>
-        <th class="history-upload-title" scope="col">Measure Uploads</th>
-        <th class="history-upload-title" scope="col"><span class="sr-only">Before or After</span></th>
+        <th class="history-upload-title" scope="col">Upload Time</th>
+        <th class="history-upload-title" scope="col">Version</th>
         {{#each patientIndex}}
           <th class="history-patient-header" data-patient-id="{{id}}" scope="col"><div><span><i class="fa fa-user" aria-hidden="true"></i> <a class="history-patient-header-name" title="{{name}}" href="#measures/{{../../hqmf_set_id}}/patients/{{id}}/edit">{{name}}</a></span></div></th>
         {{/each}}
@@ -15,11 +15,17 @@
       {{#each upload_summaries.models}}
         {{! Get the specific population }}
         {{#with (lookup attributes.population_set_summaries ../../populationIndex)}}
-          <tr class="active" data-upload-id="{{../attributes._id}}">
-            <th class="history-upload-header" scope="row">
-              v{{../attributes.hqmf_version_number_post_upload}} @ <small>{{moment ../attributes.uploaded_at "M/D/YY h:mm a"}}</small>
+          <tr data-upload-id="{{../attributes._id}}">
+            <th rowspan="2" scope="row">
+              <p>
+                <i aria-hidden="true" class="fa fa-fw fa-clock-o"></i>
+                <time datetime="{{../attributes.uploaded_at}}">{{moment ../attributes.uploaded_at "M/D/YY h:mm a"}}</time>
+              </p>
+              {{#button "showDiffClicked" data-upload-id=../attributes._id class="btn btn-xs btn-default"}}View Changes{{/button}}
             </th>
-            <th class="history-upload-header" scope="row"><small>After</small></th>
+            <th class="history-upload-header" scope="row">
+              v{{../attributes.hqmf_version_number_post_upload}}
+            </th>
             {{! Loop through each patient in same order as header }}
             {{#each ../../../patientIndex}}
               {{#if (lookup ../patients id)}}
@@ -40,10 +46,10 @@
           {{#if ../attributes.measure_db_id_pre_upload}}
             <tr data-upload-id="{{../upload_id}}">
               <th class="history-upload-header" scope="row">
-                {{#button "showDiffClicked" data-upload-id=../../attributes._id class="btn btn-xs btn-default"}}VIEW CHANGES{{/button}}
-
+                <i aria-hidden="true" class="fa fa-fw fa-long-arrow-up"></i>
+                <span class="sr-only">from</span>
+                 v{{../../attributes.hqmf_version_number_pre_upload}}
               </th>
-              <th scope="row"><small>Before</small></th>
               {{! Loop through each patient in same order as header }}
               {{#each ../../../../patientIndex}}
                 {{#if (lookup ../patients id)}}

--- a/app/assets/javascripts/templates/measure_history_timeline.hbs
+++ b/app/assets/javascripts/templates/measure_history_timeline.hbs
@@ -3,10 +3,10 @@
     <table class="table measure-history-table">
       <thead>
       <tr>
-        <th class="history-upload-title" scope="col">Upload Time</th>
-        <th class="history-upload-title" scope="col">Version</th>
+        <th id="upload-time" class="history-upload-title" scope="col">Upload Time</th>
+        <th id="upload-version" class="history-upload-title" scope="col">Version</th>
         {{#each patientIndex}}
-          <th class="history-patient-header" data-patient-id="{{id}}" scope="col"><div><span><i class="fa fa-user" aria-hidden="true"></i> <a class="history-patient-header-name" title="{{name}}" href="#measures/{{../../hqmf_set_id}}/patients/{{id}}/edit">{{name}}</a></span></div></th>
+          <th id="patient-{{id}}" class="history-patient-header" data-patient-id="{{id}}" scope="col"><div><span><i class="fa fa-user" aria-hidden="true"></i> <a class="history-patient-header-name" title="patient {{name}}" aria-label="patient {{name}}" href="#measures/{{../../hqmf_set_id}}/patients/{{id}}/edit">{{name}}</a></span></div></th>
         {{/each}}
       </tr>
       </thead>
@@ -16,21 +16,21 @@
         {{! Get the specific population }}
         {{#with (lookup attributes.population_set_summaries ../../populationIndex)}}
           <tr data-upload-id="{{../attributes._id}}">
-            <th rowspan="2" scope="row">
+            <th id="upload-{{../attributes._id}}" headers="upload-time" rowspan="2" scope="row">
               <p>
                 <i aria-hidden="true" class="fa fa-fw fa-clock-o"></i>
                 <time datetime="{{../attributes.uploaded_at}}">{{moment ../attributes.uploaded_at "M/D/YY h:mm a"}}</time>
               </p>
               {{#button "showDiffClicked" data-upload-id=../attributes._id class="btn btn-xs btn-default"}}View Changes{{/button}}
             </th>
-            <th class="history-upload-header" scope="row">
+            <th id="version-after-{{../attributes._id}}" headers="upload-version upload-{{../attributes._id}}" class="history-upload-header" scope="row">
               v{{../attributes.hqmf_version_number_post_upload}}
             </th>
             {{! Loop through each patient in same order as header }}
             {{#each ../../../patientIndex}}
               {{#if (lookup ../patients id)}}
                 {{#with (lookup ../../patients id)}}
-                  <td class="history-patient-cell">
+                  <td headers="version-after-{{../../../../attributes._id}} upload-{{../../../../attributes._id}} patient-{{../../id}}" class="history-patient-cell">
                     <a class="history-circle history-{{post_upload_status}}" href="#measures/{{../../../../../hqmf_set_id}}/patients/{{../../id}}/compare/at_upload/{{../../../../attributes._id}}" data-upload-id="{{../../../../attributes._id}}" data-patient-id="{{../../id}}">
                       <span class="sr-only">Patient {{post_upload_status}} after measure upload</span>
                       <i class="fa {{#ifCond post_upload_status '==' 'pass'}}fa-check history-pass-icon{{else}}fa-times history-fail-icon{{/ifCond}}" aria-hidden="true"></i>
@@ -44,17 +44,18 @@
           </tr>
 
           {{#if ../attributes.measure_db_id_pre_upload}}
-            <tr data-upload-id="{{../upload_id}}">
-              <th class="history-upload-header" scope="row">
+            <tr data-upload-id="{{../../attributes._id}}">
+              <th headers="upload-version upload-{{../../attributes._id}}" id="version-before-{{../../attributes._id}}" class="history-upload-header" scope="row">
                 <i aria-hidden="true" class="fa fa-fw fa-long-arrow-up"></i>
-                <span class="sr-only">from</span>
                  v{{../../attributes.hqmf_version_number_pre_upload}}
+                 <span class="sr-only">before v{{../../attributes.hqmf_version_number_post_upload}} upload
+                 </span>
               </th>
               {{! Loop through each patient in same order as header }}
               {{#each ../../../../patientIndex}}
                 {{#if (lookup ../patients id)}}
                   {{#with (lookup ../../patients id)}}
-                    <td class="history-patient-cell">
+                    <td headers="version-before-{{../../../../../attributes._id}} upload-{{../../../../../attributes._id}} patient-{{../../id}}" class="history-patient-cell">
                       <a class="history-circle history-{{pre_upload_status}}" href="#measures/{{../../../../../../hqmf_set_id}}/patients/{{../../id}}/compare/at_upload/{{../../../../../attributes._id}}" data-upload-id="{{../../../../../attributes._id}}" data-patient-id="{{../../id}}">
                         <span class="sr-only">Patient {{pre_upload_status}} before measure upload</span>
                         <i class="fa {{#ifCond pre_upload_status '==' 'pass'}}fa-check history-pass-icon{{else}}fa-times history-fail-icon{{/ifCond}}" aria-hidden="true"></i>

--- a/app/assets/stylesheets/measure_history.less
+++ b/app/assets/stylesheets/measure_history.less
@@ -17,9 +17,31 @@
   font-size: 18px;
 }
 
-table.measure-history-table {
+.measure-history-table {
   width: auto;
   margin-top: 55px;
+
+  thead > tr > th {
+    border-top: none;
+    height: 55px;
+    white-space: nowrap;
+  }
+
+  tbody {
+    > tr:nth-child(2n-1) > td,
+    > tr:nth-child(2n-1) > th {
+      border-top-width: 4px;
+    }
+    
+    > tr > th.history-upload-header {
+      position: relative;
+
+      i {
+        position: absolute;
+        top: -.7em;
+      }
+    }
+  }
 }
 
 .history-circle i.history-pass-icon {
@@ -38,21 +60,6 @@ table.measure-history-table {
 .history-fail {
   background-color: rgba(166, 59, 18, 0.5);
   border-color: #730800;
-}
-
-td.history-patient-cell {
-  /*
-  width: 30px;
-  height: 30px;
-  padding: 3px;
-  */
-}
-
-.measure-history-table > thead > tr > th,
-.measure-history-table > thead > tr > tr {
-  border-top: none;
-  height: 55px;
-  white-space: nowrap;
 }
 
 th.history-patient-header div {


### PR DESCRIPTION
..to be 508 compliant and also better-designed. Tested with JAWS in IE11.

# before 
![image](https://cloud.githubusercontent.com/assets/2136286/20935061/54dab3a0-bbab-11e6-951d-89aae3dc7162.png)

# after
![image](https://cloud.githubusercontent.com/assets/2136286/20934957/f70cbd22-bbaa-11e6-8513-4a8705c18522.png)
