### PR TITLE
Measure history r upload summary size

### DIFF
--- a/app/assets/javascripts/templates/patient_builder/patient_version_compare.hbs
+++ b/app/assets/javascripts/templates/patient_builder/patient_version_compare.hbs
@@ -10,7 +10,8 @@
       {{view populationLogicViewBefore}}
     {{else}}
       <br><br>
-      <h3>The results of the selected population of the measure are too large to be stored in the database.</h3>
+      <h3>No patient calculation data</h3>
+      <p>The patient calculation data was too large to store in the database.</p>
     {{/if}}
   </div>
   
@@ -24,7 +25,8 @@
       {{view populationLogicViewAfter}}
     {{else}}
       <br><br>
-      <h3>The results of the selected population of the measure are too large to be stored in the database.</h3>
+      <h3>No patient calculation data</h3>
+      <p>The patient calculation data was too large to store in the database.</p>
     {{/if}}
   </div>
 </div>

--- a/lib/ext/measure_upload_summary.rb
+++ b/lib/ext/measure_upload_summary.rb
@@ -102,7 +102,7 @@ module UploadSummary
 
       # store patient calculation information based on the newly uploaded measure
       (0..post_upload_population_set_count-1).each do |population_set_index|
-        if population_set_index >= self.population_set_summaries.count
+        if population_set_index >= self.population_set_summaries.length
           population_set_summary = PopulationSetSummary.new
           self.population_set_summaries << population_set_summary
         else
@@ -126,14 +126,16 @@ module UploadSummary
       upload_summary_size = self.to_json.size
       if upload_summary_size > APP_CONFIG['record']['max_size_in_bytes']
         self.population_set_summaries.each do |population_set_summary|
-          population_set_summary[:patients].each do |patient|
-            patient[1][:pre_upload_results].delete('rationale')
-            patient[1][:pre_upload_results].delete('finalSpecifics')
-            patient[1][:results_exceeds_storage_pre_upload] = true
-            if patient[1].has_key? :post_upload_results
-              patient[1][:post_upload_results].delete('rationale')
-              patient[1][:post_upload_results].delete('finalSpecifics')
-              patient[1][:results_exceeds_storage_post_upload] = true
+          population_set_summary[:patients].each do |patient_id, patient|
+            if patient.has_key? :pre_upload_results
+              patient[:pre_upload_results].delete('rationale')
+              patient[:pre_upload_results].delete('finalSpecifics')
+              patient[:results_exceeds_storage_pre_upload] = true
+            end
+            if patient.has_key? :post_upload_results
+              patient[:post_upload_results].delete('rationale')
+              patient[:post_upload_results].delete('finalSpecifics')
+              patient[:results_exceeds_storage_post_upload] = true
             end
           end # each patient
         end # each population set summary
@@ -179,8 +181,6 @@ module UploadSummary
           end
         end
       end
-
-      save!
     end
 
     protected


### PR DESCRIPTION
made it so there was a size check prior to saving the upload summary so that a large upload summary could store properly.

removed unnecessary call to `save`.

a `count` got changed to `length` because `count` queries the count on the db whereas `length` looks at the length directly present. at this time, this information is not stored in the db (because removed the call to `save`).

also redid wording to indicate that measure history was too big.

**to test**

EITHER: modify the config for max size to be something along the lines of 30000 or use CMS117, create a patient that passes the numer, and create 100 duplicates of that patient. To modify the config size, go to `config/bonnie.yml` and modify `defaults->record->max_size_in_bytes`