### PR TITLE
Updates backend test fixture loading to convert ids to bson objects, …

### DIFF
--- a/lib/tasks/generate_fixtures.rake
+++ b/lib/tasks/generate_fixtures.rake
@@ -1,6 +1,6 @@
 namespace :bonnie do
   namespace :fixtures do
-
+    require_relative "../../test/test_helper.rb"
     ###
     # Generates a set of front end fixtures representing a specific database state.
     #
@@ -178,54 +178,6 @@ namespace :bonnie do
         json.each_pair do |k,v|
           if k.ends_with?("_at")
             json[k] = Time.parse(v)
-          end
-        end
-      end
-    end
-
-    ###
-    # Parses json object for id fields and converts them to bson objects
-    #
-    # Code is derived from set_mongoid_ids function defined in test/test_helper.rb
-    # This version includes checks to convert specific fields into BSON objects for usability purposes.
-    #
-    # json: The json object to parse
-    def set_mongoid_ids(json)
-      if json.kind_of?( Hash)
-        json.each_pair do |k,v|
-          if v && v.kind_of?( Hash )
-            if v["$oid"]
-              json[k] = BSON::ObjectId.from_string(v["$oid"])
-            else
-              set_mongoid_ids(v)
-            end
-          elsif k == '_id' || k == 'bundle_id' || k == 'user_id'
-            json[k] = BSON::ObjectId.from_string(v)
-          end
-        end
-      end
-    end
-
-    ##
-    # Loads fixtures into the active database.
-    # Code is derived from collection_fixtures function found in test/test_helper.rb
-    # Code has been altered to address issues arising from inserting data into an active database with existing data.
-    #
-    # collection_names: array of paths leading to the relevant collections.
-    def collection_fixtures(*collection_names)
-      collection_names.each do |collection|
-        collection_name = collection.split(File::SEPARATOR)[0]
-        Mongoid.default_session[collection_name].drop
-        Dir.glob(File.join(Rails.root, 'test', 'fixtures', collection, '*.json')).each do |json_fixture_file|
-          fixture_json = JSON.parse(File.read(json_fixture_file))
-          if fixture_json.length > 0
-            convert_times(fixture_json)
-            set_mongoid_ids(fixture_json)
-            # Mongoid names collections based off of the default_session argument.
-            # With nested folders,the collection name is “records/X” (for example).
-            # To ensure we have consistent collection names in Mongoid, we need to take the file directory as the collection name.
-            puts "Inserting into collection #{collection}"
-            Mongoid.default_session[collection_name].insert(fixture_json)
           end
         end
       end

--- a/test/fixtures/draft_measures/base_set/CMS128v2.json
+++ b/test/fixtures/draft_measures/base_set/CMS128v2.json
@@ -1,4 +1,4 @@
-{ "_id" : "40280381-3D61-56A7-013E-7AF612436402",
+{ "_id" : "53ce63744d4d32e2cd4b0502",
   "_type" : "Measure",
   "bundle_id" : "5346d238908563511c000001",
   "category" : "Behavioral Health Adult",

--- a/test/fixtures/draft_measures/base_set/CMS138v2.json
+++ b/test/fixtures/draft_measures/base_set/CMS138v2.json
@@ -1,4 +1,4 @@
-{ "_id" : "40280381-3D61-56A7-013E-5CD94A4D64FA",
+{ "_id" : "53ce63744d4d32e2cd4b0501",
   "category" : "Core",
   "cms_id" : "CMS138v2",
   "continuous_variable" : false,

--- a/test/functional/admin_users_controller_test.rb
+++ b/test/functional/admin_users_controller_test.rb
@@ -128,7 +128,7 @@ include Devise::TestHelpers
       assert_equal 4, zip_file.glob(File.join('patients', '**', '*.json')).count
       assert_equal 3, zip_file.glob(File.join('sources', '**', '*.json')).count
       assert_equal 3, zip_file.glob(File.join('sources', '**', '*.metadata')).count
-      assert_equal 27, zip_file.glob(File.join('value_sets', '**', '*.json')).count
+      assert_equal 29, zip_file.glob(File.join('value_sets', '**', '*.json')).count
     end
     File.delete(zip_path)
   end

--- a/test/functional/admin_users_controller_test.rb
+++ b/test/functional/admin_users_controller_test.rb
@@ -17,7 +17,7 @@ include Devise::TestHelpers
     associate_user_with_measures(@user, Measure.all)
     associate_user_with_patients(@user, Record.all)
 
-    @user.measures.first.value_set_oids.uniq.each do |oid|
+    @user.measures.find('53ce63744d4d32e2cd4b0500').value_set_oids.uniq.each do |oid|
       vs = HealthDataStandards::SVS::ValueSet.new(oid: oid)
       vs.concepts << HealthDataStandards::SVS::Concept.new(code_set: 'foo', code:'bar')
       vs.user = @user

--- a/test/functional/measures_controller_test.rb
+++ b/test/functional/measures_controller_test.rb
@@ -118,7 +118,7 @@ include Devise::TestHelpers
     get :show, {id: @measure.id, format: :json}
     assert_response :success
     measure = JSON.parse(response.body)
-    assert_equal @measure.id, measure['id']
+    assert_equal @measure.id, BSON::ObjectId.from_string(measure['id'])
     assert_equal @measure.title, measure['title']
     assert_equal @measure.hqmf_id, measure['hqmf_id']
     assert_equal @measure.hqmf_set_id, measure['hqmf_set_id']

--- a/test/functional/populations_controller_test.rb
+++ b/test/functional/populations_controller_test.rb
@@ -35,12 +35,12 @@ class PopulationsControllerTest  < ActionController::TestCase
   test "update population" do
     sign_in @user
     # This particular test measure has multiple populations, and therefore can have their titles changed
-    measure = Measure.by_user(@user).find("40280381-3D61-56A7-013E-7AF612436402")
+    measure = Measure.by_user(@user).find("53ce63744d4d32e2cd4b0502")
     assert_equal("85 days",measure.populations.at("Populations1".to_i)['title'])
     # Change title of Population1 from "85 days" to "New Title Text"
-    post :update, {measure_id: "40280381-3D61-56A7-013E-7AF612436402",
+    post :update, {measure_id: "53ce63744d4d32e2cd4b0502",
       id: "Populations1", title: "New Title Text"}
-    measure = Measure.by_user(@user).find("40280381-3D61-56A7-013E-7AF612436402")
+    measure = Measure.by_user(@user).find("53ce63744d4d32e2cd4b0502")
     assert_equal("New Title Text",measure.populations.at("Populations1".to_i)['title'])
   end
 

--- a/test/functional/users_controller_test.rb
+++ b/test/functional/users_controller_test.rb
@@ -12,7 +12,7 @@ class UsersControllerTest  < ActionController::TestCase
     @user = User.by_email('bonnie@example.com').first
     associate_user_with_measures(@user, Measure.all)
     associate_user_with_patients(@user, Record.all)
-    @user.measures.first.value_set_oids.uniq.each do |oid|
+    @user.measures.find('53ce63744d4d32e2cd4b0500').value_set_oids.uniq.each do |oid|
       vs = HealthDataStandards::SVS::ValueSet.new(oid: oid)
       vs.concepts << HealthDataStandards::SVS::Concept.new(code_set: 'foo', code:'bar')
       vs.user = @user

--- a/test/functional/users_controller_test.rb
+++ b/test/functional/users_controller_test.rb
@@ -12,14 +12,12 @@ class UsersControllerTest  < ActionController::TestCase
     @user = User.by_email('bonnie@example.com').first
     associate_user_with_measures(@user, Measure.all)
     associate_user_with_patients(@user, Record.all)
-
     @user.measures.first.value_set_oids.uniq.each do |oid|
       vs = HealthDataStandards::SVS::ValueSet.new(oid: oid)
       vs.concepts << HealthDataStandards::SVS::Concept.new(code_set: 'foo', code:'bar')
       vs.user = @user
       vs.save!
     end
-
   end
 
   test "bundle download" do
@@ -37,7 +35,7 @@ class UsersControllerTest  < ActionController::TestCase
       assert_equal 4, zip_file.glob(File.join('patients', '**', '*.json')).count
       assert_equal 3, zip_file.glob(File.join('sources', '**', '*.json')).count
       assert_equal 3, zip_file.glob(File.join('sources', '**', '*.metadata')).count
-      assert_equal 27, zip_file.glob(File.join('value_sets', '**', '*.json')).count
+      assert_equal 29, zip_file.glob(File.join('value_sets', '**', '*.json')).count
     end
     File.delete(zip_path)
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -13,18 +13,49 @@ class ActiveSupport::TestCase
     end
   end
 
+  ###
+  # Parses json object for id fields and converts them to bson objects
+  #
+  # Code is derived from set_mongoid_ids function defined in test/test_helper.rb
+  # This version includes checks to convert specific fields into BSON objects for usability purposes.
+  #
+  # json: The json object to parse
+  def set_mongoid_ids(json)
+    if json.kind_of?( Hash)
+      json.each_pair do |k,v|
+        if v && v.kind_of?( Hash )
+          if v["$oid"]
+            json[k] = BSON::ObjectId.from_string(v["$oid"])
+          else
+            set_mongoid_ids(v)
+          end
+        elsif k == '_id' || k == 'bundle_id' || k == 'user_id'
+          json[k] = BSON::ObjectId.from_string(v)
+        end
+      end
+    end
+  end
+
+  ##
+  # Loads fixtures into the active database.
+  # Code is derived from collection_fixtures function found in test/test_helper.rb
+  # Code has been altered to address issues arising from inserting data into an active database with existing data.
+  #
+  # collection_names: array of paths leading to the relevant collections.
   def collection_fixtures(*collection_names)
     collection_names.each do |collection|
-      Mongoid.default_session[collection].drop
+      collection_name = collection.split(File::SEPARATOR)[0]
+#      Mongoid.default_session[collection_name].drop
       Dir.glob(File.join(Rails.root, 'test', 'fixtures', collection, '*.json')).each do |json_fixture_file|
         fixture_json = JSON.parse(File.read(json_fixture_file))
-        convert_times(fixture_json)
-        set_mongoid_ids(fixture_json)
-        # Mongoid names collections based off of the default_session argument.
-        # With nested folders,the collection name is “records/X” (for example).
-        # To ensure we have consistent collection names in Mongoid, we need to take the file directory as the collection name.
-        collection = collection.split(File::SEPARATOR)[0]
-        Mongoid.default_session[collection].insert(fixture_json)
+        if fixture_json.length > 0
+          convert_times(fixture_json)
+          set_mongoid_ids(fixture_json)
+          # Mongoid names collections based off of the default_session argument.
+          # With nested folders,the collection name is “records/X” (for example).
+          # To ensure we have consistent collection names in Mongoid, we need to take the file directory as the collection name.
+          Mongoid.default_session[collection_name].insert(fixture_json)
+        end
       end
     end
   end
@@ -36,20 +67,6 @@ class ActiveSupport::TestCase
       json.each_pair do |k,v|
         if k.ends_with?("_at")
           json[k] = Time.parse(v)
-        end
-      end
-    end
-  end
-
-  def set_mongoid_ids(json)
-    if json.kind_of?( Hash)
-      json.each_pair do |k,v|
-        if v && v.kind_of?( Hash )
-          if v["$oid"]
-            json[k] = BSON::ObjectId.from_string(v["$oid"])
-          else
-            set_mongoid_ids(v)
-          end
         end
       end
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -16,9 +16,6 @@ class ActiveSupport::TestCase
   ###
   # Parses json object for id fields and converts them to bson objects
   #
-  # Code is derived from set_mongoid_ids function defined in test/test_helper.rb
-  # This version includes checks to convert specific fields into BSON objects for usability purposes.
-  #
   # json: The json object to parse
   def set_mongoid_ids(json)
     if json.kind_of?( Hash)
@@ -38,14 +35,11 @@ class ActiveSupport::TestCase
 
   ##
   # Loads fixtures into the active database.
-  # Code is derived from collection_fixtures function found in test/test_helper.rb
-  # Code has been altered to address issues arising from inserting data into an active database with existing data.
   #
   # collection_names: array of paths leading to the relevant collections.
   def collection_fixtures(*collection_names)
     collection_names.each do |collection|
       collection_name = collection.split(File::SEPARATOR)[0]
-#      Mongoid.default_session[collection_name].drop
       Dir.glob(File.join(Rails.root, 'test', 'fixtures', collection, '*.json')).each do |json_fixture_file|
         fixture_json = JSON.parse(File.read(json_fixture_file))
         if fixture_json.length > 0

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -45,9 +45,8 @@ class ActiveSupport::TestCase
         if fixture_json.length > 0
           convert_times(fixture_json)
           set_mongoid_ids(fixture_json)
-          # Mongoid names collections based off of the default_session argument.
-          # With nested folders,the collection name is “records/X” (for example).
-          # To ensure we have consistent collection names in Mongoid, we need to take the file directory as the collection name.
+          # The first directory layer after test/fixtures is used to determine what type of fixtures they are.
+          # The directory name is used as the name of the collection being inserted into.
           Mongoid.default_session[collection_name].insert(fixture_json)
         end
       end


### PR DESCRIPTION
Updates test infrastructure to address issues raised by updating fixture loading.
Adding logic to convert id fields into bson objects conflicted with existing fixtures.  Those fixtures had to have their id's updated, and the tests that reference them as well.

This had the side effect of fixing a longstanding bug in the tests where value sets were being exported incorrectly due to inconsistencies with ids.