### PR TITLE
Fix for highlight suppression on multiple population measures

### DIFF
--- a/app/assets/javascripts/views/measure_view.js.coffee
+++ b/app/assets/javascripts/views/measure_view.js.coffee
@@ -56,7 +56,7 @@ class Thorax.Views.Measure extends Thorax.Views.BonnieView
 
     # display layout view when there are multiple populations; otherwise, just show logic view
     if @populations.length > 1
-      @logicView = new Thorax.Views.PopulationsLogic collection: @populations
+      @logicView = new Thorax.Views.PopulationsLogic collection: @populations, suppressDataCriteriaHighlight: @suppressDataCriteriaHighlight
       @logicView.setView populationLogicView
     else
       @logicView = populationLogicView

--- a/app/assets/javascripts/views/patient_bank/patient_bank_view.js.coffee
+++ b/app/assets/javascripts/views/patient_bank/patient_bank_view.js.coffee
@@ -52,9 +52,9 @@ class Thorax.Views.PatientBankView extends Thorax.Views.BonnieView
 
     populations = @model.get('populations')
     @currentPopulation = @model.get('displayedPopulation')
-    populationLogicView = new Thorax.Views.PopulationLogic(model: @currentPopulation)
+    populationLogicView = new Thorax.Views.PopulationLogic(model: @currentPopulation, suppressDataCriteriaHighlight: true)
     if populations.length > 1
-      @bankLogicView = new Thorax.Views.PopulationsLogic collection: populations
+      @bankLogicView = new Thorax.Views.PopulationsLogic collection: populations, suppressDataCriteriaHighlight: true
       @bankLogicView.setView populationLogicView
     else
       @bankLogicView = populationLogicView


### PR DESCRIPTION
On multiple population set measures, changing population sets created new views without the suppression setting persisted. This fix passes the suppression option to the PopulationsLogic view so it can be properly passed to the PopulationLogic views when the use changes the population set.

Test this by using any measure with multiple population sets and switching to a measure other than the first one and rolling over the measure logic. If no errors result, then it was properly suppressed. To ensure suppression doesn't go too far, test the data element highlighting in the patient builder.