### PR TITLE
BONNIE-455 fixing CQL based measures to support episode of care

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,7 +31,7 @@ GIT
 
 GIT
   remote: https://github.com/projecttacoma/bonnie_bundler.git
-  revision: a4851ce0ec39df97228f74dea56adf6aeafc024a
+  revision: 73df919155c607002e90680985f5fed21bf61a29
   branch: cql4bonnie
   specs:
     bonnie_bundler (1.0.0)

--- a/app/assets/javascripts/cql_calculator.js.coffee
+++ b/app/assets/javascripts/cql_calculator.js.coffee
@@ -101,7 +101,7 @@
           # Grab CQL result value and adjust for Bonnie
           value = results['patientResults'][patient.id][cql_population]
           if typeof value is 'object' and value.length > 0
-            population_results[popCode] = 1
+            population_results[popCode] = value.length
           else if typeof value is 'boolean' and value
             population_results[popCode] = 1
           else

--- a/app/assets/javascripts/templates/import/finalize_measures.hbs
+++ b/app/assets/javascripts/templates/import/finalize_measures.hbs
@@ -17,22 +17,24 @@
             <h4>{{title}}</h4>
             <input type="hidden" name="{{@cid}}[hqmf_id]" value="{{hqmf_id}}">
             {{#if episode_of_care}}
-              <div class="alert alert-info">Please select which episode of care to use for this measure.</div>
-              <div class="form-group">
-                <label for="episodeSelect_{{@cid}}" class="col-lg-3 control-label">Episode(s) of Care:</label>
-                <div class="col-lg-9">
-                  <select multiple="true" class="form-control" id="episodeSelect_{{@cid}}" name="{{@cid}}[episode_ids][]">
-                    {{#each source_data_criteria.models}}
-                      {{#with attributes}}
-                        {{#if specific_occurrence}}
-                          <option value="{{source_data_criteria}}" id="{{@cid}}">{{description}}</option>
-                        {{/if}}
-                      {{/with}}
-                    {{/each}}
-                  </select>
-                  <span class="">Ctrl+click to select multiple</span>
+              {{#unless cql}}
+                <div class="alert alert-info">Please select which episode of care to use for this measure.</div>
+                <div class="form-group">
+                  <label for="episodeSelect_{{@cid}}" class="col-lg-3 control-label">Episode(s) of Care:</label>
+                  <div class="col-lg-9">
+                    <select multiple="true" class="form-control" id="episodeSelect_{{@cid}}" name="{{@cid}}[episode_ids][]">
+                      {{#each source_data_criteria.models}}
+                        {{#with attributes}}
+                          {{#if specific_occurrence}}
+                            <option value="{{source_data_criteria}}" id="{{@cid}}">{{description}}</option>
+                          {{/if}}
+                        {{/with}}
+                      {{/each}}
+                    </select>
+                    <span class="">Ctrl+click to select multiple</span>
+                  </div>
                 </div>
-              </div>
+              {{/unless}}
             {{/if}}
             {{#ifCond populations.models.length '>' 1}}
               <div class="alert alert-info">Please update the titles for the populations or stratifications.</div>

--- a/app/assets/javascripts/templates/logic/cql_patient_builder_logic.hbs
+++ b/app/assets/javascripts/templates/logic/cql_patient_builder_logic.hbs
@@ -3,12 +3,8 @@
 </br><b><center>CQL Calculation Results:</center></b>
   <p>
     {{#each results}}
-      <label for="{{key}}_actual_check" class="checkbox-inline">{{@key}}</label>
-      {{#if this}}
-        <i class="fa fa-check-square-o default" aria-hidden="true" id="{{key}}_actual_check" name="{{key}}_actual_check"></i>
-      {{else}}
-        <i class="fa fa-square-o default" aria-hidden="true" id="{{key}}_actual_check" name="{{key}}_actual_check"></i>
-      {{/if}}
+      <label for="{{@key}}_val">{{@key}}</label>
+      <span class="default" aria-hidden="true" id="{{@key}}_val" name="{{@key}}_val">{{this}}</span>,
     {{/each}}
   </p>
   </br>

--- a/app/assets/javascripts/templates/measure.hbs
+++ b/app/assets/javascripts/templates/measure.hbs
@@ -20,18 +20,18 @@
     <div class="measure-dsp">
       <h2 class="full-title">{{title}}</h2>
       {{#if episode_of_care}}
+        {{#if isNotCQL}}
         <div class="measure-dsp-title">
           Episode(s) of Care:
         </div>
-          {{#if cql}}
-              This is a CQL measure
-          {{else}}
-            {{#each episodesOfCare tag="ul"}}
-              {{#with attributes}}
-                <li>{{description}}</li>
-              {{/with}}
-            {{/each}}
-          {{/if}}
+          {{#each episodesOfCare tag="ul"}}
+            {{#with attributes}}
+              <li>{{description}}</li>
+            {{/with}}
+          {{/each}}
+        {{else}}
+            Episode of Care Based Measure
+        {{/if}}
         <p></p>
       {{/if}}
 

--- a/app/assets/javascripts/templates/measure.hbs
+++ b/app/assets/javascripts/templates/measure.hbs
@@ -23,11 +23,15 @@
         <div class="measure-dsp-title">
           Episode(s) of Care:
         </div>
-          {{#each episodesOfCare tag="ul"}}
-            {{#with attributes}}
-              <li>{{description}}</li>
-            {{/with}}
-          {{/each}}
+          {{#if cql}}
+              This is a CQL measure
+          {{else}}
+            {{#each episodesOfCare tag="ul"}}
+              {{#with attributes}}
+                <li>{{description}}</li>
+              {{/with}}
+            {{/each}}
+          {{/if}}
         <p></p>
       {{/if}}
 

--- a/app/assets/javascripts/views/measure_view.js.coffee
+++ b/app/assets/javascripts/views/measure_view.js.coffee
@@ -93,7 +93,7 @@ class Thorax.Views.Measure extends Thorax.Views.BonnieView
     @measures = @model.collection
 
   episodesOfCare: ->
-    return null if @model.get('is_cql')
+    return null if @model.get('cql')
     @model.get('source_data_criteria').filter((sdc) => sdc.get('source_data_criteria') in @model.get('episode_ids'))
 
   updateMeasure: (e) ->

--- a/app/assets/javascripts/views/measure_view.js.coffee
+++ b/app/assets/javascripts/views/measure_view.js.coffee
@@ -93,6 +93,7 @@ class Thorax.Views.Measure extends Thorax.Views.BonnieView
     @measures = @model.collection
 
   episodesOfCare: ->
+    return null if @model.get('is_cql')
     @model.get('source_data_criteria').filter((sdc) => sdc.get('source_data_criteria') in @model.get('episode_ids'))
 
   updateMeasure: (e) ->

--- a/app/assets/javascripts/views/measure_view.js.coffee
+++ b/app/assets/javascripts/views/measure_view.js.coffee
@@ -50,13 +50,9 @@ class Thorax.Views.Measure extends Thorax.Views.BonnieView
       isNotCQL: !@model.has('cql') # Hide certain features in handlebars if the measure is cql.
 
   initialize: ->
+    @measureViz = Bonnie.viz.measureVisualzation().fontSize("1.25em").rowHeight(20).rowPadding({top: 14, right: 6}).dataCriteria(@model.get("data_criteria")).measurePopulation(@population).measureValueSets(@model.valueSets())
     if @model.has('cql')
       populationLogicView = new Thorax.Views.CqlLogic(model: @model)
-    else
-      populationLogicView = new Thorax.Views.PopulationLogic(model: @population)
-    @measureViz = Bonnie.viz.measureVisualzation().fontSize("1.25em").rowHeight(20).rowPadding({top: 14, right: 6}).dataCriteria(@model.get("data_criteria")).measurePopulation(@population).measureValueSets(@model.valueSets())
-
-    if @model.has('cql')
       if @populations.length > 1 # CQL Measure with multiple populations
         @logicView = new Thorax.Views.CqlPopulationsLogic model: @model, collection: @populations
         @logicView.setView populationLogicView
@@ -64,6 +60,7 @@ class Thorax.Views.Measure extends Thorax.Views.BonnieView
         # CQL measure with one population
         @logicView = populationLogicView
     else
+      populationLogicView = new Thorax.Views.PopulationLogic(model: @population)
       # display layout view when there are multiple populations; otherwise, just show logic view
       if @populations.length > 1
         @logicView = new Thorax.Views.PopulationsLogic collection: @populations
@@ -93,7 +90,7 @@ class Thorax.Views.Measure extends Thorax.Views.BonnieView
     @measures = @model.collection
 
   episodesOfCare: ->
-    return null if @model.get('cql')
+    return null unless @model.has('episode_ids')
     @model.get('source_data_criteria').filter((sdc) => sdc.get('source_data_criteria') in @model.get('episode_ids'))
 
   updateMeasure: (e) ->

--- a/app/assets/javascripts/views/patient_builder/data_criteria.js.coffee
+++ b/app/assets/javascripts/views/patient_builder/data_criteria.js.coffee
@@ -462,7 +462,7 @@ class Thorax.Views.EditCriteriaValueView extends Thorax.Views.BuilderChildView
     @showAddCodes = false
     @render()
 
- class Thorax.Views.EditCriteriaReferenceView extends Thorax.Views.EditCriteriaValueView
+class Thorax.Views.EditCriteriaReferenceView extends Thorax.Views.EditCriteriaValueView
   className: -> "#{if @fieldValue then 'field-' else ''}value-formset"
 
   template: JST['patient_builder/edit_reference']

--- a/app/controllers/measures_controller.rb
+++ b/app/controllers/measures_controller.rb
@@ -267,11 +267,14 @@ class MeasuresController < ApplicationController
     measure_finalize_data = params.values.select {|p| p['hqmf_id']}.uniq
     measure_finalize_data.each do |data|
       measure = Measure.by_user(current_user).where(hqmf_id: data['hqmf_id']).first
-      measure.update_attributes({needs_finalize: false, episode_ids: data['episode_ids']})
+      is_cql = measure == nil
+      measure = CqlMeasure.by_user(current_user).where(hqmf_id: data['hqmf_id']).first if is_cql
+      measure['needs_finalize'] = false
+      measure['episode_ids'] = data['episode_ids'] if !is_cql
       measure.populations.each_with_index do |population, population_index|
         population['title'] = data['titles']["#{population_index}"] if (data['titles'])
       end
-      measure.generate_js(clear_db_cache: true)
+      measure.generate_js(clear_db_cache: true) if !is_cql
       measure.save!
     end
     redirect_to root_path

--- a/app/controllers/measures_controller.rb
+++ b/app/controllers/measures_controller.rb
@@ -280,7 +280,7 @@ class MeasuresController < ApplicationController
         population['title'] = data['titles']["#{population_index}"] if (data['titles'])
       end
       # CQL-based measures don't have episode_ids field
-      if !is_cql
+      unless is_cql
         measure['episode_ids'] = data['episode_ids']
         measure.generate_js(clear_db_cache: true)
       end

--- a/app/controllers/measures_controller.rb
+++ b/app/controllers/measures_controller.rb
@@ -61,98 +61,82 @@ class MeasuresController < ApplicationController
     begin
       # Is this a CQL measure, or a CQL MAT export?
       # TODO: This will need to change when we know what the MAT will be exporting!
+      is_cql = false
       if extension == '.cql' || (extension == '.zip' && Measures::CqlLoader.mat_cql_export?(params[:measure_file]))
+        is_cql = true
         measure = Measures::MATLoader.load(params[:measure_file], current_user, measure_details, params[:vsac_username], params[:vsac_password]) # overwrite_valuesets=true, cache=false, includeDraft=true
 
         existing = CqlMeasure.by_user(current_user).where(hqmf_set_id: measure.hqmf_set_id)
-        if existing.count > 0
+        if existing.count > 1
           flash[:error] = {title: "Error Loading Measure", summary: "A version of this measure is already loaded.", body: "You have a version of this measure loaded already.  Try deleting that measure and re-uploading it."}
           redirect_to "#{root_path}##{params[:redirect_route]}"
           return
+        end
+      else
+        is_update = false
+        if (params[:hqmf_set_id] && !params[:hqmf_set_id].empty?)
+          is_update = true
+          existing = Measure.by_user(current_user).where(hqmf_set_id: params[:hqmf_set_id]).first
+          measure_details['type'] = existing.type
+          measure_details['episode_of_care'] = existing.episode_of_care
+          if measure_details['episode_of_care']
+            episodes = params["eoc_#{existing.hqmf_set_id}"]
+            if episodes && episodes['episode_ids'] && !episodes['episode_ids'].empty?
+              measure_details['episode_ids'] = episodes['episode_ids']
+            else
+              measure_details['episode_ids'] = existing.episode_ids
+            end
+          end
+
+          measure_details['population_titles'] = existing.populations.map {|p| p['title']} if existing.populations.length > 1
+        end
+
+        if extension == '.xml'
+          includeDraft = params[:include_draft] == 'true'
+          effectiveDate = nil
+          unless includeDraft
+            effectiveDate = Date.strptime(params[:vsac_date],'%m/%d/%Y').strftime('%Y%m%d')
+          end
+          measure = Measures::SourcesLoader.load_measure_xml(params[:measure_file].tempfile.path, current_user, params[:vsac_username], params[:vsac_password], measure_details, true, false, effectiveDate, includeDraft, get_ticket_granting_ticket) # overwrite_valuesets=true, cache=false, includeDraft=true
         else
-          current_user.measures << measure
-          current_user.save!
-          measure.save!
+          measure = Measures::MATLoader.load(params[:measure_file], current_user, measure_details)
         end
 
-        # rebuild the users patients if set to do so
-        if params[:rebuild_patients] == "true"
-          Record.by_user(current_user).each do |r|
-            Measures::PatientBuilder.rebuild_patient(r)
-            r.save!
+        if (!is_update)
+          existing = Measure.by_user(current_user).where(hqmf_set_id: measure.hqmf_set_id)
+          if existing.count > 1
+            measure.delete
+            flash[:error] = {title: "Error Loading Measure", summary: "A version of this measure is already loaded.", body: "You have a version of this measure loaded already.  Either update that measure with the update button, or delete that measure and re-upload it."}
+            redirect_to "#{root_path}##{params[:redirect_route]}"
+            return
+          end
+        else
+          if existing.hqmf_set_id != measure.hqmf_set_id
+            measure.delete
+            flash[:error] = {title: "Error Updating Measure", summary: "The update file does not match the measure.", body: "You have attempted to update a measure with a file that represents a different measure.  Please update the correct measure or upload the file as a new measure."}
+            redirect_to "#{root_path}##{params[:redirect_route]}"
+            return
           end
         end
 
-        redirect_to "#{root_path}##{params[:redirect_route]}"
-    #    create_cql(measure_details, params)
-        return
-      end
-
-      is_update = false
-      if (params[:hqmf_set_id] && !params[:hqmf_set_id].empty?)
-        is_update = true
-        existing = Measure.by_user(current_user).where(hqmf_set_id: params[:hqmf_set_id]).first
-        measure_details['type'] = existing.type
-        measure_details['episode_of_care'] = existing.episode_of_care
-        if measure_details['episode_of_care']
-          episodes = params["eoc_#{existing.hqmf_set_id}"]
-          if episodes && episodes['episode_ids'] && !episodes['episode_ids'].empty?
-            measure_details['episode_ids'] = episodes['episode_ids']
-          else
-            measure_details['episode_ids'] = existing.episode_ids
-          end
-        end
-
-        measure_details['population_titles'] = existing.populations.map {|p| p['title']} if existing.populations.length > 1
-      end
-
-  #  begin
-      if extension == '.xml'
-        includeDraft = params[:include_draft] == 'true'
-        effectiveDate = nil
-        unless includeDraft
-          effectiveDate = Date.strptime(params[:vsac_date],'%m/%d/%Y').strftime('%Y%m%d')
-        end
-        measure = Measures::SourcesLoader.load_measure_xml(params[:measure_file].tempfile.path, current_user, params[:vsac_username], params[:vsac_password], measure_details, true, false, effectiveDate, includeDraft, get_ticket_granting_ticket) # overwrite_valuesets=true, cache=false, includeDraft=true
-      else
-        measure = Measures::MATLoader.load(params[:measure_file], current_user, measure_details)
-      end
-
-      if (!is_update)
-        existing = Measure.by_user(current_user).where(hqmf_set_id: measure.hqmf_set_id)
-        if existing.count > 1
+        if measure_details['episode_of_care'] && measure.data_criteria.values.select {|d| d['specific_occurrence']}.empty?
           measure.delete
-          flash[:error] = {title: "Error Loading Measure", summary: "A version of this measure is already loaded.", body: "You have a version of this measure loaded already.  Either update that measure with the update button, or delete that measure and re-upload it."}
+          flash[:error] = {title: "Error Loading Measure", summary: "An episode of care measure requires at least one specific occurrence for the episode of care.", body: "You have loaded the measure as an episode of care measure.  Episode of care measures require at lease one data element that is a specific occurrence.  Please add a specific occurrence data element to the measure logic."}
           redirect_to "#{root_path}##{params[:redirect_route]}"
           return
         end
-      else
-        if existing.hqmf_set_id != measure.hqmf_set_id
+
+        # exclude patient birthdate and expired OIDs used by SimpleXML parser for AGE_AT handling and bad oid protection in missing VS check
+        missing_value_sets = (measure.as_hqmf_model.all_code_set_oids - measure.value_set_oids - ['2.16.840.1.113883.3.117.1.7.1.70', '2.16.840.1.113883.3.117.1.7.1.309'])
+        if missing_value_sets.length > 0
           measure.delete
-          flash[:error] = {title: "Error Updating Measure", summary: "The update file does not match the measure.", body: "You have attempted to update a measure with a file that represents a different measure.  Please update the correct measure or upload the file as a new measure."}
+          flash[:error] = {title: "Measure is missing value sets", summary: "The measure you have tried to load is missing value sets.", body: "The measure you are trying to load is missing value sets.  Try re-packaging and re-exporting the measure from the Measure Authoring Tool.  The following value sets are missing: [#{missing_value_sets.join(', ')}]"}
           redirect_to "#{root_path}##{params[:redirect_route]}"
           return
         end
+
+        existing.delete if (existing && is_update)
       end
-
-      if measure_details['episode_of_care'] && measure.data_criteria.values.select {|d| d['specific_occurrence']}.empty?
-        measure.delete
-        flash[:error] = {title: "Error Loading Measure", summary: "An episode of care measure requires at least one specific occurrence for the episode of care.", body: "You have loaded the measure as an episode of care measure.  Episode of care measures require at lease one data element that is a specific occurrence.  Please add a specific occurrence data element to the measure logic."}
-        redirect_to "#{root_path}##{params[:redirect_route]}"
-        return
-      end
-
-      # exclude patient birthdate and expired OIDs used by SimpleXML parser for AGE_AT handling and bad oid protection in missing VS check
-      missing_value_sets = (measure.as_hqmf_model.all_code_set_oids - measure.value_set_oids - ['2.16.840.1.113883.3.117.1.7.1.70', '2.16.840.1.113883.3.117.1.7.1.309'])
-      if missing_value_sets.length > 0
-        measure.delete
-        flash[:error] = {title: "Measure is missing value sets", summary: "The measure you have tried to load is missing value sets.", body: "The measure you are trying to load is missing value sets.  Try re-packaging and re-exporting the measure from the Measure Authoring Tool.  The following value sets are missing: [#{missing_value_sets.join(', ')}]"}
-        redirect_to "#{root_path}##{params[:redirect_route]}"
-        return
-      end
-
-      existing.delete if (existing && is_update)
-
     rescue Exception => e
       if params[:measure_file]
         measure.delete if measure
@@ -210,7 +194,7 @@ class MeasuresController < ApplicationController
         end
       end
     else
-      measure.needs_finalize = (measure_details['episode_of_care'] || measure.populations.size > 1)
+      measure.needs_finalize = (!is_cql && measure_details['episode_of_care']) || measure.populations.size > 1
       if measure.populations.size > 1
         strat_index = 1
         measure.populations.each do |population|
@@ -223,9 +207,11 @@ class MeasuresController < ApplicationController
 
     end
 
-    Measures::ADEHelper.update_if_ade(measure)
+    if !is_cql
+      Measures::ADEHelper.update_if_ade(measure)
 
-    measure.generate_js
+      measure.generate_js
+    end
 
     measure.save!
 

--- a/app/controllers/measures_controller.rb
+++ b/app/controllers/measures_controller.rb
@@ -209,7 +209,7 @@ class MeasuresController < ApplicationController
 
     end
 
-    if !is_cql
+    unless is_cql
       Measures::ADEHelper.update_if_ade(measure)
 
       measure.generate_js


### PR DESCRIPTION
- changed placeholder checkboxes in patient builder to text boxes, for simplicity, as JB says these are going away when we add highlighting
 - put in temporary "This is a CQL measure" description for episodes of care at top of measure view - JB, Kristian, and Chris theorize we might be able to show actual CQL statements here

 ----------------------------------------------
 Need associated changes in bonnie_bundler
 ----------------------------------------------

Tested loading CQL and HQMF measures. It is desired behavior to skip the finalize dialog for CQL-based measures with episodes of care