### PR TITLE
Remove unnecessary use of waitsForAndRuns in router tests

### DIFF
--- a/spec/javascripts/views/measure_history_display_spec.js.coffee
+++ b/spec/javascripts/views/measure_history_display_spec.js.coffee
@@ -41,6 +41,4 @@ describe 'MeasureHistoryView', ->
     it 'should not find history for non existant measure', ->
       spyOn(bonnie,'showPageNotFound')
       bonnie.renderMeasureUploadHistory('non_existant_hqmf_set_id')
-      waitsForAndRuns( false, 
-        expect(bonnie.showPageNotFound).toHaveBeenCalled(),
-        )
+      expect(bonnie.showPageNotFound).toHaveBeenCalled()

--- a/spec/javascripts/views/patient_bank_spec.coffee
+++ b/spec/javascripts/views/patient_bank_spec.coffee
@@ -29,9 +29,7 @@ describe 'PatientBankView', ->
     spyOn(bonnie,'showPageNotFound')
     patient = @patients.first()
     bonnie.renderHistoricPatientCompare('non_existant_hqmf_set_id', patient.id, 'non_existant_upload_id')
-    waitsForAndRuns( false, 
-      expect(bonnie.showPageNotFound).toHaveBeenCalled(),
-      )
+    expect(bonnie.showPageNotFound).toHaveBeenCalled()
 
   it 'shows list of shared patients', ->
     shared_patients = @patients.where({ is_shared: true })

--- a/spec/javascripts/views/patient_builder_spec.js.coffee
+++ b/spec/javascripts/views/patient_builder_spec.js.coffee
@@ -17,9 +17,7 @@ describe 'PatientBuilderView', ->
   it 'should not open patient builder for non existent measure', ->
     spyOn(bonnie,'showPageNotFound')
     bonnie.renderPatientBuilder('non_existant_hqmf_set_id', @patient.id)
-    waitsForAndRuns( false, 
-      expect(bonnie.showPageNotFound).toHaveBeenCalled(),
-      )
+    expect(bonnie.showPageNotFound).toHaveBeenCalled()
 
   it 'renders the builder correctly', ->
     expect(@$el.find(":input[name='first']")).toHaveValue @patient.get('first')
@@ -356,8 +354,6 @@ describe 'PatientBuilderViewHistory', ->
   it 'should not open historic compare for non existant measure', ->
     spyOn(bonnie,'showPageNotFound')
     bonnie.renderPatientBank('non_existant_hqmf_set_id')
-    waitsForAndRuns( false, 
-      expect(bonnie.showPageNotFound).toHaveBeenCalled(),
-    )
+    expect(bonnie.showPageNotFound).toHaveBeenCalled()
 
   afterEach -> @patientBuilder.remove()

--- a/spec/javascripts/views/patient_dashboard_view_spec.js.coffee
+++ b/spec/javascripts/views/patient_dashboard_view_spec.js.coffee
@@ -27,10 +27,7 @@ describe 'EmptyPatientDashboardView', ->
   it 'should not show patient dashboard for non existant measure', ->
     spyOn(bonnie,'showPageNotFound')
     bonnie.renderPatientDashboard('non_existant_hqmf_set_id')
-    waitsForAndRuns( false, 
-      expect(bonnie.showPageNotFound).toHaveBeenCalled(),
-      )
-
+    expect(bonnie.showPageNotFound).toHaveBeenCalled()
 
 ###
  The following tests should be converted to use webdriver if possible 


### PR DESCRIPTION
waitsForAndRuns was introducing console errors, no synchronous processes that require waiting occurred therefore waitsForAndRuns was not even necessary 