### PR TITLE
Added selenium-webdriver gem and modified Teaspoon config.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,9 +4,6 @@
 # or operating system, you probably want to add a global ignore instead:
 #   git config --global core.excludesfile ~/.gitignore_global
 
-# Ignore teaspoon config file
-/spec/teaspoon_env.rb
-
 # Ignore bundler config
 /.bundle
 

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 # or operating system, you probably want to add a global ignore instead:
 #   git config --global core.excludesfile ~/.gitignore_global
 
+# Ignore teaspoon config file
+/spec/teaspoon_env.rb
+
 # Ignore bundler config
 /.bundle
 

--- a/Gemfile
+++ b/Gemfile
@@ -63,6 +63,7 @@ group :test, :development do
   gem 'capistrano-rails'
   gem 'rvm1-capistrano3', require: false
   gem 'phantomjs'
+  gem 'selenium-webdriver'
 end
 
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -114,6 +114,8 @@ GEM
     capistrano-rails (1.1.3)
       capistrano (~> 3.1)
       capistrano-bundler (~> 1.1)
+    childprocess (0.5.9)
+      ffi (~> 1.0, >= 1.0.11)
     coderay (1.1.0)
     coffee-rails (4.1.0)
       coffee-script (>= 2.2.0)
@@ -151,6 +153,7 @@ GEM
       actionmailer (>= 3.0.4)
       activesupport (>= 3.0.4)
     execjs (2.5.2)
+    ffi (1.9.14)
     foreman (0.78.0)
       thor (~> 0.19.1)
     handlebars_assets (0.16)
@@ -259,6 +262,11 @@ GEM
       capistrano (~> 3.0)
       sshkit (>= 1.2)
     safe_yaml (1.0.4)
+    selenium-webdriver (2.35.1)
+      childprocess (>= 0.2.5)
+      multi_json (~> 1.0)
+      rubyzip (< 1.0.0)
+      websocket (~> 1.0.4)
     simplecov (0.11.2)
       docile (~> 1.1.0)
       json (~> 1.8)
@@ -312,6 +320,7 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff
+    websocket (1.0.7)
 
 PLATFORMS
   ruby
@@ -347,6 +356,7 @@ DEPENDENCIES
   roo
   rubyzip (< 1.0.0)
   rvm1-capistrano3
+  selenium-webdriver
   simplecov
   simplexml_parser!
   sprockets (~> 2.8)
@@ -361,4 +371,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.13.1
+   1.13.6

--- a/spec/teaspoon_env.rb
+++ b/spec/teaspoon_env.rb
@@ -65,7 +65,7 @@ Teaspoon.configure do |config|
     #suite.hook :fixtures, &proc{}
 
     # Determine whether specs loaded into the test harness should be embedded as individual script tags or concatenated
-    # into a single file. Similar to Rails' asset `debug: true` and `config.assets.debug = true` options. By default, 
+    # into a single file. Similar to Rails' asset `debug: true` and `config.assets.debug = true` options. By default,
     # Teaspoon expands all assets to provide more valuable stack traces that reference individual source files.
     suite.expand_assets = true
 
@@ -98,7 +98,7 @@ Teaspoon.configure do |config|
   # Selenium Webdriver: https://github.com/modeset/teaspoon/wiki/Using-Selenium-WebDriver
   # BrowserStack Webdriver: https://github.com/modeset/teaspoon/wiki/Using-BrowserStack-WebDriver
   # Capybara Webkit: https://github.com/modeset/teaspoon/wiki/Using-Capybara-Webkit
-  #config.driver = :phantomjs
+  #config.driver = :selenium
 
   # Specify additional options for the driver.
   #
@@ -106,7 +106,7 @@ Teaspoon.configure do |config|
   # Selenium Webdriver: https://github.com/modeset/teaspoon/wiki/Using-Selenium-WebDriver
   # BrowserStack Webdriver: https://github.com/modeset/teaspoon/wiki/Using-BrowserStack-WebDriver
   # Capybara Webkit: https://github.com/modeset/teaspoon/wiki/Using-Capybara-Webkit
-  #config.driver_options = nil
+  #config.driver_options = {client_driver: :chrome}
 
   # Specify the timeout for the driver. Specs are expected to complete within this time frame or the run will be
   # considered a failure. This is to avoid issues that can arise where tests stall.
@@ -183,5 +183,5 @@ Teaspoon.configure do |config|
     #coverage.branches = nil
     #coverage.lines = nil
   end
-  
+
 end


### PR DESCRIPTION
Added Selenium Webdriver support. In order to use selenium, 2 lines in teaspoon config need to be uncommented. (So we don't break our CI).

Please see the new [Selenium-Testing](https://github.com/projecttacoma/bonnie/wiki/Testing) section on the Testing wiki page.
 