### PR TITLE
Add more check conditions

### DIFF
--- a/app/assets/javascripts/cql_calculator.js.coffee
+++ b/app/assets/javascripts/cql_calculator.js.coffee
@@ -153,9 +153,19 @@
         population_results['DENEXCEP'] = 0
       if 'NUMER' of population_results
         population_results['NUMER'] = 0
+    # Can not be in the numerator if excluded or excepted from the denominator
+    else if !@isValueZero('DENEX', population_results) or !@isValueZero('DENEXCEP', population_results)
+      if 'NUMER' of population_results
+        population_results['NUMER'] = 0
+      if 'NUMEX' of population_results
+        population_results['NUMEX'] = 0
     else if @isValueZero('NUMER', population_results)
       if 'NUMEX' of population_results
         population_results['NUMEX'] = 0
+    # Can not be in the numerator if explicitly excluded
+    else if !@isValueZero('NUMEX', population_results)
+      if 'NUMER' of population_results
+        population_results['NUMER'] = 0
     return population_results
 
   isValueZero: (value, population_set) ->


### PR DESCRIPTION
Addressing external bug [BONNIE-251](https://oncprojectracking.healthit.gov/support/browse/BONNIE-251).  
Needed to extend the rules for what happens when a test case qualifies for certain combinations for populations.
DENEX !=0 or DENEXCEP !=0
NUMEX !=0