### PR TITLE
updating Gemfile.lock to point to latest bundler, from bundler pull r…

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,7 +31,7 @@ GIT
 
 GIT
   remote: https://github.com/projecttacoma/bonnie_bundler.git
-  revision: 7a4c2745f8ac39a3ee3eef1c81a4ae3b1dac21ec
+  revision: 0cdf90af36cea14d6b90530cada69c10c3248c37
   branch: cql4bonnie
   specs:
     bonnie_bundler (1.0.0)
@@ -361,4 +361,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.13.7
+   1.14.6


### PR DESCRIPTION
Gemfile.lock now points to bundler version merged from pull request https://github.com/projecttacoma/bonnie_bundler/pull/78