### PR TITLE
Fix OBSERV showing failure in patient dashboard

### DIFF
--- a/app/assets/javascripts/models/patient_dashboard_patient.js.coffee
+++ b/app/assets/javascripts/models/patient_dashboard_patient.js.coffee
@@ -66,7 +66,10 @@ class Thorax.Models.PatientDashboardPatient extends Thorax.Model
     expectedResults = {}
     expected_model = @patient.get('expected_values').findWhere(measure_id: @measure.get('hqmf_set_id'), population_index: @populationSet.get('index'))
     for population in @populations
-      expectedResults[population] = expected_model.get(population)
+      if population == 'OBSERV'
+        expectedResults[population] = expected_model.get(population)?.toString()
+      else
+        expectedResults[population] = expected_model.get(population)
     expectedResults
 
   ###
@@ -78,8 +81,6 @@ class Thorax.Models.PatientDashboardPatient extends Thorax.Model
       if population == 'OBSERV'
         if 'values' of @patientResult && population of @patientResult['rationale']
           actualResults[population] = @patientResult['values'].toString()
-        else
-          actualResults[population] = 0
       else
         actualResults[population] = @patientResult[population]
     actualResults

--- a/app/assets/javascripts/views/patient_dashboard/measure_patient_dashboard.js.coffee
+++ b/app/assets/javascripts/views/patient_dashboard/measure_patient_dashboard.js.coffee
@@ -387,8 +387,8 @@ class Thorax.Views.MeasurePopulationPatientDashboard extends Thorax.Views.Bonnie
       td = $('td:nth-child(' + actualIndex + ')', nodes[0])
       patient = row.patient
       expected = row.expected
-      patient_results = @getPatientResultsById(patient.id)
-      if expected[population] != patient_results[population]
+      actual = row.actual
+      if expected[population] != actual[population]
         td.addClass('warn')
       else
         td.removeClass('warn')


### PR DESCRIPTION
made actual results check for observ. have actual results follow the same behavior as expected results here: you make this into a string. If there are multiple values, it will look like '120,60'. Not a perfect solution but it seems to work. Then use the 'actual' that has been recorded on the patient rather than recalculating the patient. this ensures we're using the same formatting.