### PR TITLE
Cql4bonnie 546

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,7 +11,7 @@ GIT
 
 GIT
   remote: https://github.com/projectcypress/health-data-standards.git
-  revision: 6b73cffd3892452e9cf51416f5e81b1bc36d7dc1
+  revision: a82737e4728a2f9b568089a32cb336b994e7c2c7
   branch: cql4bonnie
   specs:
     health-data-standards (3.6.1)

--- a/app/assets/javascripts/cql_calculator.js.coffee
+++ b/app/assets/javascripts/cql_calculator.js.coffee
@@ -116,6 +116,9 @@
         else
           defined_pops = cql_map[popCode]
         index = 0 unless defined_pops.length > 1
+        # The STRAT populations array does not contain the population data criteria object, which causes
+        # an off by one mismatch between the populations cql map and the defined_pops[STRAT] array
+        index -=1 if popCode == "STRAT"
         cql_population = defined_pops[index]
         # Is there a patient result for this population?
         if results['patientResults'][patient.id][cql_population]?

--- a/app/assets/javascripts/cql_calculator.js.coffee
+++ b/app/assets/javascripts/cql_calculator.js.coffee
@@ -121,8 +121,9 @@
         # If retrieving the STRAT, set the index to the correct STRAT in the cql_map
         index = population.get('stratification_index') if popCode == "STRAT" && population.get('stratification')?
         cql_population = defined_pops[index]
-        # Is there a patient result for this population?
-        if results['patientResults'][patient.id][cql_population]?
+        # Is there a patient result for this population? and does this populationCriteria contain the population
+        # We need to check if the populationCriteria contains the population so that a STRAT is not set to zero if there is not a STRAT in the populationCriteria
+        if results['patientResults'][patient.id][cql_population]? && population.get(popCode)?
           # Grab CQL result value and adjust for Bonnie
           value = results['patientResults'][patient.id][cql_population]
           if Array.isArray(value) and value.length > 0

--- a/app/assets/javascripts/views/logic/cql_logic_view.js.coffee
+++ b/app/assets/javascripts/views/logic/cql_logic_view.js.coffee
@@ -72,7 +72,13 @@ class Thorax.Views.CqlPopulationLogic extends Thorax.Views.BonnieView
             index = @population.get('index')
             # The STRAT populations array does not contain the population data criteria object, which causes
             # an off by one mismatch between the populations cql map and the popStatements[STRAT] array
-            index -= 1 if pop == "STRAT"
+            popNames.push(pop) if statement.name == popStatements[@population.get('index')]  # note that there may be multiple populations that it defines
+            index = @population.get('index')
+            # If displaying a stratification, we need to set the index to the associated populationCriteria
+            # that the stratification is on so that the correct (IPOP, DENOM, NUMER..) are retrieved
+            index = @population.get('population_index') if @population.get('stratification')?
+            # If retrieving the STRAT, set the index to the correct STRAT in the cql_map
+            index = @population.get('stratification_index') if pop == "STRAT" && @population.get('stratification')?
             popNames.push(pop) if statement.name == popStatements[index]  # note that there may be multiple populations that it defines
           if popNames.length > 0
             popName = popNames.join(', ')

--- a/app/assets/javascripts/views/logic/cql_logic_view.js.coffee
+++ b/app/assets/javascripts/views/logic/cql_logic_view.js.coffee
@@ -69,7 +69,11 @@ class Thorax.Views.CqlPopulationLogic extends Thorax.Views.BonnieView
         # if a population (population set) was provided for this view it should mark the statment if it is a population defining statement  
         if @population
           for pop, popStatements of @model.get('populations_cql_map')
-            popNames.push(pop) if statement.name == popStatements[@population.get('index')]  # note that there may be multiple populations that it defines
+            index = @population.get('index')
+            # The STRAT populations array does not contain the population data criteria object, which causes
+            # an off by one mismatch between the populations cql map and the popStatements[STRAT] array
+            index -= 1 if pop == "STRAT"
+            popNames.push(pop) if statement.name == popStatements[index]  # note that there may be multiple populations that it defines
           if popNames.length > 0
             popName = popNames.join(', ')
 

--- a/app/assets/javascripts/views/logic/cql_logic_view.js.coffee
+++ b/app/assets/javascripts/views/logic/cql_logic_view.js.coffee
@@ -70,16 +70,13 @@ class Thorax.Views.CqlPopulationLogic extends Thorax.Views.BonnieView
         if @population
           for pop, popStatements of @model.get('populations_cql_map')
             index = @population.get('index')
-            # The STRAT populations array does not contain the population data criteria object, which causes
-            # an off by one mismatch between the populations cql map and the popStatements[STRAT] array
-            popNames.push(pop) if statement.name == popStatements[@population.get('index')]  # note that there may be multiple populations that it defines
-            index = @population.get('index')
             # If displaying a stratification, we need to set the index to the associated populationCriteria
             # that the stratification is on so that the correct (IPOP, DENOM, NUMER..) are retrieved
             index = @population.get('population_index') if @population.get('stratification')?
             # If retrieving the STRAT, set the index to the correct STRAT in the cql_map
             index = @population.get('stratification_index') if pop == "STRAT" && @population.get('stratification')?
-            popNames.push(pop) if statement.name == popStatements[index]  # note that there may be multiple populations that it defines
+            # There may be multiple populations that it defines. Only push population name if @population has a pop ie: not all populations will have STRAT
+            popNames.push(pop) if statement.name == popStatements[index] && @population.get(pop)?
           if popNames.length > 0
             popName = popNames.join(', ')
 


### PR DESCRIPTION
Should be tested with health data standards branch Cql4bonnie_546. The 137 measure (attached) has 2 strats and 2 populations if you look at the HQMF you will see that BOTH populations have BOTH of the stratifications. That is why when you load it, there will be 6 groups that show up, population 1 and 2 and stratifications 1-4. That is pop1,pop2, pop1-strat1, pop1-strat2, pop2-strat1, pop2-strat2. Measure 126, also attached shows that this still works with single pop single strats. Some things to look for is that all of the highlighting and population boxing works, and that the calculations are correct. A known (very small) issue is that in the edit patient view under CQL Calculation results section, the STRAT title still shows up when you are selecting a population criteria.
[cqltest137_v5_0_artifacts.zip](https://github.com/projecttacoma/bonnie/files/1042532/cqltest137_v5_0_artifacts.zip)
[pauldcms126v4_v5_0_Artifacts.zip](https://github.com/projecttacoma/bonnie/files/1042533/pauldcms126v4_v5_0_Artifacts.zip)

