### PR TITLE
Reenabling QRDA export feature for CQL measures

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,7 +31,7 @@ GIT
 
 GIT
   remote: https://github.com/projecttacoma/bonnie_bundler.git
-  revision: 25c0b6b66213fe7be398124854560fbe3b6e61a1
+  revision: 7b8319833c3cc3cf3ded3321eea890982c976038
   branch: cql4bonnie
   specs:
     bonnie_bundler (1.0.0)

--- a/app/assets/javascripts/templates/measure.hbs
+++ b/app/assets/javascripts/templates/measure.hbs
@@ -53,16 +53,16 @@
   <div class="right-sidebar">
     <div class="patients-title">
       <h1><i class="fa fa-user fa-fw" aria-hidden="true"></i> Test Patients</h1>
-      {{#unless cql}}
-        <span class="settings-container">
-          <div class="patients-settings">
-            {{#button "exportQrdaPatients" class="btn btn-default export-patients"}}<i class="fa fa-download" aria-hidden="true"></i> QRDA <span class="sr-only">Patient Export</span>{{/button}}
+      <span class="settings-container">
+        <div class="patients-settings">
+          {{#button "exportQrdaPatients" class="btn btn-default export-patients"}}<i class="fa fa-download" aria-hidden="true"></i> QRDA <span class="sr-only">Patient Export</span>{{/button}}
+          {{#unless cql}}
             {{#button "exportExcelPatients" class="btn btn-default export-patients"}}<i class="fa fa-download" aria-hidden="true"></i> Excel <span class="sr-only">Patient Export</span>{{/button}}
             {{#link "measures/{{hqmf_set_id}}/patient_bank" expand-tokens=true class="btn btn-primary import-patients"}}<i class="fa fa-group" aria-hidden="true"></i> <i class="fa fa-plus" aria-hidden="true"></i><span class="sr-only">Import patients from patient bank</span>{{/link}}
-          </div>
-          {{#button "patientsSettings" tag="a" class="btn-settings" href=""}}<i class="fa fa-cog" aria-hidden="true"></i> <span class="sr-only">Patient Options</span>{{/button}}
-        </span>
-      {{/unless}}
+          {{/unless}}
+        </div>
+        {{#button "patientsSettings" tag="a" class="btn-settings" href=""}}<i class="fa fa-cog" aria-hidden="true"></i> <span class="sr-only">Patient Options</span>{{/button}}
+      </span>
     </div>
     {{view populationCalculation}}
   </div>

--- a/app/assets/javascripts/views/measure_view.js.coffee
+++ b/app/assets/javascripts/views/measure_view.js.coffee
@@ -112,7 +112,7 @@ class Thorax.Views.Measure extends Thorax.Views.BonnieView
         successCallback: => @exportPatientsView.qrdaSuccess()
         failCallback: => @exportPatientsView.fail()
         httpMethod: "POST"
-        data: {authenticity_token: $("meta[name='csrf-token']").attr('content'), results: differences }
+        data: {authenticity_token: $("meta[name='csrf-token']").attr('content'), results: differences, isCQL: @model.has('cql')}
 
   exportExcelPatients: (e) ->
     @exportPatientsView.exporting()

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -57,7 +57,11 @@ class PatientsController < ApplicationController
       unless current_user.portfolio?
         records = records.where({:measure_ids.in => [params[:hqmf_set_id]]})
       end
-      measure = Measure.by_user(current_user).where({:hqmf_set_id => params[:hqmf_set_id]})
+      if params[:isCQL]
+        measure = CqlMeasure.by_user(current_user).where({:hqmf_set_id => params[:hqmf_set_id]})
+      else
+        measure = Measure.by_user(current_user).where({:hqmf_set_id => params[:hqmf_set_id]})
+      end
     end
 
     qrda_errors = {}
@@ -86,14 +90,23 @@ class PatientsController < ApplicationController
       end
       # add the summary content if there are results
       if (params[:results] && !params[:patients])
-        measure = Measure.by_user(current_user).where({:hqmf_set_id => params[:hqmf_set_id]}).first
+        if params[:isCQL] == 'true'
+          measure = CqlMeasure.by_user(current_user).where({:hqmf_set_id => params[:hqmf_set_id]}).first
+        else
+          measure = Measure.by_user(current_user).where({:hqmf_set_id => params[:hqmf_set_id]}).first
+        end
         zip.put_next_entry("#{measure.cms_id}_patients_results.html")
         zip.puts measure_patients_summary(records, params[:results].values, qrda_errors, html_errors, measure)
       end
     end
     cookies[:fileDownload] = "true" # We need to set this cookie for jquery.fileDownload
     stringio.rewind
-    filename = if params[:hqmf_set_id] then "#{Measure.by_user(current_user).where({:hqmf_set_id => params[:hqmf_set_id]}).first.cms_id}_patient_export.zip" else "bonnie_patient_export.zip" end
+    if params[:isCQL] == 'true'
+      measure = CqlMeasure.by_user(current_user).where({:hqmf_set_id => params[:hqmf_set_id]}).first
+    else
+      measure = Measure.by_user(current_user).where({:hqmf_set_id => params[:hqmf_set_id]}).first
+    end
+    filename = if params[:hqmf_set_id] then "#{measure.cms_id}_patient_export.zip" else "bonnie_patient_export.zip" end
     send_data stringio.sysread, :type => 'application/zip', :disposition => 'attachment', :filename => filename
   end
 


### PR DESCRIPTION
Reenabling QRDA export feature for CQL measures.

Requires https://github.com/projecttacoma/bonnie_bundler/pull/83

NOTE: You need to upload a new copy of a measure to get QRDA exporting properly.