### PR TITLE
CQL JSON ELM based logic views with highlighting

### DIFF
--- a/app/assets/javascripts/templates/logic/cql_logic.hbs
+++ b/app/assets/javascripts/templates/logic/cql_logic.hbs
@@ -1,3 +1,5 @@
-<div class="measure-viz rationale panel-group">
-  <div class="cql-editor" id="editor"></div>
+<div class="cql-logic measure-viz rationale panel-group">
+  {{#each statementViews}}
+    {{view .}}
+  {{/each}}
 </div>

--- a/app/assets/javascripts/templates/logic/cql_logic.hbs
+++ b/app/assets/javascripts/templates/logic/cql_logic.hbs
@@ -1,3 +1,4 @@
+{{! TODO: Remove this outdated message once CQL settles for production. Currently needed because the volatile annotation structure. }}
 {{#if isOutdatedUpload}}
 <p>
   <div class="alert alert-warning">

--- a/app/assets/javascripts/templates/logic/cql_logic.hbs
+++ b/app/assets/javascripts/templates/logic/cql_logic.hbs
@@ -1,3 +1,10 @@
+{{#if isOutdatedUpload}}
+<p>
+  <div class="alert alert-warning">
+    <strong>Outdated Measure!</strong> This measure appears to be uploaded with an earlier version of Bonnie Alpha. This view may not function properly until the measure is reuploaded.
+  </div>
+</p>
+{{/if}}
 <div class="cql-logic measure-viz rationale panel-group">
   {{#each statementViews}}
     {{view .}}

--- a/app/assets/javascripts/templates/logic/cql_patient_builder_logic.hbs
+++ b/app/assets/javascripts/templates/logic/cql_patient_builder_logic.hbs
@@ -9,8 +9,6 @@
   </p>
   </br>
 
-  {{#each cqlLines}}
-    {{this}}<br/>
-  {{/each}}
+  {{view cqlLogicView}}
 
 </div>

--- a/app/assets/javascripts/templates/logic/cql_statement.hbs
+++ b/app/assets/javascripts/templates/logic/cql_statement.hbs
@@ -1,0 +1,1 @@
+<pre class="cql-statement"><code>{{text}}</code></pre>

--- a/app/assets/javascripts/templates/logic/cql_statement.hbs
+++ b/app/assets/javascripts/templates/logic/cql_statement.hbs
@@ -1,1 +1,4 @@
-<pre class="cql-statement"><code>{{text}}</code></pre>
+{{#if cqlPopulation}}
+  <div class="cql-population-name">{{cqlPopulation}}</div>
+{{/if}}
+<pre class="cql-statement{{#if cqlPopulation}} cql-statement-population{{/if}}"><code>{{text}}</code></pre>

--- a/app/assets/javascripts/views/logic/cql_logic_patient_builder_view.js.coffee
+++ b/app/assets/javascripts/views/logic/cql_logic_patient_builder_view.js.coffee
@@ -7,10 +7,10 @@ class Thorax.Views.CqlPatientBuilderLogic extends Thorax.Views.BonnieView
     @results = {}
     for pop in @population_names
       @results[pop] = 0
-
-  context: -> _(super).extend cqlLines: @model.get('cql').split("\n")
+    @cqlLogicView = new Thorax.Views.CqlPopulationLogic(model: @model)
 
   showRationale: (result) ->
     for pop in @population_names
       @results[pop] = result.get(pop)
+    @cqlLogicView.showRationale result
     @render()

--- a/app/assets/javascripts/views/logic/cql_logic_patient_builder_view.js.coffee
+++ b/app/assets/javascripts/views/logic/cql_logic_patient_builder_view.js.coffee
@@ -7,7 +7,7 @@ class Thorax.Views.CqlPatientBuilderLogic extends Thorax.Views.BonnieView
     @results = {}
     for pop in @population_names
       @results[pop] = 0
-    @cqlLogicView = new Thorax.Views.CqlPopulationLogic(model: @model, highlightPatientDataEnabled: true)
+    @cqlLogicView = new Thorax.Views.CqlPopulationLogic(model: @model, highlightPatientDataEnabled: true, population: @population)
 
   showRationale: (result) ->
     for pop in @population_names

--- a/app/assets/javascripts/views/logic/cql_logic_patient_builder_view.js.coffee
+++ b/app/assets/javascripts/views/logic/cql_logic_patient_builder_view.js.coffee
@@ -7,7 +7,7 @@ class Thorax.Views.CqlPatientBuilderLogic extends Thorax.Views.BonnieView
     @results = {}
     for pop in @population_names
       @results[pop] = 0
-    @cqlLogicView = new Thorax.Views.CqlPopulationLogic(model: @model)
+    @cqlLogicView = new Thorax.Views.CqlPopulationLogic(model: @model, highlightPatientDataEnabled: true)
 
   showRationale: (result) ->
     for pop in @population_names

--- a/app/assets/javascripts/views/logic/cql_logic_view.js.coffee
+++ b/app/assets/javascripts/views/logic/cql_logic_view.js.coffee
@@ -48,9 +48,12 @@ class Thorax.Views.CqlPopulationLogic extends Thorax.Views.BonnieView
   # Expects model to be a Measure model object of a CQL measure.
   ###
   initialize: ->
+    @isOutdatedUpload = false
     @statementViews = []
     _.each @model.get('elm').library.statements.def, (statement) =>
       if (statement.annotation)
+        if (statement.annotation[0].s.value[0] == "define ")
+          @isOutdatedUpload = true  # if the annotation only has "define" then this measure upload may be out of date.
         @statementViews.push new Thorax.Views.CqlStatement(statement: statement, highlightPatientDataEnabled: @highlightPatientDataEnabled)
 
   ###*

--- a/app/assets/javascripts/views/logic/cql_logic_view.js.coffee
+++ b/app/assets/javascripts/views/logic/cql_logic_view.js.coffee
@@ -83,8 +83,6 @@ class Thorax.Views.CqlStatement extends Thorax.Views.BonnieView
       @$('code').attr('class', 'eval-true')
     else
       @$('code').attr('class', 'eval-false')
-  
-  _
 
   clearRationale: ->
     @$('code').attr('class', '')

--- a/app/assets/javascripts/views/logic/cql_logic_view.js.coffee
+++ b/app/assets/javascripts/views/logic/cql_logic_view.js.coffee
@@ -33,7 +33,9 @@ class Thorax.Views.CqlPopulationsLogic extends Thorax.LayoutView
       isActive:  population is population.measure().get('displayedPopulation')
       populationTitle: population.get('title') || population.get('sub_id')
 
-
+###*
+# View for CQL Logic. Contains CqlStatement views.
+###
 class Thorax.Views.CqlPopulationLogic extends Thorax.Views.BonnieView
 
   template: JST['logic/cql_logic']
@@ -41,34 +43,86 @@ class Thorax.Views.CqlPopulationLogic extends Thorax.Views.BonnieView
   events:
     "ready": ->
 
+  ###*
+  # Initializes the view. Creates the CqlStatement views.
+  # Expects model to be a Measure model object of a CQL measure.
+  ###
   initialize: ->
     @statementViews = []
     _.each @model.get('elm').library.statements.def, (statement) =>
       if (statement.annotation)
-        @statementViews.push new Thorax.Views.CqlStatement(statement: statement)
+        @statementViews.push new Thorax.Views.CqlStatement(statement: statement, highlightPatientDataEnabled: @highlightPatientDataEnabled)
 
-  context: -> _(super).extend cqlLines: @model.get('cql').split("\n")
-
+  ###*
+  # Shows the coverage information.
+  ###
   showCoverage: ->
+    @clearRationale()
 
+  ###*
+  # Clears the coverage information from the view.
+  ###
   clearCoverage: ->
 
+  ###*
+  # Shows the rationale (aka. calculation results) by highlighting the CQL Statements that returned true or with values.
+  # This grabs the individual statement results and sends them to the respective CQLStatement views.
+  # @param {Result} result - The Result object from the calculator
+  ###
   showRationale: (result) ->
+    @latestResult = result
     for statementView in @statementViews
       statementView.showRationale result.get('statement_results')[statementView.name]
 
+  ###*
+  # Clears the rationale hightlighting on all CqlStatement views.
+  ###
   clearRationale: ->
     for statementView in @statementViews
       statementView.clearRationale()
 
+  ###*
+  # Handles the patient highlighting in the patient builder. This function is called by the CqlStatement view if its
+  # statement is hovered over and has results.
+  # @param {string[]} dataCriteriaIDs - A list of the dataCriteriaIDs that should be highlighted.
+  ###
+  highlightPatientData: (dataCriteriaIDs) ->
+    if @highlightPatientDataEnabled == true && @latestResult
+      for dataCriteriaID in dataCriteriaIDs
+        @latestResult.patient.get('source_data_criteria').findWhere(coded_entry_id: dataCriteriaID).trigger 'highlight', Thorax.Views.EditCriteriaView.highlight.valid
+  
+  ###*
+  # Clears all highlighted patient data. Called by the CqlStatement if its statement is mouseout'd.
+  ###
+  clearHighlightPatientData: ->
+    @latestResult?.patient.trigger 'clearHighlight'
+
+###*
+# View representing a CQL statement (aka. define).
+###
 class Thorax.Views.CqlStatement extends Thorax.Views.BonnieView
   template: JST['logic/cql_statement']
 
+  events:
+    'mouseover code': 'highlightEntry'
+    'mouseout code': 'clearHighlightEntry'
+
+  ###*
+  # Initializes the CqlStatement view. Expects statement to be the JSON ELM statement that should be shown.
+  # highlightPatientDataEnabled can optionally be set to true when constructing to turn on the highlighing patient 
+  # data functionality.
+  ###
   initialize: ->
     @text = @statement.annotation[0].s.value[0]
     @name = @statement.name
 
+  ###*
+  # Show the results of this statement's calculation by highlighing appropiately. 
+  # @param {boolean|Object[]} result - The result for this statement. May be a boolean or an array of entries.
+  ###
   showRationale: (result) ->
+    @latestResult = result
+
     if result == true  # Specifically a boolean true
       @_setResult true
     else if result == false  # Specifically a boolean false
@@ -78,11 +132,40 @@ class Thorax.Views.CqlStatement extends Thorax.Views.BonnieView
     else
       @clearRationale()  # Clear the rationale if we can't make sense of the result
 
+  ###*
+  # Modifies the class attribute of the code element to highlight the result.
+  # @private
+  # @param {boolean} evalResult - The result that should be shown.
+  ###
   _setResult: (evalResult) ->
     if evalResult == true
       @$('code').attr('class', 'eval-true')
     else
       @$('code').attr('class', 'eval-false')
 
+  ###*
+  # Clear the result for this statement.
+  ###
   clearRationale: ->
+    @latestResult = null
     @$('code').attr('class', '')
+
+  ###*
+  # Event handler for the mouseover event. This will report to the CqlPopulationLogic view with the ids of the patient
+  # data elements that should be highlighted.
+  ###
+  highlightEntry: ->
+    # only highlight entries if highlighting is enabled and there are results in the form of an array.
+    if @highlightPatientDataEnabled == true && Array.isArray(@latestResult) && @latestResult.length > 0
+      dataCriteriaIDs = []
+      for resultEntry in @latestResult
+        if resultEntry.entry  # if the result is an entry then grab the id so it can be highlighted
+          dataCriteriaIDs.push(resultEntry.entry._id)
+      @parent?.highlightPatientData(dataCriteriaIDs)  # report the id of the data criteria to be highlighted to the CqlPopulationLogic view.
+
+  ###*
+  # Event handler for the mouseout event. This will report to the CqlPopulationLogic view that highlighting should be cleared.
+  ###
+  clearHighlightEntry: ->
+    if @highlightPatientDataEnabled == true
+      @parent?.clearHighlightPatientData()

--- a/app/assets/javascripts/views/logic/cql_logic_view.js.coffee
+++ b/app/assets/javascripts/views/logic/cql_logic_view.js.coffee
@@ -53,9 +53,13 @@ class Thorax.Views.CqlPopulationLogic extends Thorax.Views.BonnieView
   initialize: ->
     @isOutdatedUpload = false
     @statementViews = []
-    _.each @model.get('elm').library.statements.def, (statement) =>
+    _.each @model.get('elm')?.library.statements?.def, (statement) =>
       if statement.annotation
-        if (statement.annotation[0].s.value[0] == "define ")
+
+        # Check to see if this measure was uploaded with an older version of the translation service that had clause level
+        # annotations enabled. This checks if the first annotation is just the define keyword and its delimiting space.
+        # TODO: Update this check as needed. Remove these checks when CQL has settled for production.
+        if (statement.annotation[0]?.s.value[0] == "define ")
           @isOutdatedUpload = true  # if the annotation only has "define" then this measure upload may be out of date.
 
         # skip if this is a statement the user doesn't need to see
@@ -114,76 +118,3 @@ class Thorax.Views.CqlPopulationLogic extends Thorax.Views.BonnieView
   ###
   clearHighlightPatientData: ->
     @latestResult?.patient.trigger 'clearHighlight'
-
-###*
-# View representing a CQL statement (aka. define).
-###
-class Thorax.Views.CqlStatement extends Thorax.Views.BonnieView
-  template: JST['logic/cql_statement']
-
-  events:
-    'mouseover code': 'highlightEntry'
-    'mouseout code': 'clearHighlightEntry'
-
-  ###*
-  # Initializes the CqlStatement view. Expects statement to be the JSON ELM statement that should be shown.
-  # highlightPatientDataEnabled can optionally be set to true when constructing to turn on the highlighing patient 
-  # data functionality.
-  ###
-  initialize: ->
-    @text = @statement.annotation[0].s.value[0]
-    @name = @statement.name
-
-  ###*
-  # Show the results of this statement's calculation by highlighing appropiately. 
-  # @param {boolean|Object[]} result - The result for this statement. May be a boolean or an array of entries.
-  ###
-  showRationale: (result) ->
-    @latestResult = result
-
-    if result == true  # Specifically a boolean true
-      @_setResult true
-    else if result == false  # Specifically a boolean false
-      @_setResult false
-    else if Array.isArray(result)  # Check if result is an array
-      @_setResult result.length > 0  # Result is true if the array is not empty
-    else
-      @clearRationale()  # Clear the rationale if we can't make sense of the result
-
-  ###*
-  # Modifies the class attribute of the code element to highlight the result.
-  # @private
-  # @param {boolean} evalResult - The result that should be shown.
-  ###
-  _setResult: (evalResult) ->
-    if evalResult == true
-      @$('code').attr('class', 'eval-true')
-    else
-      @$('code').attr('class', 'eval-false')
-
-  ###*
-  # Clear the result for this statement.
-  ###
-  clearRationale: ->
-    @latestResult = null
-    @$('code').attr('class', '')
-
-  ###*
-  # Event handler for the mouseover event. This will report to the CqlPopulationLogic view with the ids of the patient
-  # data elements that should be highlighted.
-  ###
-  highlightEntry: ->
-    # only highlight entries if highlighting is enabled and there are results in the form of an array.
-    if @highlightPatientDataEnabled == true && Array.isArray(@latestResult) && @latestResult.length > 0
-      dataCriteriaIDs = []
-      for resultEntry in @latestResult
-        if resultEntry.entry  # if the result is an entry then grab the id so it can be highlighted
-          dataCriteriaIDs.push(resultEntry.entry._id)
-      @parent?.highlightPatientData(dataCriteriaIDs)  # report the id of the data criteria to be highlighted to the CqlPopulationLogic view.
-
-  ###*
-  # Event handler for the mouseout event. This will report to the CqlPopulationLogic view that highlighting should be cleared.
-  ###
-  clearHighlightEntry: ->
-    if @highlightPatientDataEnabled == true
-      @parent?.clearHighlightPatientData()

--- a/app/assets/javascripts/views/logic/cql_statement_view.js.coffee
+++ b/app/assets/javascripts/views/logic/cql_statement_view.js.coffee
@@ -1,0 +1,72 @@
+###*
+# View representing a CQL statement (aka. define).
+###
+class Thorax.Views.CqlStatement extends Thorax.Views.BonnieView
+  template: JST['logic/cql_statement']
+
+  events:
+    'mouseover code': 'highlightEntry'
+    'mouseout code': 'clearHighlightEntry'
+
+  ###*
+  # Initializes the CqlStatement view. Expects statement to be the JSON ELM statement that should be shown.
+  # highlightPatientDataEnabled can optionally be set to true when constructing to turn on the highlighing patient 
+  # data functionality.
+  ###
+  initialize: ->
+    @text = @statement.annotation[0].s.value[0]
+    @name = @statement.name
+
+  ###*
+  # Show the results of this statement's calculation by highlighing appropiately. 
+  # @param {boolean|Object[]} result - The result for this statement. May be a boolean or an array of entries.
+  ###
+  showRationale: (result) ->
+    @latestResult = result
+
+    if result == true  # Specifically a boolean true
+      @_setResult true
+    else if result == false  # Specifically a boolean false
+      @_setResult false
+    else if Array.isArray(result)  # Check if result is an array
+      @_setResult result.length > 0  # Result is true if the array is not empty
+    else
+      @clearRationale()  # Clear the rationale if we can't make sense of the result
+
+  ###*
+  # Modifies the class attribute of the code element to highlight the result.
+  # @private
+  # @param {boolean} evalResult - The result that should be shown.
+  ###
+  _setResult: (evalResult) ->
+    if evalResult == true
+      @$('code').attr('class', 'eval-true')
+    else
+      @$('code').attr('class', 'eval-false')
+
+  ###*
+  # Clear the result for this statement.
+  ###
+  clearRationale: ->
+    @latestResult = null
+    @$('code').attr('class', '')
+
+  ###*
+  # Event handler for the mouseover event. This will report to the CqlPopulationLogic view with the ids of the patient
+  # data elements that should be highlighted.
+  ###
+  highlightEntry: ->
+    # only highlight entries if highlighting is enabled and there are results in the form of an array.
+    if @highlightPatientDataEnabled == true && Array.isArray(@latestResult) && @latestResult.length > 0
+      dataCriteriaIDs = []
+      for resultEntry in @latestResult
+        if resultEntry.entry  # if the result is an entry then grab the id so it can be highlighted
+          dataCriteriaIDs.push(resultEntry.entry._id)
+      @parent?.highlightPatientData(dataCriteriaIDs)  # report the id of the data criteria to be highlighted to the CqlPopulationLogic view.
+
+  ###*
+  # Event handler for the mouseout event. This will report to the CqlPopulationLogic view that highlighting should be cleared.
+  ###
+  clearHighlightEntry: ->
+    if @highlightPatientDataEnabled == true
+      @parent?.clearHighlightPatientData()

--- a/app/assets/javascripts/views/measure_view.js.coffee
+++ b/app/assets/javascripts/views/measure_view.js.coffee
@@ -52,7 +52,7 @@ class Thorax.Views.Measure extends Thorax.Views.BonnieView
     @measureViz = Bonnie.viz.measureVisualzation().fontSize("1.25em").rowHeight(20).rowPadding({top: 14, right: 6}).dataCriteria(@model.get("data_criteria")).measurePopulation(@population).measureValueSets(@model.valueSets())
     # Determine which population logic view use
     if @model.has('cql')
-      populationLogicView = new Thorax.Views.CqlPopulationLogic(model: @model)
+      populationLogicView = new Thorax.Views.CqlPopulationLogic(model: @model, population: @population)
     else
       populationLogicView = new Thorax.Views.PopulationLogic(model: @population)
   

--- a/app/assets/javascripts/views/patient_builder/patient_builder.js.coffee
+++ b/app/assets/javascripts/views/patient_builder/patient_builder.js.coffee
@@ -252,7 +252,7 @@ class Thorax.Views.BuilderPopulationLogic extends Thorax.LayoutView
 
     #TODO: Better test for cql logic here?
     if population.measure().has('cql')
-      populationLogicView = new Thorax.Views.CqlPatientBuilderLogic(model: population.measure())
+      populationLogicView = new Thorax.Views.CqlPatientBuilderLogic(model: population.measure(), population: population)
     else
       populationLogicView = new Thorax.Views.PopulationLogic(model: population)
     @setView populationLogicView

--- a/app/assets/stylesheets/application.css.less
+++ b/app/assets/stylesheets/application.css.less
@@ -78,3 +78,4 @@
 @import "errors";
 @import "patient_dashboard";
 @import "cql_playground";
+@import "cql_logic";

--- a/app/assets/stylesheets/cql_logic.less
+++ b/app/assets/stylesheets/cql_logic.less
@@ -1,0 +1,5 @@
+.cql-logic {
+  pre.cql-statement {
+    white-space: pre-wrap;
+  }
+}

--- a/app/assets/stylesheets/cql_logic.less
+++ b/app/assets/stylesheets/cql_logic.less
@@ -1,5 +1,16 @@
 .cql-logic {
   pre.cql-statement {
     white-space: pre-wrap;
+    margin: 0 0 1em;
+  }
+
+  pre.cql-statement-population {
+    border: 1px solid gray;
+  }
+
+  .cql-population-name {
+    border-top: 1px solid gray;
+    border-left: 1px solid gray;
+    border-right: 1px solid gray;
   }
 }


### PR DESCRIPTION
- Replaces use of ACE Editor in the logic view.
- View for each define statement that gets highlighted from execution engine results.
- Used in patient builder as well with patient data highlighting for defines that result in a list of entries.