### PR TITLE
CQL Logic Improvements BONNIE-669

### DIFF
--- a/app/assets/javascripts/views/logic/cql_logic_view.js.coffee
+++ b/app/assets/javascripts/views/logic/cql_logic_view.js.coffee
@@ -108,11 +108,18 @@ class Thorax.Views.CqlPopulationLogic extends Thorax.Views.BonnieView
       
       statementView.showRationale(result.get('statement_results')[statementView.name], showHighlighting)
 
+  ###*
+  # Make a map of population to boolean of if the result of the define statement result should be shown or not. This is
+  # what determines if we don't highlight the statements that are "not calculated".
+  # TODO: This is stop gap solution, should be moved to the calculator.
+  # @private
+  # @param {Result} result = The result object from the calculator.
+  ###
   _makePopulationResultShownMap: (result) ->
     # initialize to true for every population
     resultShown = {}
     _.each(_.without(result.keys(), 'statement_results', 'patient_id'), (population) -> resultShown[population] = true)
-    
+
     # If STRAT is 0 then everything else is not calculated
     if result.get('STRAT')? && result.get('STRAT') == 0
       resultShown.IPP = false if resultShown.IPP?
@@ -121,7 +128,7 @@ class Thorax.Views.CqlPopulationLogic extends Thorax.Views.BonnieView
       resultShown.DENOM = false if resultShown.DENOM?
       resultShown.DENEX = false if resultShown.DENEX?
       resultShown.DENEXCEP = false if resultShown.DENEXCEP?
-    
+
     # If IPP is 0 then everything else is not calculated
     if result.get('IPP') == 0
       resultShown.NUMER = false if resultShown.NUMER?

--- a/app/assets/javascripts/views/logic/cql_statement_view.js.coffee
+++ b/app/assets/javascripts/views/logic/cql_statement_view.js.coffee
@@ -21,10 +21,11 @@ class Thorax.Views.CqlStatement extends Thorax.Views.BonnieView
   # Show the results of this statement's calculation by highlighing appropiately. 
   # @param {boolean|Object[]} result - The result for this statement. May be a boolean or an array of entries.
   ###
-  showRationale: (result) ->
+  showRationale: (result, highlightResult) ->
     @latestResult = result
-
-    if result == true  # Specifically a boolean true
+    if highlightResult == false
+      @clearRationale()  # If the result shouldn't be highlighted
+    else if result == true  # Specifically a boolean true
       @_setResult true
     else if result == false  # Specifically a boolean false
       @_setResult false


### PR DESCRIPTION
-Does not highlight statements that define populations that are not being considered.
-The logic for this is stopgap until we move it and have clause level highlighting.