### PR TITLE
Patient Save Refactor

### DIFF
--- a/app/assets/javascripts/models/patient.js.coffee
+++ b/app/assets/javascripts/models/patient.js.coffee
@@ -260,15 +260,10 @@ class Thorax.Models.Patient extends Thorax.Model
       
       # wait for all calculation deferreds to complete
       $.when.apply(@, allCalculations)
-        .done((results...) =>
+        .done( (results...) =>
           # Pull out only the result parts we need to save and replace them on the patient
           @set({ calc_results: _.map(results, @_filterResult) }, { silent: true })
-          @save(null, options)
-          )
-        .fail( ->
-          # TODO: deal with failure situation
-          debugger
-          )
+          @save(null, options) )
       )
 
 class Thorax.Collections.Patients extends Thorax.Collection

--- a/app/assets/javascripts/models/patient.js.coffee
+++ b/app/assets/javascripts/models/patient.js.coffee
@@ -206,6 +206,13 @@ class Thorax.Models.Patient extends Thorax.Model
 
     return errors if errors.length > 0
 
+  ###*
+  # Pulls out only the needed parts of a result from the calculation engine to create the structure needed
+  # to save the calc_results for the specific population set.
+  # @private
+  # @param {Thorax.Models.Result} result - The result from the calculation engine.
+  # @retun {object} The result objet that will be saved.
+  ###
   _filterResult: (result) ->
     filteredResult = {}
     for populationName in Thorax.Models.Measure.allPopulationCodes
@@ -216,7 +223,15 @@ class Thorax.Models.Patient extends Thorax.Model
     filteredResult['measure_id'] = result.measure.get('hqmf_set_id')
     filteredResult['population_index'] = result.population.get('index')
     return filteredResult
-    
+  
+  ###*
+  # Makes changes to the patient, materializes, calculates results for this patient for each
+  # measure they belong to, then saves using the backbone save function.
+  # @param {object} attributes - The attributes to be changed.
+  # @param {object} options - The options. These are passed to backbone's save function. `silent`
+  #   option is obeyed for setting attribute changes. `success` option is useful to know when the
+  #   save has been completed.
+  ###
   calculateAndSave: (attributes, options) ->
     # make the changes
     @set(attributes, if options?.silent then { silent: true } else null)

--- a/app/assets/javascripts/models/patient.js.coffee
+++ b/app/assets/javascripts/models/patient.js.coffee
@@ -236,6 +236,13 @@ class Thorax.Models.Patient extends Thorax.Model
     # make the changes
     @set(attributes, if options?.silent then { silent: true } else null)
     
+    # validate the changes made
+    @validationError = @validate()
+    
+    # return false if there are any validation errors
+    if @validationError?.length > 0
+      return false
+    
     # make sure that materialize happens
     @materialize( =>
       measuresToCalculate = []

--- a/app/assets/javascripts/models/result.js.coffee
+++ b/app/assets/javascripts/models/result.js.coffee
@@ -6,7 +6,7 @@ class Thorax.Models.Result extends Thorax.Model
 
     # Provide a deferred that allows usage of a result to be deferred until it's populated
     @calculation = $.Deferred()
-    if @isPopulated() then @calculation.resolve() else @once 'change:rationale', -> @calculation.resolve()
+    if @isPopulated() then @calculation.resolve(@) else @once 'change:rationale', -> @calculation.resolve(@)
 
     # When a patient changes, is materialized, or is destroyed, we need to respond appropriately
     @listenTo @patient, 'change materialize destroy', =>
@@ -233,4 +233,4 @@ class Thorax.Models.CachedResult extends Thorax.Models.Result
     @patient = null # the result is never calculated so the patient is not needed.
     @calculation = $.Deferred()
     
-    @calculation.resolve()
+    @calculation.resolve(@)

--- a/app/assets/javascripts/views/patient_dashboard/measure_patient_dashboard.js.coffee
+++ b/app/assets/javascripts/views/patient_dashboard/measure_patient_dashboard.js.coffee
@@ -549,7 +549,7 @@ class Thorax.Views.MeasurePopulationPatientDashboard extends Thorax.Views.Bonnie
     $('#ariaalerts').html "Saving edits on this patient."
 
     # Update row on recalculation
-    status = patient.save editedData,
+    status = patient.calculateAndSave editedData,
       success: (model) =>
         result = @populationSet.calculateResult patient
         result.calculationComplete =>

--- a/app/assets/javascripts/views/patient_dashboard/measure_patient_dashboard.js.coffee
+++ b/app/assets/javascripts/views/patient_dashboard/measure_patient_dashboard.js.coffee
@@ -550,6 +550,7 @@ class Thorax.Views.MeasurePopulationPatientDashboard extends Thorax.Views.Bonnie
 
     # Update row on recalculation
     status = patient.calculateAndSave editedData,
+      silent: true
       success: (model) =>
         result = @populationSet.calculateResult patient
         result.calculationComplete =>

--- a/spec/javascripts/models/patient_spec.js.coffee
+++ b/spec/javascripts/models/patient_spec.js.coffee
@@ -68,3 +68,27 @@ describe 'Patient', ->
       errors = @errorsForPatientWithout('deathdate', expired: true)
       expect(errors.length).toEqual 1
       expect(errors[0][2]).toEqual 'Deceased patient must have date of death'
+      
+  describe 'calculateAndSave', ->
+  
+    # Set up fake/spy functions for materialize and backbone save
+    beforeEach ->
+      spyOn(@patient, 'materialize').and
+        .callFake((callback) -> 
+          callback() if callback?)
+          
+      spyOn(@patient, 'save').and
+        .callFake((attrs, options) ->
+          options.success() if options.success?)
+      
+    it 'materializes before saving', (done) ->
+      @patient.calculateAndSave {},
+        success: =>
+          expect(@patient.materialize).toHaveBeenCalled()
+          done()
+    
+    it 'has calc_results for the measure after save', (done) ->
+      @patient.calculateAndSave {},
+        success: =>
+          expect(@patient.get('calc_results')).toBeDefined()
+          done()

--- a/spec/javascripts/views/patient_builder_spec.js.coffee
+++ b/spec/javascripts/views/patient_builder_spec.js.coffee
@@ -11,7 +11,7 @@ describe 'PatientBuilderView', ->
     @firstCriteria.canHaveResult = -> true
     @patientBuilder.render()
     spyOn(@patientBuilder.model, 'materialize')
-    spyOn(@patientBuilder.originalModel, 'save').and.returnValue(true)
+    spyOn(@patientBuilder.originalModel, 'calculateAndSave').and.returnValue(true)
     @$el = @patientBuilder.$el
 
   it 'renders the builder correctly', ->


### PR DESCRIPTION
Added a new function to the patient model for both the patient builder and patient dashboard to use. This function runs the calculations before saving.

Other changes needed for this:
 - Calculation result deferred now to resolves with a reference to the result.
 - Patient materialize now has an optional callback for when it completes.