### PR TITLE
made the authodatetime changes to bonnie. no changes were necessary t…

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem 'less-rails'
 gem "non-stupid-digest-assets"
 
 gem 'health-data-standards', :git => 'https://github.com/projectcypress/health-data-standards.git', :branch => 'cql4bonnie'
-gem 'cql_qdm_patientapi', :git => 'https://github.com/projecttacoma/cql_qdm_patientapi.git', :branch => 'cql4bonnie'
+gem 'cql_qdm_patientapi', :git => 'https://github.com/projecttacoma/cql_qdm_patientapi.git', :branch => 'cql4bonnie_QDM_5-2'
 gem 'simplexml_parser', :git => 'https://github.com/projecttacoma/simplexml_parser.git', :branch => 'master'
 gem 'hqmf2js', :git => 'https://github.com/projecttacoma/hqmf2js.git', :branch => 'master'
 gem 'bonnie_bundler', :git => 'https://github.com/projecttacoma/bonnie_bundler.git', :branch => 'cql4bonnie'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,8 +38,8 @@ GIT
 
 GIT
   remote: https://github.com/projecttacoma/cql_qdm_patientapi.git
-  revision: 72a7ba7c3e674257e25a423fa547098b00373ea9
-  branch: cql4bonnie
+  revision: 7c82482835a0ed8af1162dcf5f87ecae19b4fde3
+  branch: cql4bonnie_QDM_5-2
   specs:
     cql_qdm_patientapi (0.1.0)
 

--- a/app/assets/javascripts/models/data_criteria.js.coffee
+++ b/app/assets/javascripts/models/data_criteria.js.coffee
@@ -40,7 +40,7 @@ class Thorax.Models.PatientDataCriteria extends Thorax.Model
   initialize: ->
     @set('codes', new Thorax.Collections.Codes) unless @has 'codes'
     if @get('type') == "medications" then @set('fulfillments', new Thorax.Collection()) unless @has 'fulfillments'
-    if !@isPeriod() then @set('end_date', undefined)
+    if !@isPeriodType() then @set('end_date', undefined)
 
   parse: (attrs) ->
     attrs.criteria_id ||= Thorax.Models.MeasureDataCriteria.generateCriteriaId()
@@ -141,7 +141,7 @@ class Thorax.Models.PatientDataCriteria extends Thorax.Model
 
   # determines if a data criteria has a time period associated with it: it potentially has both
   # a start and end date.
-  isPeriod: ->
+  isPeriodType: ->
     criteriaType = @getCriteriaType()
     # in QDM 5.0, these are all things that are considered 'authored' - they are instances and do not have a time interval.
     criteriaType not in ['assessment_performed', 'assessment_recommended', 'communication_from_patient_to_provider',
@@ -158,29 +158,6 @@ class Thorax.Models.PatientDataCriteria extends Thorax.Model
   isIssue: ->
     criteriaType = @getCriteriaType()
     criteriaType in ['allergy_intolerance', 'diagnosis', 'symptom']
-
-  startLabel: ->
-    if @isPeriod()
-      if @isIssue()
-        'Onset'
-      else
-        'Start'
-    else
-      'Authored'
-
-  stopLabel: ->
-    if @isPeriod()
-      if @isIssue()
-        'Abatement'
-      else
-        'Stop'
-
-  periodLabel: ->
-    if @isPeriod()
-      if @isIssue()
-        'Prevalence Period'
-      else
-        'Relevant Period'
 
   # returns the criteria type including the status or subtype
   # e.g., for "Encounter, Performed", returns "encounter_performed"

--- a/app/assets/javascripts/templates/patient_builder/edit_criteria.hbs
+++ b/app/assets/javascripts/templates/patient_builder/edit_criteria.hbs
@@ -40,16 +40,14 @@
         {{/button}}
       </div>
 
-      {{#if isPeriod}}
-      <div class="row">
+      <div class="row{{#unless isPeriod}} hide{{/unless}}" id="periodLabel">
         <div class="col-md-12">
-          <label class="control-label"><i class="fa fa-clock-o" aria-hidden="true"></i> {{periodLabel}}</label>
+          <label class="control-label"> {{periodLabel}}</label>
         </div>
       </div>
-      {{/if}}
       <div class="row">
-        <div class="form-group col-md-6">
-          <label for="start_date_{{@cid}}" class="control-label">{{#unless isPeriod}}<i class="fa fa-clock-o" aria-hidden="true"></i>{{/unless}} {{startLabel}}<span class="sr-only"> date month/day/year</span></label></label>
+        <div class="form-group col-md-6" id="startControl">
+          <label for="start_date_{{@cid}}" class="control-label"><i class="fa fa-clock-o" aria-hidden="true"></i> <span id='startLabel'>{{startLabel}}</span><span class="sr-only"> date month/day/year</span></label></label>
           <div class="datetime-control">
             <div>
               <input type="text" name="start_date" id="start_date_{{@cid}}" class="date-picker form-control" placeholder="mm/dd/yyyy" data-date-format="mm/dd/yyyy" data-date-keyboard-navigation="false" data-date-autoclose="true">
@@ -62,9 +60,8 @@
           </div>
         </div>
         
-        {{#if isPeriod}}
-        <div class="form-group col-md-6">
-          <label for="end_date_{{@cid}}" class="control-label"> {{stopLabel}}<span class="sr-only"> date month/day/year</span></label>
+        <div class="form-group col-md-6{{#unless isPeriod}} hide{{/unless}}" id="stopControl">
+          <label for="end_date_{{@cid}}" class="control-label"><i class="fa fa-clock-o" aria-hidden="true"></i> <span id='stopLabel'>{{stopLabel}}</span><span class="sr-only"> date month/day/year</span></label>
           <div class="datetime-control">
             <div>
               <input type="text" name="end_date" id="end_date_{{@cid}}" class="date-picker form-control" placeholder="mm/dd/yyyy" data-date-format="mm/dd/yyyy" data-date-keyboard-navigation="false" data-date-autoclose="true"{{#if end_date_is_undefined}} disabled{{/if}}>
@@ -82,7 +79,6 @@
             </label>
           </div>
         </div>
-        {{/if}}
       </div>
 
       <div class="form-group">

--- a/app/assets/javascripts/views/patient_builder/data_criteria.js.coffee
+++ b/app/assets/javascripts/views/patient_builder/data_criteria.js.coffee
@@ -115,10 +115,10 @@ class Thorax.Views.EditCriteriaView extends Thorax.Views.BuilderChildView
       faIcon: @model.faIcon()
       definition_title: definition_title
       canHaveNegation: @model.canHaveNegation()
-      startLabel: @model.startLabel()
-      stopLabel: @model.stopLabel()
-      periodLabel: @model.periodLabel()
-      isPeriod: @model.isPeriod()
+      startLabel: @startLabel(@model.get('negation'))
+      stopLabel: @stopLabel()
+      periodLabel: @periodLabel()
+      isPeriod: @model.isPeriodType() && !@model.get('negation') # if something is negated, it didn't happen so is not a period
 
   # When we serialize the form, we want to convert formatted dates back to times
   events:
@@ -188,6 +188,20 @@ class Thorax.Views.EditCriteriaView extends Thorax.Views.BuilderChildView
 
   toggleNegationSelect: (e) ->
     @$('.negation-code-list').prop('selectedIndex',0).toggleClass('hide')
+
+    if $(e.target).is(':checked')
+      @$('#periodLabel').addClass('hide')
+      @$('#stopControl').addClass('hide')
+    else
+      @$('#periodLabel').removeClass('hide')
+      @$('#stopControl').removeClass('hide')
+    @$('#startLabel').text(@startLabel($(e.target).is(':checked')))
+
+    # make it so end date is always undefined if negation is toggled
+    $end_date_is_undefined = @$('[name="end_date_is_undefined"]')
+    $end_date_is_undefined.prop('checked', true)
+    @toggleEndDateDefinition({target: $end_date_is_undefined})
+
     @triggerMaterialize()
 
   removeCriteria: (e) ->
@@ -208,6 +222,31 @@ class Thorax.Views.EditCriteriaView extends Thorax.Views.BuilderChildView
     e.preventDefault()
     type = @$(e.target).model().get('type')
     $(".#{type}-elements").focus()
+
+
+  startLabel: (negated) ->
+    if @model.isPeriodType() && !negated
+      if @model.isIssue()
+        'Onset'
+      else
+        'Start'
+    else
+      # authored used for instances or negations
+      'Authored'
+
+  stopLabel: ->
+    if @model.isPeriodType()
+      if @model.isIssue()
+        'Abatement'
+      else
+        'Stop'
+
+  periodLabel: ->
+    if @model.isPeriodType()
+      if @model.isIssue()
+        'Prevalence Period'
+      else
+        'Relevant Period'
 
 class Thorax.Views.CodeSelectionView extends Thorax.Views.BuilderChildView
   template: JST['patient_builder/edit_codes']


### PR DESCRIPTION
…o the model. the authordatetime will still be the model's date time. however, for periods types (e.g. encounter performed), this only shows up if negation is selected. in the qdm docs, it is specified that the intent of authordatetime for period types is to be used when the period type never happened but that needs to be recorded.