### PR TITLE
Tweaks to data criteria display

### DIFF
--- a/app/assets/javascripts/views/measure_value_sets.js.coffee
+++ b/app/assets/javascripts/views/measure_value_sets.js.coffee
@@ -98,7 +98,7 @@ class Thorax.Views.MeasureValueSets extends Thorax.Views.BonnieView
           # might contain negation rationale
           if criteria.negation_code_list_id? and criteria.negation
             displayed_item_name = @model.valueSets().findWhere({oid: criteria.negation_code_list_id})?.get('display_name') ? criteria.description
-            displayed_item_name = displayed_item_name + " (Negation Rationale)"
+            displayed_item_name = valueSet.name + " (Not Done: " + displayed_item_name + ")"
             # added another property to hold the negation criteria cid because criteria already has cid
             criteria.negationCidHolder = cid: undefined
             dataCriteria.push(@._createValueSet(criteria.negationCidHolder, criteria.negation_code_list_id, displayed_item_name))

--- a/app/assets/javascripts/views/measure_value_sets.js.coffee
+++ b/app/assets/javascripts/views/measure_value_sets.js.coffee
@@ -85,19 +85,28 @@ class Thorax.Views.MeasureValueSets extends Thorax.Views.BonnieView
           # if not supplemental criteria, may contain attributes in "value" property
           # we show attributes that have type="CD", a non-empty title, and non-empty code_list_id
           if criteria.value?.type? and criteria.value.type is "CD" and criteria.value.code_list_id?
-            displayed_item_name = @model.valueSets().findWhere({oid: criteria.value.code_list_id})?.get('display_name') ? criteria.value.title
+            displayed_item_name = @model.valueSets().findWhere({oid: criteria.value.code_list_id})?.get('display_name')
+            displayed_item_name ?= criteria.value.title
             attributesCriteria.push(@._createValueSet(criteria.value, criteria.value.code_list_id, displayed_item_name)) if displayed_item_name
 
           # attributes are also stored in "field_values" property, under a key, e.g. "PRINCIPAL_DIAGNOSIS"
           if criteria.field_values?
             for key, value of criteria.field_values
               if value.type? and value.type is "CD" and value.code_list_id?
-                displayed_item_name = @model.valueSets().findWhere({oid: value.code_list_id})?.get('display_name') ? value.title
+                valueSetDisplayName = @model.valueSets().findWhere({oid: value.code_list_id})?.get('display_name')
+                if value.key_title?
+                  displayed_item_name = value.key_title
+                  displayed_item_name += ': ' + valueSetDisplayName if valueSetDisplayName?
+                else if valueSetDisplayName?
+                  displayed_item_name = valueSetDisplayName
+                else
+                  displayed_item_name = value.title
                 attributesCriteria.push(@._createValueSet(value, value.code_list_id, displayed_item_name)) if displayed_item_name
 
           # might contain negation rationale
           if criteria.negation_code_list_id? and criteria.negation
-            displayed_item_name = @model.valueSets().findWhere({oid: criteria.negation_code_list_id})?.get('display_name') ? criteria.description
+            displayed_item_name = @model.valueSets().findWhere({oid: criteria.negation_code_list_id})?.get('display_name')
+            displayed_item_name ?= criteria.description
             displayed_item_name = valueSet.name + " (Not Done: " + displayed_item_name + ")"
             # added another property to hold the negation criteria cid because criteria already has cid
             criteria.negationCidHolder = cid: undefined

--- a/app/assets/javascripts/views/measure_value_sets.js.coffee
+++ b/app/assets/javascripts/views/measure_value_sets.js.coffee
@@ -97,7 +97,8 @@ class Thorax.Views.MeasureValueSets extends Thorax.Views.BonnieView
 
           # might contain negation rationale
           if criteria.negation_code_list_id? and criteria.negation
-            displayed_item_name = criteria.description + " (Negation Rationale)"
+            displayed_item_name = @model.valueSets().findWhere({oid: criteria.negation_code_list_id})?.get('display_name') ? criteria.description
+            displayed_item_name = displayed_item_name + " (Negation Rationale)"
             # added another property to hold the negation criteria cid because criteria already has cid
             criteria.negationCidHolder = cid: undefined
             dataCriteria.push(@._createValueSet(criteria.negationCidHolder, criteria.negation_code_list_id, displayed_item_name))

--- a/app/assets/javascripts/views/measure_value_sets.js.coffee
+++ b/app/assets/javascripts/views/measure_value_sets.js.coffee
@@ -87,7 +87,7 @@ class Thorax.Views.MeasureValueSets extends Thorax.Views.BonnieView
           if criteria.value?.type? and criteria.value.type is "CD" and criteria.value.code_list_id?
             displayed_item_name = @model.valueSets().findWhere({oid: criteria.value.code_list_id})?.get('display_name')
             displayed_item_name ?= criteria.value.title
-            attributesCriteria.push(@._createValueSet(criteria.value, criteria.value.code_list_id, displayed_item_name)) if displayed_item_name
+            attributesCriteria.push(@._createValueSet(criteria.value, criteria.value.code_list_id, 'Result: ' + displayed_item_name)) if displayed_item_name
 
           # attributes are also stored in "field_values" property, under a key, e.g. "PRINCIPAL_DIAGNOSIS"
           if criteria.field_values?


### PR DESCRIPTION
- revised attribute criteria to use value set display name
- added negation rationale to data criteria

For example, in CMS100V5:
- in addition to `Medication, Administered: Aspirin` (oid 2.16.840.1.113883.3.666.5.626), added is: `Medication, Administered: Aspirin (Negation Rationale)` (oid: 2.16.840.1.113883.3.666.5.1145)
- the attribute value set `Acute Myocardial Infarction (AMI) Grouping Value Set` now shows up as `Acute Myocardial Infarction (AMI)`