### PR TITLE
updating Gemfile.lock to point to latest bundler

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,7 +31,7 @@ GIT
 
 GIT
   remote: https://github.com/projecttacoma/bonnie_bundler.git
-  revision: b87f3f986903438bdf1efe026f5bb24e00d1c8c3
+  revision: 9caf81cd577dcd33f25532fa6a3fd6f5c9aa2f02
   branch: master
   specs:
     bonnie_bundler (1.0.0)
@@ -381,4 +381,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.13.6
+   1.14.6

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -381,4 +381,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.14.6
+   1.13.6


### PR DESCRIPTION
Gemfile.lock now points to bundler version merged from pull request #79: https://github.com/projecttacoma/bonnie_bundler/pull/79