### PR TITLE
BONNIE-571

### DIFF
--- a/app/assets/javascripts/error_handler.js.coffee
+++ b/app/assets/javascripts/error_handler.js.coffee
@@ -3,14 +3,9 @@ Costanza.init (info, rawError) ->
   # Still print out the raw error for developers.
   console.error rawError
   
-  # First check:
   # Ignore mirrored Costanza error messages (we have already handled these).
   # This check stops doubled error message popups from appearing.
-  #
-  # Second check:
-  # Ignore logic highlighting errors. TODO: The highlighting bug should be
-  # fixed, and when that happens, the second check should be removed.
-  unless /Costanza/i.test(rawError.toString()) || /highlight-target/i.test(info.section)
+  unless /Costanza/i.test rawError.toString()
     info.url = window.location.href
     $.ajax
       url: 'application/client_error'

--- a/app/assets/javascripts/views/measure_view.js.coffee
+++ b/app/assets/javascripts/views/measure_view.js.coffee
@@ -48,7 +48,10 @@ class Thorax.Views.Measure extends Thorax.Views.BonnieView
       isPrimaryView: @isPrimaryView
 
   initialize: ->
-    populationLogicView = new Thorax.Views.PopulationLogic(model: @population)
+    # ensure that @suppressDataCriteriaHighlight is true if it isn't passed in
+    # We don't want to have the highlighting on the measure view as the data elements aren't displayed
+    @suppressDataCriteriaHighlight ?= true
+    populationLogicView = new Thorax.Views.PopulationLogic(model: @population, suppressDataCriteriaHighlight: @suppressDataCriteriaHighlight)
     @measureViz = Bonnie.viz.measureVisualzation().fontSize("1.25em").rowHeight(20).rowPadding({top: 14, right: 6}).dataCriteria(@model.get("data_criteria")).measurePopulation(@population).measureValueSets(@model.valueSets())
 
     # display layout view when there are multiple populations; otherwise, just show logic view


### PR DESCRIPTION
set suppressDataCriteriaHighlight for measure_view
Setting to true (so that highlighting is suppressed).
The only other place in the code that this variable was being set was in the patient builder (where it was set to `false`).