### PR TITLE
Measure History New Controllers Comments and Fixes

### DIFF
--- a/app/controllers/archived_measures_controller.rb
+++ b/app/controllers/archived_measures_controller.rb
@@ -1,16 +1,24 @@
-# Methods for handling archived measures
+##
+# This controller provides access to the ArchivedMeasures. Backbone accesses these functions to lazy
+# load ArchivedMeasures.
+
 class ArchivedMeasuresController < ApplicationController
-  
-  skip_before_action :verify_authenticity_token, only: [:show, :value_sets]
   
   respond_to :json, :js, :html
   
-  # List the measure_db_id for all of versions of a measure using the
-  # hqmf_set_id as the measure identifier (so as to version agnostic)
+  ##
+  # GET /measures/:measure_id/archived_measures
+  #
+  # Lists the measure_db_id for all ArchivedMeasures for a specific measure. This is an index function that only returns
+  # a list of measure_db_ids.
+  
   def index
     begin
-      @measure = Measure.by_user(current_user).only(:hqmf_set_id).find(params[:measure_id])
-      @archived_measures = ArchivedMeasure.by_user(current_user).only(:measure_db_id).where(hqmf_set_id: @measure.hqmf_set_id)
+      # Fetch only hqmf_set_id of the measure so we can use it to grab the archived measures for that hqmf_set_id.
+      @measure = Measure.by_user(current_user).only(:hqmf_set_id, :_id).find(params[:measure_id])
+      
+      # Fetch only the measure_db_id and _id fields of the archived measures.
+      @archived_measures = ArchivedMeasure.by_user(current_user).only(:measure_db_id, :_id).where(hqmf_set_id: @measure.hqmf_set_id)
       
       respond_with @archived_measure do |format|
         format.json { render json: @archived_measures }
@@ -20,7 +28,11 @@ class ArchivedMeasuresController < ApplicationController
     end
   end
   
-  # Show the archived content of a measure at specific point in time
+  ##
+  # GET /measures/:measure_id/archived_measures/:id
+  #
+  # Gets a specific archived measure by its measure_db_id.
+  
   def show
     skippable_fields = [:map_fns, :record_ids, :measure_attributes]
     @archived_measure = ArchivedMeasure.by_user(current_user).where(measure_db_id: params[:id]).first

--- a/app/controllers/archived_measures_controller.rb
+++ b/app/controllers/archived_measures_controller.rb
@@ -14,7 +14,8 @@ class ArchivedMeasuresController < ApplicationController
   
   def index
     begin
-      # Fetch only hqmf_set_id of the measure so we can use it to grab the archived measures for that hqmf_set_id.
+      # Fetch only hqmf_set_id and _id fields of the measure so we can use it to grab the archived measures for that 
+      # hqmf_set_id.
       @measure = Measure.by_user(current_user).only(:hqmf_set_id, :_id).find(params[:measure_id])
       
       # Fetch only the measure_db_id and _id fields of the archived measures.

--- a/app/controllers/upload_summaries_controller.rb
+++ b/app/controllers/upload_summaries_controller.rb
@@ -14,7 +14,8 @@ class UploadSummariesController < ApplicationController
   
   def index
     begin
-      # Fetch only hqmf_set_id of the measure so we can use it to grab the upload summaries for that hqmf_set_id.
+      # Fetch only hqmf_set_id and _id fields of the measure so we can use it to grab the upload summaries for that 
+      # hqmf_set_id.
       @measure = Measure.by_user(current_user).only(:hqmf_set_id, :_id).find(params[:measure_id])
       
       # Fetch only the _id and created_at fields of the upload summaries that have the given hqmf_set_id.

--- a/app/controllers/upload_summaries_controller.rb
+++ b/app/controllers/upload_summaries_controller.rb
@@ -1,12 +1,23 @@
+##
+# This controller provides access to the UploadSumamries. Backbone accesses these functions to lazy
+# load UploadSummaries.
+
 class UploadSummariesController < ApplicationController
-  
-  skip_before_action :verify_authenticity_token, only: [:show, :value_sets]
   
   respond_to :json, :js, :html
   
+  ##
+  # GET /measures/:measure_id/upload_summaries
+  #
+  # Lists the _id and created_at fields for every upload summary for a measure ordered by created_at in a descending
+  # order.
+  
   def index
     begin
-      @measure = Measure.by_user(current_user).only(:hqmf_set_id).find(params[:measure_id])
+      # Fetch only hqmf_set_id of the measure so we can use it to grab the upload summaries for that hqmf_set_id.
+      @measure = Measure.by_user(current_user).only(:hqmf_set_id, :_id).find(params[:measure_id])
+      
+      # Fetch only the _id and created_at fields of the upload summaries that have the given hqmf_set_id.
       @upload_summaries = UploadSummary::MeasureSummary.by_user_and_hqmf_set_id(current_user, @measure.hqmf_set_id).only([:_id, :created_at]).desc(:created_at)
       
       respond_with @upload_summaries do |format|
@@ -17,7 +28,10 @@ class UploadSummariesController < ApplicationController
     end
   end
   
-  
+  ##
+  # GET /measures/:measure_id/upload_summaries/:id
+  #
+  # Gets a specific UploadSummary by its _id.
   def show
     @upload_summary = UploadSummary::MeasureSummary.by_user(current_user).find(params[:id])
     

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,8 +37,11 @@ Bonnie::Application.routes.draw do
         get 'calculate_code'
       end
     end
-    resources :archived_measures
-    resources :upload_summaries
+    
+    # The following two routes are to the measure history member collections. These go to ArchivedMeasuresController and
+    # UploadSummariesController. They are routed as sub URLs to each measure. They only have index and show methods.
+    resources :archived_measures, only: [:index, :show]
+    resources :upload_summaries, only: [:index, :show]
   end
 
   resources :patients do


### PR DESCRIPTION
- Added comments to controllers and new routes
- Removed skip_before_action. This was bad copy pasting.
- Made it so limited attribute database calls include _id.
  - @mayerm94 showed me these being excluded are causing silent errors that appear in tests
- Removed extraneous routes to controller methods that don't exist.