### PR TITLE
Measure history r upload summaries 500 error

### DIFF
--- a/app/assets/javascripts/router.js.coffee
+++ b/app/assets/javascripts/router.js.coffee
@@ -114,8 +114,8 @@
         @navigationSetup "Measure Upload History - #{measure.get('cms_id')}", 'test-case-history'
         # @collection = new Thorax.Collections.Patients
         @mainView.setView new Thorax.Views.MeasureHistoryView model: measure, patients: measure.get('patients'), upload_summaries: uploadSummaries
-        @breadcrumb.viewMeasureHistory(measure)
-        )
+        @breadcrumb.viewMeasureHistory(measure) )
+      .fail( => @showError title: "Measure History Load Failed", summary: "Historic data failed to load due to a server error." )
 
   renderHistoricPatientCompare: (measureHqmfSetId, patientId, uploadId) ->
     @navigationSetup "Patient Builder", "patient-compare"
@@ -127,10 +127,12 @@
     @breadcrumb.viewComparePatient(measure, patient) 
     
     # Deal with getting the archived measure and the calculation snapshot for the patient at measure upload
-    measure.loadModelsForCompareAtUpload(uploadId).done( (models) => 
-      patientBuilderView = new Thorax.Views.PatientBuilderCompare(model: patient, measure: measure, patients: @patients, measures: @measures, preUploadMeasureVersion: models.beforeMeasure, uploadSummary: models.uploadSummary, postUploadMeasureVersion: models.afterMeasure)
-      @mainView.setView patientBuilderView
-      @breadcrumb.viewComparePatient(measure, patient) )
+    measure.loadModelsForCompareAtUpload(uploadId)
+      .done( (models) => 
+        patientBuilderView = new Thorax.Views.PatientBuilderCompare(model: patient, measure: measure, patients: @patients, measures: @measures, preUploadMeasureVersion: models.beforeMeasure, uploadSummary: models.uploadSummary, postUploadMeasureVersion: models.afterMeasure)
+        @mainView.setView patientBuilderView
+        @breadcrumb.viewComparePatient(measure, patient) )
+      .fail( => @showError title: "Historic Patient Compare Load Failed", summary: "Historic data failed to load due to a server error." )
 
   # Common setup method used by all routes
   navigationSetup: (title, selectedNav) ->

--- a/app/assets/javascripts/views/patient_builder/patient_builder.js.coffee
+++ b/app/assets/javascripts/views/patient_builder/patient_builder.js.coffee
@@ -275,7 +275,7 @@ class Thorax.Views.PatientBuilder extends Thorax.Views.BonnieView
     uploadSummaries = @measure.get('upload_summaries')
     $.when(uploadSummaries.loadCollection())
       .then( -> uploadSummaries.at(0).loadModel() )
-      .then( => 
+      .done( => 
         @patientCompareView = new Thorax.Views.PatientBuilderCompare(model: @model, measure: @measure, patients: @patients, measures: @measures, uploadSummary: uploadSummaries.at(0))
         @patientCompareView.appendTo('#patient-compare-content')
         @$('#patient-compare-dialog').modal('show')
@@ -283,6 +283,7 @@ class Thorax.Views.PatientBuilder extends Thorax.Views.BonnieView
         @$('#patient-compare-dialog').on 'hidden.bs.modal', (event) =>
           @patientCompareView.remove()
         )
+      .fail( -> bonnie.showError title: "Patient Compare Load Failed", summary: "Historic data failed to load due to a server error." )
     
 
 class Thorax.Views.BuilderPopulationLogic extends Thorax.LayoutView

--- a/lib/ext/measure_upload_summary.rb
+++ b/lib/ext/measure_upload_summary.rb
@@ -25,6 +25,9 @@ module UploadSummary
     accepts_nested_attributes_for :population_set_summaries
 
     index "user_id" => 1
+    # Index for descending sort of upload summary creation time. Makes it so mongo doesn't have to sort on query.
+    index "created_at" => -1
+
     scope :by_user, ->(user) { where({'user_id'=>user.id}) }
     scope :by_user_and_hqmf_set_id, ->(user, hqmf_set_id) { where({'user_id'=>user.id, 'hqmf_set_id'=>hqmf_set_id}) }
 


### PR DESCRIPTION
- Added dialog boxes that show up if the loading fails
- Added index for descending order `created_at` on the upload summary model. This makes it so mongo can skip sorting when fetching the upload_summaries 