### PR TITLE
Measure history r cv fix

### DIFF
--- a/app/assets/javascripts/models/patient.js.coffee
+++ b/app/assets/javascripts/models/patient.js.coffee
@@ -219,6 +219,8 @@ class Thorax.Models.Patient extends Thorax.Model
       filteredResult[populationName] = result.get(populationName) if result.get(populationName)?
     filteredResult['rationale'] = result.get('rationale') if result.get('rationale')?
     filteredResult['finalSpecifics'] = result.get('finalSpecifics') if result.get('finalSpecifics')?
+    # this is for continuous variable measures. OBSERV actuals are stored in 'values'.
+    filteredResult['values'] = result.get('values') if result.get('values')?
 
     filteredResult['measure_id'] = result.measure.get('hqmf_set_id')
     filteredResult['population_index'] = result.population.get('index')

--- a/lib/ext/measure_upload_summary.rb
+++ b/lib/ext/measure_upload_summary.rb
@@ -130,6 +130,8 @@ module UploadSummary
     field :summary, type: Hash, default: { pass_before: 0, pass_after: 0, fail_before: 0, fail_after: 0 }
     embedded_in :measure_summaries
 
+    # 'rationale' and 'finaleSpecifics' used for logic coloring. 'values' is the stored result for 'OBSERV'
+    # on continuous variable measures.
     ATTRIBUTE_FILTER = HQMF::PopulationCriteria::ALL_POPULATION_CODES + ['rationale', 'finalSpecifics', 'values']
 
     # stores the calculation summary information for a collection of patients in the population summary

--- a/lib/ext/measure_upload_summary.rb
+++ b/lib/ext/measure_upload_summary.rb
@@ -130,7 +130,7 @@ module UploadSummary
     field :summary, type: Hash, default: { pass_before: 0, pass_after: 0, fail_before: 0, fail_after: 0 }
     embedded_in :measure_summaries
 
-    ATTRIBUTE_FILTER = HQMF::PopulationCriteria::ALL_POPULATION_CODES + ['rationale', 'finalSpecifics']
+    ATTRIBUTE_FILTER = HQMF::PopulationCriteria::ALL_POPULATION_CODES + ['rationale', 'finalSpecifics', 'values']
 
     # stores the calculation summary information for a collection of patients in the population summary
     # object. The 'upload_timing' argument determines if the pre-upload calculation information is being

--- a/lib/ext/record.rb
+++ b/lib/ext/record.rb
@@ -178,7 +178,11 @@ class Record
       # add population sets that didn't exist (populations in the measure that don't exist in the expected values)
       added_populations = measure_population_set - expected_value_population_set
       added_populations.each do |population|
-        expected_value_set[population] = 0
+        if population == 'OBSERV'
+          expected_value_set[population] = []
+        else
+          expected_value_set[population] = 0
+        end
       end
 
       # delete populations that no longer exist (populations in the expected values that don't exist in the measure)

--- a/lib/ext/record.rb
+++ b/lib/ext/record.rb
@@ -193,7 +193,7 @@ class Record
   # NOTE: this method assumes that the calculator has already been setup with the
   # measure and population index.
   def update_calc_results!(measure, population_set_index, calculator)
-    populations_to_process = HQMF::PopulationCriteria::ALL_POPULATION_CODES + ['rationale', 'finalSpecifics']
+    populations_to_process = HQMF::PopulationCriteria::ALL_POPULATION_CODES + ['rationale', 'finalSpecifics', 'values']
 
     result = calculator.calculate(self).slice(*populations_to_process)
 
@@ -238,6 +238,10 @@ class Record
 
       filtered_expected_values = expected_value.slice(*HQMF::PopulationCriteria::ALL_POPULATION_CODES)
       filtered_calc_results = calc_result.slice(*HQMF::PopulationCriteria::ALL_POPULATION_CODES)
+
+      # for some reason, OBSERV results are stored in `values` on the calculation object. Converting
+      # to `OBSERV` for comparison.
+      filtered_calc_results['OBSERV'] = calc_result['values'] if calc_result['values']
 
       status = (filtered_expected_values.to_a - filtered_calc_results.to_a).empty?
 

--- a/lib/ext/record.rb
+++ b/lib/ext/record.rb
@@ -197,6 +197,8 @@ class Record
   # NOTE: this method assumes that the calculator has already been setup with the
   # measure and population index.
   def update_calc_results!(measure, population_set_index, calculator)
+    # 'rationale' and 'finaleSpecifics' used for logic coloring. 'values' is the stored result for 'OBSERV'
+    # on continuous variable measures.
     populations_to_process = HQMF::PopulationCriteria::ALL_POPULATION_CODES + ['rationale', 'finalSpecifics', 'values']
 
     result = calculator.calculate(self).slice(*populations_to_process)


### PR DESCRIPTION
Test with CMS111v5

measure history was not properly handling continuous variable measures (measures with OBSERV values). this code makes it so measure history does properly handle those measure types.

Note: there are pre-existing issues with the saved expected OBSERV values populating correctly in the patient builder. This seems to be unrelated to the measure history changes. I've added an internal bug: BONNIE-353.