### PR TITLE
there was an error in slugify for measures with only a single populat…

### DIFF
--- a/app/assets/javascripts/helpers.js.coffee
+++ b/app/assets/javascripts/helpers.js.coffee
@@ -75,6 +75,10 @@ Handlebars.registerHelper 'populationName', (population) =>
 ###
 Takes a string and returns a slugified version by replacing any spaces with dashes and making all characters lowercase. This is useful for transforming phrases into strings formatted appropriately for HTML markup. e.g. "Population 2" to "population-2"
 ###
-Handlebars.registerHelper 'slugify', (str) ->
-  slug = str.replace(/[^\w\s]+/gi, '').replace(/ +/gi, '-')
-  return slug.toLowerCase()
+Handlebars.registerHelper 'slugify', (str, defaultStr='') ->
+  str = str || defaultStr # sets str to the default value if str doesn't exist
+  if str
+    slug = str.replace(/[^\w\s]+/gi, '').replace(/ +/gi, '-')
+    return slug.toLowerCase()
+  else
+    return ''

--- a/app/assets/javascripts/templates/measure_upload_summary.hbs
+++ b/app/assets/javascripts/templates/measure_upload_summary.hbs
@@ -7,7 +7,7 @@
           {{#each populationInformation}}
             {{#ifCond totalChanged "!=" 0}}
               <li role="presentation">
-                <a href="#changed-{{slugify populationTitle}}" aria-controls="changed-{{slugify populationTitle}}" role="tab" data-toggle="tab">
+                <a href="#changed-{{slugify populationTitle 'population'}}" aria-controls="changed-{{slugify populationTitle 'population'}}" role="tab" data-toggle="tab">
                   {{populationTitle}}
                 </a>
               </li>
@@ -19,7 +19,7 @@
       <div class="tab-content">
       {{#each populationInformation}} {{! Iterate through the populations}}
         {{#ifCond totalChanged "!=" 0}} {{! We have patients who were affected by the upload}}
-          <div id="changed-{{slugify populationTitle}}" role="tabpanel" class="tab-pane">
+          <div id="changed-{{slugify populationTitle 'population'}}" role="tabpanel" class="tab-pane">
             <table class="table-summary">
               <caption class="sr-only">
                 {{#ifCond ../../../numberOfPopulations ">=" 1}}{{populationTitle}}{{/ifCond}}


### PR DESCRIPTION
…ion. in this case, the measure might not have a population title. this is what got passed into the slugify method. if there was no title, slugify errored out. this change fixes that so that slugify also takes a default value (defaulted to an empty string)