### PR TITLE
Adds an error log if there is an issue during measure calculation

### DIFF
--- a/lib/ext/measure_upload_summary.rb
+++ b/lib/ext/measure_upload_summary.rb
@@ -87,11 +87,11 @@ module UploadSummary
           begin
             patient.update_calc_results!(current_measure, population_set_index, calculator)
           rescue => e
-            puts "\n\nThere has been an error calculating the patient in measure_upload_summary:get_population_set_summaries"
-            puts "Error for #{current_measure.user.email} measure #{current_measure.cms_id} population set #{population_set_index} patient '#{patient.first} #{patient.last}' (_id: ObjectId('#{patient.id}'))"
-            puts e.message
-            puts e.backtrace.inspect
-            puts "\n\n"
+            logger.error "\n\nThere has been an error calculating the patient in measure_upload_summary:get_population_set_summaries"
+            logger.error "Error for #{current_measure.user.email} measure #{current_measure.cms_id} population set #{population_set_index} patient '#{patient.first} #{patient.last}' (_id: ObjectId('#{patient.id}'))"
+            logger.error e.message
+            logger.error e.backtrace.inspect
+            logger.error "\n\n"
             raise e # want to re-raise the error so any internal handling continues
           end
         end

--- a/lib/ext/measure_upload_summary.rb
+++ b/lib/ext/measure_upload_summary.rb
@@ -84,7 +84,16 @@ module UploadSummary
       current_measure.populations.each_with_index do |population, population_set_index|
         patients.each do |patient|
           patient.has_measure_history = true # update_calc_results does the patient save to persist this change
-          patient.update_calc_results!(current_measure, population_set_index, calculator)
+          begin
+            patient.update_calc_results!(current_measure, population_set_index, calculator)
+          rescue => e
+            puts "\n\nThere has been an error calculating the patient in measure_upload_summary:get_population_set_summaries"
+            puts "Error for #{current_measure.user.email} measure #{current_measure.cms_id} population set #{population_set_index} patient '#{patient.first} #{patient.last}' (_id: ObjectId('#{patient.id}'))"
+            puts e.message
+            puts e.backtrace.inspect
+            puts "\n\n"
+            raise e # want to re-raise the error so any internal handling continues
+          end
         end
       end
 


### PR DESCRIPTION
Currently there is no error handling around a calculation error when an update summary occurs. The appropriate error handling for this will likely require some sort of roll back. This is not implemented in bonnie generally and would not be a capability that could be added before release.

An intermediate solution is to ensure that the error is captured in the log messages.

Note: I could not force an error here. All calculation errors that exist were based on the previous version of the measure and seemed related to the generated calculation logic. When I uploaded a new (or the same) version of the measure, the logic calculation error no longer occurred. However, I did test that the log message was actually captured by adding an log message earlier in the function and the checking that it existed in the logs.