### PR TITLE
Initial implementation of client side error handling using Costanza

### DIFF
--- a/app/assets/javascripts/application.js.coffee
+++ b/app/assets/javascripts/application.js.coffee
@@ -32,18 +32,22 @@
 #= require jquery-color/jquery.color
 #= require bootstrap-file-input/bootstrap.file-input
 #= require MutationObserver-shim/dist/mutationobserver.min
-#= require cql_qdm_patientapi
-#= require ace-builds/src/ace.js
-#= require ace-builds/src/ext-language_tools.js
-#= require ace-builds/src/mode-cql_highlight_rules.js
-#= require ace-builds/src/mode-cql.js
-#= require ace-builds/src/theme-chrome.js
+#
+#= require costanza/js/costanza
+#= require costanza/thorax
 #
 #= require datatables.net/js/jquery.dataTables
 #= require datatables.net-bs/js/dataTables.bootstrap
 #= require datatables.net-fixedcolumns/js/dataTables.fixedColumns
 #= require jquery.scrollTo/jquery.scrollTo
 #= require eonasdan-bootstrap-datetimepicker/build/js/bootstrap-datetimepicker.min
+#
+#= require cql_qdm_patientapi
+#= require ace-builds/src/ace.js
+#= require ace-builds/src/ext-language_tools.js
+#= require ace-builds/src/mode-cql_highlight_rules.js
+#= require ace-builds/src/mode-cql.js
+#= require ace-builds/src/theme-chrome.js
 #
 #= require helpers
 #= require_tree ./templates
@@ -54,7 +58,6 @@
 #= require measure_libraries
 #= require_self
 #= require_tree .
-
 
 # Make all JST templates available as Handlebars templates, so the {{template 'foo'}} helper works as expected
 Handlebars.templates[name] = template for name, template of JST

--- a/app/assets/javascripts/calculator.js.coffee
+++ b/app/assets/javascripts/calculator.js.coffee
@@ -66,10 +66,9 @@
           result.state = 'unstarted'
           return
         result.state = 'complete'
-        try
+        # Capture calculation errors that may arise and handle them using Costanza
+        Costanza.run 'measure-calculation', {cms_id: result.measure.get('cms_id')}, () =>
           result.set @calculator[calcKey](patient.toJSON())
-        catch error
-          bonnie.showError({title: "Measure Calculation Error", summary: "There was an error calculating the measure #{result.measure.get('cms_id')}.", body: "One of the data elements associated with the measure is causing an issue.  Please review the elements associated with the measure to verify that they are all constructed properly.  Error message: #{error.message}."})
 
       setTimeout deferredCalculation, 0
 

--- a/app/assets/javascripts/error_handler.js.coffee
+++ b/app/assets/javascripts/error_handler.js.coffee
@@ -2,7 +2,7 @@
 Costanza.init (info, rawError) ->
   $.ajax
     url: 'application/client_error'
-    method: 'GET'
+    method: 'POST'
     dataType: 'json'
     data: info
     success: (message) ->

--- a/app/assets/javascripts/error_handler.js.coffee
+++ b/app/assets/javascripts/error_handler.js.coffee
@@ -1,11 +1,17 @@
 # Initialize Costanza front-end error handling/tracking
 Costanza.init (info, rawError) ->
-  $.ajax
-    url: 'application/client_error'
-    method: 'POST'
-    dataType: 'json'
-    data: info
-    success: (message) ->
-      bonnie.showError(message) if message
-    error: (info) ->
-      bonnie.showError({'body': info.status + ': ' + info.statusText}) if info
+  # Ignore mirrored Costanza error messages (we have already handled these).
+  # This check stops doubled error message popups from appearing.
+  unless /Costanza/i.test rawError.toString()
+    $.ajax
+      url: 'application/client_error'
+      method: 'POST'
+      dataType: 'json'
+      data: info
+      success: (message) ->
+        bonnie.showError(message) if message
+      error: (jqXHR, textStatus, errorThrown) ->
+        connectionError =
+          title: 'Connection Issues'
+          body: 'An error occurred in Bonnie. You may be experiencing network connectivity issues. Please check your network connection and try reloading Bonnie.'
+        bonnie.showError(connectionError)

--- a/app/assets/javascripts/error_handler.js.coffee
+++ b/app/assets/javascripts/error_handler.js.coffee
@@ -1,0 +1,11 @@
+# Initialize Costanza front-end error handling/tracking
+Costanza.init (info, rawError) ->
+  $.ajax
+    url: 'application/client_error'
+    method: 'GET'
+    dataType: 'json'
+    data: info
+    success: (message) ->
+      bonnie.showError(message) if message
+    error: () ->
+      console.error(info) if info

--- a/app/assets/javascripts/error_handler.js.coffee
+++ b/app/assets/javascripts/error_handler.js.coffee
@@ -7,5 +7,5 @@ Costanza.init (info, rawError) ->
     data: info
     success: (message) ->
       bonnie.showError(message) if message
-    error: () ->
-      console.error(info) if info
+    error: (info) ->
+      bonnie.showError({'body': info.status + ': ' + info.statusText}) if info

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -30,6 +30,14 @@ class ApplicationController < ActionController::Base
     end
   end
 
+  def client_error
+    # Grab better description of the given message and return as json
+    error_message = ErrorHelper.describe_error(params, Exception.new(params), request)
+    respond_to do |format|
+      format.json { render json: error_message }
+    end
+  end
+
   protected
     def log_additional_data
       request.env["exception_notifier.exception_data"] = {

--- a/app/helpers/error_helper.rb
+++ b/app/helpers/error_helper.rb
@@ -1,0 +1,45 @@
+# Helper module for handling client side errors.
+module ErrorHelper
+  # Handles the given error by categorizing it based on the included
+  # section, as defined in the front end code. If the given error can
+  # not be categorized, no error message will be shown (but an email
+  # will still be sent to the development team, if on production).
+  def self.describe_error(error_info, exception, request)
+    # Do not process errors if their message includes Costanza. These are
+    # errors passed up to Thorax.onException from Costanza, which we do
+    # not care about (we've already handled them).
+    return if error_info[:msg].include? 'Costanza'
+
+    # If enabled, send an email to the development team containing
+    # information about this error.
+    ErrorHelper.send_email(error_info, exception, request) if APP_CONFIG['enable_client_error_email']
+
+    case error_info[:section]
+    # Handles errors that arise when generating the human readable logic from
+    # the measure data criteria.
+    when /data-criteria-logic-view-creation/
+      {
+        title: 'Measure Logic Error',
+        summary: 'Error Building Measure Logic View',
+        body: 'You have imported a measure that contains logic that cannot be rendered. This is usually caused by errors in the measure logic. Please review the measure logic for correctness, and re-upload the measure.<br>Data criteria reference that failed: <b>' + error_info[:reference] + '</b>'
+      }
+    # Handles errors that arise when trying to calculate a measure against
+    # patients.
+    when /measure-calculation/
+      {
+        title: 'Measure Calculation Error',
+        summary: 'There was an error calculating measure ' + error_info[:cms_id] + '.',
+        body: 'One of the data elements associated with the measure is causing an issue. Please review the elements associated with the measure to verify that they are all constructed properly.<br>Error message: <b>' + error_info[:msg] + '</b>'
+      }
+    end
+  end
+
+  # Emails an error description notification (if on production).
+  def self.send_email(error_info, exception, request)
+    if defined? ExceptionNotifier::Notifier
+      # Create a new Ruby exception with the given error message, and deliver
+      # an email to the development team containing the same error informantion.
+      ExceptionNotifier.notify_exception(exception, env: request.env, data: error_info)
+    end
+  end
+end

--- a/bower.json
+++ b/bower.json
@@ -27,7 +27,8 @@
     "datatables.net-fixedcolumns": "^3.2.1",
     "datatables.net-fixedcolumns-dt": "^3.2.1",
     "jquery.scrollTo": "^2.1.2",
-    "eonasdan-bootstrap-datetimepicker": "^4.17.37"
+    "eonasdan-bootstrap-datetimepicker": "^4.17.37",
+    "costanza": "^2.1.0"
   },
   "resolutions": {
     "bootstrap": "~3.3.0",

--- a/config/bonnie.yml
+++ b/config/bonnie.yml
@@ -13,6 +13,7 @@ defaults: &defaults
   record:
     # This value should not exceed 16000000 as that is the current size limit of a document in MongoDB.
     max_size_in_bytes: 12000000
+  enable_client_error_email: true
 
 development:
   <<: *defaults

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,10 @@ Bonnie::Application.routes.draw do
   get '404', :to => 'application#page_not_found'
   get '500', :to => 'application#server_error'
 
+  # The following route is for the reporting of front end (javascript) errors
+  # to the backend.
+  get '/application/client_error' => 'application#client_error'
+
   root to: 'home#index'
 
   resources :measures, defaults: { format: :json } do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,7 +19,7 @@ Bonnie::Application.routes.draw do
 
   # The following route is for the reporting of front end (javascript) errors
   # to the backend.
-  get '/application/client_error' => 'application#client_error'
+  post '/application/client_error' => 'application#client_error'
 
   root to: 'home#index'
 

--- a/vendor/assets/components/costanza/.bower.json
+++ b/vendor/assets/components/costanza/.bower.json
@@ -1,0 +1,33 @@
+{
+  "name": "costanza",
+  "version": "2.1.0",
+  "main": "js/costanza.js",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "/components",
+    "bower_components",
+    "Jakefile",
+    "package.json",
+    "test",
+    "tests"
+  ],
+  "devDependencies": {
+    "backbone": "~1.0.0",
+    "handlebars": "1.x.x",
+    "underscore": "~1.5.2",
+    "expect": "~0.3.1",
+    "jquery": "~1.10.0"
+  },
+  "homepage": "https://github.com/walmartlabs/costanza",
+  "_release": "2.1.0",
+  "_resolution": {
+    "type": "version",
+    "tag": "v2.1.0",
+    "commit": "09119b70fad65a9c4101de4d57789732f79d8372"
+  },
+  "_source": "https://github.com/walmartlabs/costanza.git",
+  "_target": "^2.1.0",
+  "_originalSource": "costanza",
+  "_direct": true
+}

--- a/vendor/assets/components/costanza/LICENSE
+++ b/vendor/assets/components/costanza/LICENSE
@@ -1,0 +1,7 @@
+Copyright (c) 2011-2013 @WalmartLabs
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/vendor/assets/components/costanza/README.md
+++ b/vendor/assets/components/costanza/README.md
@@ -1,0 +1,204 @@
+# Costanza
+[![Build Status](https://travis-ci.org/walmartlabs/costanza.png?branch=master)](https://travis-ci.org/walmartlabs/costanza)
+
+Frontend error tracking toolkit: Own your own domain
+
+Provides a [Node.js domains][node_domains] inspired async error-tracking system for frontend clients. This allows for tracking errors with more than the `Undefined is not an object` level of detail that many implementations of generic `window.onerror` provide.
+
+```
+onerror:
+  msg: Uncaught TypeError: 'undefined' is not an object
+  url: http://localhost/home.js
+  line: 1
+```
+
+But with Costanza the logged error is much more expressive:
+
+```
+Costanza error:
+  type: javascript
+  section: thorax-exception: home ;; DOM-event:click .js-big-red-button
+
+TypeError: 'undefined' is not an object
+    at bigRedButtonHandler (http://localhost/home.js:1:129)
+    at http://localhost/base.js:1:2221
+    at ret (http://localhost/base.js:1:9860)
+```
+
+Showing that the error occurred in the `click .js-big-red-button` event handler of the Thorax `home` view as well as providing the stack trace associated with that event.
+
+## Features
+
+- Automatically associating callbacks and events with the code group that created them
+- Tracking global javascript errors
+- Tracking resource load failures
+- Page unload tracking
+
+## Usage
+
+Initialize the library using the `Costanza.init` method, passing a callback that will handle errors. This callback should send the error info to your centralized tracking server.
+
+```javascript
+Costanza.init(function(info, rawError) {
+  $.ajax({
+    url: myAnalyticsServer,
+    method: 'POST',
+    data: info
+  });
+});
+```
+
+This is the minimum required to use the library, but the fidelity of the error tracking is greatly improved if code is associated with known sections. Sections allow for a unique name to be associated with a code execution path. Should an error occur within the section or one of its anonymous sections, this unique name will be included in the error result, easing debugging.
+
+The easiest way to create a section is with the `run` method, which will immediately execute.
+
+```javascript
+Costanza.run('unique-name', function() {
+  // Do stuff that fails
+});
+```
+
+Callbacks may also be created with sections for later execution:
+
+```javascript
+var callback = Costanza.bind('another-unique-name', function() {
+  // Bang!
+});
+```
+
+Anonomyous sections may be created within other known sections. When these child sections execute, they will do so using the same identifier pased to the parent section. This is done automatically for callbacks passed to `setTimeout`, `setInterval`, and `addEventListener` by default.
+
+```javascript
+Costanza.run('yet-another-unique-name', function() {
+  setTimeout(function() {
+    // A later bang!
+  }, 1000);
+});
+```
+
+Ideally new named sections are created for any logical entry point into the system from the event loop. Things like DOM event handlers and ajax callbacks are prime candidates for creating named sections. Plugins such as costanza-thorax allow for doing this in an automated fashion. (Don't see a plugin for your framework of choice? [Send over a PR][pull_request]!)
+
+### Implementation Warning
+
+This code hijacks majors portions of built-in prototype objects. This should be fail-safe but is not guaranteed to do so. Use only after considering the risks. Users who would like to avoid prototype extension may pass the `safeMode` option to avoid altering host objects. `safeMode` users will need to manually wrap callback functions to ensure that stack traces are available for methods that are executed on subsequent event loops.
+
+
+```javascript
+Costanza.init(function(info, rawError) {
+  $.ajax();
+}, {safeMode: true});
+
+Costanza.run('still-yet-another-unique-name', function() {
+  setTimeout(Costanza.bind('still-yet-another-unique-name', function() {
+    // A later bang!
+  }), 1000);
+});
+```
+
+## API
+
+### #init(callback, options)
+
+Initializes the library. In the event of an error `callback(info, rawError)` will be receive:
+
+- `info`: A stringifable object that may contain the following, in addition to custom fields for the case of `emit`.
+  - `type`: The type of error that occurred. For execution errors this will be `javascript`. For errors loading external resources for a particular element this will be tag name of the element that failed to load.
+  - `section`: Current section executing when the failure occured. `global` if there is no current section.
+  - `url`: URL of the error, if available. For element load errors this will be the referenced external object.
+  - `line`: The line number of the error, if available.
+  - `msg`: The error message.
+  - `stack`: The javascript stack trace of the error, if available.
+
+- `rawError`: The raw error object that generated the event, if available. This is not guaranteed to be JSON safe.
+
+
+Enabled features may be controlled with the `options` parameter. These include:
+
+- `safeMode`: Disables native overrides
+- `noGlobal`: Disables global `onerror` and `error` event tracking
+
+### #run(name, [info, ] callback)
+
+Creates a new named section and executes immediately. This allows for easy creation of new section scopes.
+
+### #bind([name, ]\[info, ] callback)
+
+Creates a section which may be executed at a later time. If `name` is omitted then the section will execute under the current section name. This is useful for providing callbacks to methods that do not use one of the automaticly bound paths.
+
+If an `info` object is provided, the data passed on error will be extended with any values defined on `info`. This may be used for passing arbitrary debugging data back to the tracking system.
+
+### #current()
+
+Returns the name of the current section. If none is defined then the return is `global`.
+
+### #emit(info, error)
+
+Emits a custom event to the error handler callback.
+
+### #cleanup()
+
+Removes any overrides that may have been performed. Calling this method is unnecessary under most circumstances.
+
+## Platforms
+
+Tested platforms include:
+
+Desktop:
+- Chrome: Latest
+- Firefox: Latest
+- Safari: 7+
+- IE: 8+
+- Opera: 12+
+
+Mobile:
+- iOS: 4.2+
+- Android: 2.3+
+- Windows Phone: 8+
+- Blackberry: 6.0+
+
+Not all features are supported on all platforms and the log messages will vary by platform.
+
+- Support for `error` events for for loading vary greatly by browser. [@yaypie][yaypie] has put together a good [listing][error_support] of supporting browsers for these events.
+- [Android 2.x][android_onerror] does not `window.onerror` generic handling.
+- Opera 12 does not appear to support tracking of SyntaxErrors via `window.onerror`
+
+## Hall of Shame
+
+The following are exceptions seen in the wild that appear to be thrown by 3rd party extensions or proxy injected code. Don't let friends inject buggy code... or any for that matter.
+
+- TypeError: 'undefined' is not an object (evaluating 'document.getElementsByTagName('video')[0].src')
+- TypeError: 'undefined' is not an object (evaluating 'document.getElementsByTagName('video')[0].getElementsByTagName')
+- TypeError: 'undefined' is not an object (evaluating 'document.getElementsByTagName('video')[0].getAttribute')
+- Uncaught TypeError: Cannot call method 'Log' of undefined
+- Uncaught TypeError: Cannot call method 'setHTML' of undefined
+- Uncaught TypeError: Cannot call method 'setTitleDescription' of undefined
+- ReferenceError: Can't find variable: pc_scroll_view_will_begin_dragging
+- ReferenceError: Can't find variable: pc_scroll_view_will_begin_decelerating
+- ReferenceError: Can't find variable: pc_scroll_view_did_end_decelerating
+- ReferenceError: Can't find variable: atomicFindClose
+- Uncaught ReferenceError: MMSDK is not defined
+- Uncaught ReferenceError: measurePositions is not defined
+
+## Testing
+
+Command line:
+
+    gulp
+
+Interactive:
+
+    gulp watch
+
+Costanza uses [@karma][karma], and will automatically load all locally installed browsers. If you want to access it manually or remotely, you can do so via
+`http://localhost:9876`
+
+## Why is this called Costanza?
+
+George Costanza (of Seinfeld fame) was the [master of his domain](http://en.wikipedia.org/wiki/The_Contest) and we want you to be the master of yours.
+
+[node_domains]: http://nodejs.org/api/domain.html
+[pull_request]: https://github.com/walmartlabs/costanza/pulls
+[android_onerror]: https://code.google.com/p/android/issues/detail?id=15680
+[yaypie]: https://twitter.com/yaypie
+[error_support]: http://pieisgood.org/test/script-link-events/
+[karma]: http://karma-runner.github.io/

--- a/vendor/assets/components/costanza/bower.json
+++ b/vendor/assets/components/costanza/bower.json
@@ -1,0 +1,22 @@
+{
+  "name": "costanza",
+  "version": "2.1.0",
+  "main": "js/costanza.js",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "/components",
+    "bower_components",
+    "Jakefile",
+    "package.json",
+    "test",
+    "tests"
+  ],
+  "devDependencies": {
+    "backbone": "~1.0.0",
+    "handlebars": "1.x.x",
+    "underscore": "~1.5.2",
+    "expect": "~0.3.1",
+    "jquery": "~1.10.0"
+  }
+}

--- a/vendor/assets/components/costanza/gulpfile.js
+++ b/vendor/assets/components/costanza/gulpfile.js
@@ -1,0 +1,42 @@
+/* jshint node: true */
+var gulp = require('gulp'),
+    karma = require('karma').server;
+
+gulp.task('test', function(done) {
+  karma.start({
+    configFile: __dirname + '/test/karma-phantom.js'
+  }, done);
+});
+
+gulp.task('watch', function(done) {
+  karma.start({
+    configFile: __dirname + '/test/karma-watch.js'
+  }, done);
+});
+
+gulp.task('test-local', function(done) {
+  karma.start({
+    configFile: __dirname + '/test/karma-all-local.js'
+  }, done);
+});
+
+gulp.task('sauce-ie', function(done) {
+  karma.start({
+    configFile: __dirname + '/test/karma-sauce-ie.js'
+  }, done);
+});
+
+gulp.task('sauce-mobile', function(done) {
+  karma.start({
+    configFile: __dirname + '/test/karma-sauce-mobile.js'
+  }, done);
+});
+
+gulp.task('sauce-good', function(done) {
+  karma.start({
+    configFile: __dirname + '/test/karma-sauce-good.js'
+  }, done);
+});
+
+
+gulp.task('default', ['test']);

--- a/vendor/assets/components/costanza/js/costanza.js
+++ b/vendor/assets/components/costanza/js/costanza.js
@@ -1,0 +1,382 @@
+/*global HTMLDocument, Window, console, define */
+(function (root, factory) {
+  if (typeof define === 'function' && define.amd) {
+    define([], factory);
+  } else if (typeof require === 'function') {
+    module.exports = factory();
+  } else {
+    root.Costanza = factory();
+  }
+}(this, function() {
+  function defaultReporter(info, err) {
+    /*jshint eqnull:true */
+    console.error('Costanza error:'
+          + '\n  type: ' + info.type
+          + '\n  section: ' + info.section
+          + (info.url ? '\n  url: ' + info.url : '')
+          + (info.line != null ? '\n  line: ' + info.line : '')
+          + ((info.stack && info.stack.indexOf(info.msg) < 0) ? '\n\n' + info.msg : ''),
+          + '\n\n' + (info.stack || info.msg));
+  }
+
+  var reportCallback = defaultReporter,
+      currentSection = 'global',
+      _listeners = [],
+      _addEventStr = window.addEventListener ? 'addEventListener' : 'attachEvent',
+      _removeEventStr = window.removeEventListener ? 'removeEventListener' : 'detachEvent',
+      _onError,
+      _setTimeout,
+      _setInterval;
+
+  function init(_reportCallback, options) {
+    options = options || {};
+    reportCallback = _reportCallback || defaultReporter;
+
+    if (!options.noGlobal && window.addEventListener && (!window.onerror || !window.onerror._costanza)) {
+      _onError = _onError || window.onerror;
+      window.onerror = onErrorRoot;
+
+      window.addEventListener('error', onError, true);
+
+      if ('onpagehide' in window) {
+        window.addEventListener('pageshow', onPageShow, false);
+        window.addEventListener('pagehide', onPageHide, false);
+      } else {
+        window.addEventListener('beforeunload', onPageHide, false);
+      }
+    }
+
+    // Allow users to opt out of the native prototype augmentation.
+    if (options.safeMode) {
+      return;
+    }
+
+    // IE <=8 makes it nearly impossible to override setTimeout, so we don't
+    // http://www.adequatelygood.com/Replacing-setTimeout-Globally.html
+    if (window.addEventListener) {
+      if (window.setTimeout && !setTimeout._costanza) {
+        _setTimeout = setTimeout;
+        window.setTimeout = wrapSet(_setTimeout);
+      }
+
+      if (window.setInterval && !setInterval._costanza) {
+        _setInterval = setInterval;
+        window.setInterval = wrapSet(_setInterval);
+      }
+    }
+
+    function wrapSet($super) {
+      function ret(_callback, duration) {
+        var callback = _callback;
+        if (typeof _callback === 'string') {
+          callback = function() {
+            /*jshint -W061:true */
+            // Force global exec
+            // http://perfectionkills.com/global-eval-what-are-the-options
+            (1,window.eval)(_callback);
+          };
+        }
+
+        var args = Array.prototype.slice.call(arguments);
+        args[0] = bind({
+          captureErrors: true,     // No need to propagate to global error handler
+          callback: callback
+        });
+
+        return $super.apply(this, args);
+      }
+      ret._costanza = true;
+      return ret;
+    }
+
+    if (window.Element && Element.prototype[_addEventStr] && !Element.prototype[_addEventStr]._costanza) {
+
+      wrapListener(Element.prototype);
+      if (window.HTMLDocument || window.Document) {
+        // IE10: Document, others are HTMLDocument
+        wrapListener((window.HTMLDocument || window.Document).prototype);
+      }
+      if (window.Window) {
+        wrapListener(Window.prototype);
+      }
+    }
+
+    function addCleanupListener(proto, listenerName, listener) {
+      proto[listenerName]._costanza = true;
+
+      _listeners.push(function() {
+        proto[listenerName] = listener;
+      });
+    }
+
+    function wrapListener(proto) {
+      var _addListener,
+          _removeListener;
+
+      // We must pair the native implementation with the proper proto object as ios7 will throw
+      // if they are not.
+          //
+      _addListener = proto[_addEventStr];
+      proto[_addEventStr] = function(type, callback, useCapture) {
+        if (!callback._section) {
+          var className = '';
+          if (this.className) {
+            // Use baseVal for SVGAnimatedString on svg elements
+            className = this.className.baseVal != null ? this.className.baseVal : this.className;
+            if (className) {
+              className = '.' + className.replace(' ', '.');
+            }
+          }
+
+          var elementId = (this.nodeName || 'window').toLowerCase()
+              + (this.id ? '#' + this.id : className),
+            sectionName = 'event-' + elementId + ':' + type;
+
+          if (callback.handleEvent) {
+            callback._section = {
+              handleEvent: bind(sectionName, function(event) {
+                return callback.handleEvent(event);
+              })
+            };
+          } else {
+            callback._section = bind({
+              name: sectionName,
+              captureErrors: true,   // No need to propagate to global error handler
+              callback: callback
+            });
+          }
+        }
+
+        _addListener.call(this, type, callback._section, useCapture);
+      };
+
+      addCleanupListener(proto, _addEventStr, _addListener);
+
+      _removeListener = proto[_removeEventStr];
+      proto[_removeEventStr] = function(type, callback, useCapture) {
+        _removeListener.call(this, type, callback._section || callback, useCapture);
+      };
+
+      addCleanupListener(proto, _removeEventStr, _removeListener);
+    }
+  }
+
+  function cleanup() {
+    while (_listeners.length) {
+      _listeners.pop()();
+    }
+
+    reportCallback = defaultReporter;
+    if (_setTimeout && setTimeout._costanza) {
+      window.setTimeout = _setTimeout;
+    }
+    if (_setInterval && setInterval._costanza) {
+      window.setInterval = _setInterval;
+    }
+
+    if (window.onerror && window.onerror._costanza) {
+      window.onerror = _onError;
+
+      if (window.removeEventListener) {
+        window.removeEventListener('error', onError, true);
+      }
+    }
+  }
+
+  function bind(/* [name, ][info, ] callback */) {
+    var callback = arguments[2] || arguments[1] || arguments[0],
+        captureErrors,
+        info,
+        name = currentSection;
+
+    if (!callback.apply) {
+      // Options object was passed
+      name = callback.name || name;
+      info = callback.info;
+      captureErrors = callback.captureErrors;
+
+      callback = callback.callback;
+    } else {
+      // Array-based arguments
+      if (arguments.length > 2) {
+        info = arguments[1];
+        name = arguments[0];
+      }
+      if (arguments.length > 1) {
+        name = arguments[0];
+        if (typeof name !== 'string') {
+          info = name;
+          name = currentSection;
+        }
+      }
+    }
+
+    if (!callback || !callback.apply) {
+      // If we don't have a valid function, log it and pass whatever it is on
+      reportError(new Error('Costanza:Unexpected bind: ' + callback));
+
+      return callback;
+    } else if (callback._costanza) {
+      return callback;
+    }
+
+    var ret = function() {
+      var priorSite = currentSection;
+
+      try {
+        currentSection = name;
+
+        return callback.apply(this, arguments);
+      } catch (err) {
+        reportError(err);
+
+        // Continute propagation of the error so we aren't left in an intedeterminate
+        // state
+        if (!captureErrors) {
+          // Rewrite the error so we know that its already gone through the error handling
+          // stack
+          if (!err.stack) {
+            // Unexpected data. Log and hope that this is surfaced somewhere that it's usable.
+            if (window.console) {
+              console.error('Unknown throw:', err);
+            }
+
+            var toThrow = new Error('Costanza: ' + err);
+            toThrow._costanza = true;
+            throw toThrow;
+          } else {
+            // We don't want to throw a different type or otherwise loose the data that we have
+            // attached to this error message. Instead do the "safest" thing and insert our
+            // logging message so we can detect this in the global error handler.
+            err.message = 'Costanza: ' + err.message;
+            err._costanza = true;
+            throw err;
+          }
+        }
+      } finally {
+        currentSection = priorSite;
+      }
+    };
+    ret._costanza = true;
+    return ret;
+
+    function reportError(err) {
+      // Do not over report
+      if (err._costanza) {
+        return;
+      }
+      err._costanza = true;
+
+      var reportInfo = {
+        type: 'javascript',
+        section: currentSection,
+        msg: err.message,
+        stack: (err.stack || err) + ''
+      };
+
+      // Inline debug data
+      function extend(info) {
+        if (info) {
+          for (var keyName in info) {
+            if (info.hasOwnProperty(keyName)) {
+              reportInfo[keyName] = info[keyName];
+            }
+          }
+        }
+      }
+      extend(info);
+      extend(err.info);
+
+      reportCallback(reportInfo, err);
+    }
+  }
+
+  function onError(errorMsg, url, lineNumber, error) {
+    var type = 'javascript';
+
+    // Handle ErrorEvent if we receieve it
+    if (errorMsg && errorMsg.message) {
+      url = errorMsg.filename;
+      lineNumber = errorMsg.lineno;
+      error = errorMsg.error;
+      errorMsg = errorMsg.message;
+    }
+
+    var isCostanzaError = /\bCostanza: /.test(errorMsg);
+    if ((errorMsg === 'Script error.' && !url)
+        || isCostanzaError) {
+      // Ignore untrackable external errors locally
+      // Also ignore errors that have already been reported (The _costanza flag does not
+      // propagate to window.onerror
+      return isCostanzaError;
+    }
+    if (!url && lineNumber === 0) {
+      // If the external script error message MIGHT have some more meaning then provide a more
+      // meaningful url than undefined.
+      url = 'Unknown External Script';
+    }
+
+    // This is a real event handler vs. the onerror special case.
+    // Since some browsers decide to treat window.onerror as the error event handler,
+    // we have to be prepared for either case
+    var el = errorMsg.target || errorMsg.srcElement;
+    if (errorMsg && el) {
+      // Don't submit duplciate events (and if we weren't already tracking
+      // it, it probably wasn't that important)
+      // Additionally ignore load errors that might happen after page unload has started.
+      if (errorMsg.defaultPrevented || errorMsg._costanzaHandled
+          || Costanza.pageUnloading) {
+        return;
+      }
+
+      errorMsg._costanzaHandled = true;
+      url = url || el.src || el.href;
+      type = (el.nodeName || 'window').toLowerCase();
+      errorMsg = 'load-failed';
+    }
+
+    // Error argument added to the spec. Adding support so we can catch this as it rolls out
+    // http://html5.org/tools/web-apps-tracker?from=8085&to=8086
+    reportCallback({
+      section: currentSection,
+      url: url,
+      line: lineNumber,
+      type: type,
+
+      // Cast error message to string as it sometimes can come through with objects, particularly DOM objects
+      // containing circular references.
+      msg: errorMsg+'',
+      stack: error && error.stack
+    }, error);
+  }
+
+  function onErrorRoot(errorMsg, url, lineNumber, error) {
+    _onError && _onError(errorMsg, url, lineNumber, error);
+    return onError(errorMsg, url, lineNumber, error);
+  }
+  onErrorRoot._costanza = true;
+
+  function onPageShow(event) {
+    Costanza.pageUnloading = false;
+  }
+  function onPageHide(event) {
+    Costanza.pageUnloading = true;
+  }
+
+  var Costanza = {
+    init: init,
+    cleanup: cleanup,
+    current: function() {
+      return currentSection;
+    },
+    emit: function(info, error) {
+      reportCallback(info, error);
+    },
+    bind: bind,
+    run: function(name, info, callback) {
+      return bind(name, info, callback)();
+    },
+    onError: onError
+  };
+  return Costanza;
+}));

--- a/vendor/assets/components/costanza/lumbar.json
+++ b/vendor/assets/components/costanza/lumbar.json
@@ -1,0 +1,20 @@
+{
+  "name": "costanza",
+
+  "mixins": {
+    "costanza": {
+      "scripts": [
+        "js/costanza.js"
+      ]
+    },
+    "costanza-thorax": {
+      "scripts": [
+        "thorax.js"
+      ]
+    }
+  },
+
+  "test": {
+    "auto-include": "test/"
+  }
+}

--- a/vendor/assets/components/costanza/release-notes.md
+++ b/vendor/assets/components/costanza/release-notes.md
@@ -1,0 +1,88 @@
+# Release Notes
+
+## Development
+
+[Commits](https://github.com/walmartlabs/costanza/compare/v2.1.0...master)
+
+## v2.1.0 - January 24th, 2015
+- [#21](https://github.com/walmartlabs/costanza/pull/21) - Test fix for IE8 fixes ([@zachhale](https://api.github.com/users/zachhale))
+- [#20](https://github.com/walmartlabs/costanza/pull/20) - updates for ie8 ([@patrickkettner](https://api.github.com/users/patrickkettner))
+- Update IE version support docs to 8 - 0fcd8da
+
+Compatibility notes:
+- IE8+ is now supported although some functionality such as catching setTimeout throws do not work in the older versions.
+
+[Commits](https://github.com/walmartlabs/costanza/compare/v2.0.0...v2.1.0)
+
+## v2.0.0 - December 8th, 2014
+- [#19](https://github.com/walmartlabs/costanza/pull/19) - Correct support for SVGAnimatedStrings ([@zachhale](https://api.github.com/users/zachhale))
+- [#18](https://github.com/walmartlabs/costanza/pull/18) - move project to gulp based build with karma and sauce ([@patrickkettner](https://api.github.com/users/patrickkettner))
+- Define main module entry point - 9f5952f
+- Move thorax plugin into root - 8a65ad7
+
+Compatibility notes:
+- CommonJS consumers of the constanza-thorax.js plugin now should use `require('costanza/thorax')`.
+
+[Commits](https://github.com/walmartlabs/costanza/compare/v1.3.0...v2.0.0)
+
+## v1.3.0 - August 18th, 2014
+- [#9](https://github.com/walmartlabs/costanza/issues/9) - Investigate global eval hacks ([@kpdecker](https://api.github.com/users/kpdecker))
+- Convert Costanza modules to UMD - f50d256
+
+[Commits](https://github.com/walmartlabs/costanza/compare/v1.2.5...v1.3.0)
+
+## v1.2.5 - July 10th, 2014
+- Reuse thrown errors when marking for global filter - dde0a0f
+
+[Commits](https://github.com/walmartlabs/costanza/compare/v1.2.4...v1.2.5)
+
+## v1.2.4 - July 9th, 2014
+- Additional stack error failover - 1ae223e
+- Add failover for Costanza stack lookup - 80e113c
+
+[Commits](https://github.com/walmartlabs/costanza/compare/v1.2.3...v1.2.4)
+
+## v1.2.3 - July 2nd, 2014
+- [#15](https://github.com/walmartlabs/costanza/pull/15) - Do not report previously handled global errors ([@kpdecker](https://api.github.com/users/kpdecker))
+
+[Commits](https://github.com/walmartlabs/costanza/compare/v1.2.2...v1.2.3)
+
+## v1.2.2 - April 23rd, 2014
+- [#14](https://github.com/walmartlabs/costanza/pull/14) - Fix flow control on errors ([@kpdecker](https://api.github.com/users/kpdecker))
+- Update README.md - 79c1afe
+
+Compatibility notes:
+- Thrown errors will be propagated up to the caller to prevent changes to execution flow.
+
+[Commits](https://github.com/walmartlabs/costanza/compare/v1.2.1...v1.2.2)
+
+## v1.2.1 - March 17th, 2014
+- [#13](https://github.com/walmartlabs/costanza/pull/13) - Fix for Event Handlers on SVG Elements with a class. ([@DatenMetzgerX](https://api.github.com/users/DatenMetzgerX))
+- Provide clearer url message for blocked scripts - 6c275c6
+
+[Commits](https://github.com/walmartlabs/costanza/compare/v1.2.0...v1.2.1)
+
+## v1.2.0 - January 12th, 2014
+- [#7](https://github.com/walmartlabs/costanza/pull/7) - Update thorax plugin for runSection/bindSection ([@kpdecker](https://api.github.com/users/kpdecker))
+- [#8](https://github.com/walmartlabs/costanza/issues/8) - Track page loading state
+- Define new sections for addEventListener - 3d43080
+- Augment errors with `err.info` if available. - 18cf491
+- Feature detect addEventListner and setTimeout - 322b560
+
+[Commits](https://github.com/walmartlabs/costanza/compare/v1.1.0...v1.2.0)
+
+## v1.1.0 - December 30th, 2013
+- Ignore resource load errors when unloading - e54c710
+- Track page loading state in Costanza.pageUnloading - 4a40078
+- Log unsupported bind types - 1bd8731
+- Allow return from run calls - 360b834
+- Remove use strict from library - 9309ebb
+
+[Commits](https://github.com/walmartlabs/costanza/compare/v1.0.0...v1.1.0)
+
+
+## v1.0.0 - December 13th 2013
+
+- Initial release
+
+[Commits](https://github.com/walmartlabs/phoenix-connection/compare/8224ab1...v1.0.0)

--- a/vendor/assets/components/costanza/thorax.js
+++ b/vendor/assets/components/costanza/thorax.js
@@ -1,0 +1,25 @@
+/*global Costanza */
+(function (root, factory) {
+  if (typeof define === 'function' && define.amd) {
+    define(['thorax', 'costanza'], factory);
+  } else if (typeof require === 'function') {
+    factory(require('throax'), require('costanza'));
+  } else {
+    factory(root.Thorax, root.Costanza);
+  }
+}(this, function(Thorax, Costanza) {
+  Thorax.onException = function(name, error) {
+    error = error || {};
+
+    Costanza.emit({
+        type: 'javascript',
+        section: name,
+        msg: error.message,
+        stack: error.stack || error + ''
+      },
+      error);
+  };
+
+  Thorax.bindSection = Costanza.bind;
+  Thorax.runSection = Costanza.run;
+}));


### PR DESCRIPTION
Client side errors are now passed to the backend for inspection. For known errors, the backend crafts a more helpful error message that is passed back to the front end, to be displayed to the user in a flash message. Errors are also now emailed to the development team if seen in a production deployment.

Instructions for adding new types of known frontend errors:
https://github.com/projecttacoma/bonnie/wiki/Adding-custom-error-messages-for-front-end-errors

This prevents the usual "blank screen" issue when JavaScript errors prevent the rest of certain pages from being loaded.

For testing, see: https://oncprojectracking.healthit.gov/support/projects/BONNIE/issues/BONNIE-226

Before:
![before](https://cloud.githubusercontent.com/assets/14923551/24406328/13b27eec-1396-11e7-9119-02c4c4f96c71.gif)

After:
![after](https://cloud.githubusercontent.com/assets/14923551/24406332/17f8beda-1396-11e7-9915-fc01ea96f3a5.gif)
