### PR TITLE
Medication order fulfillment delete

### DIFF
--- a/lib/tasks/bonnie_run_once.rake
+++ b/lib/tasks/bonnie_run_once.rake
@@ -43,8 +43,11 @@ namespace :bonnie do
     # Medication orders previously contained fulfillment histories. This actually
     # doesn't make sense as an order is a future concept and a fulfillment history
     # is what happened. This also does not align with the QDM specification.
-    #  This became an issue when trying to do QRDA exports because the 
+    # This became an issue when trying to do QRDA exports because the 
     # medication order QDM model did not support fulfillment history information.
+    # The UI for medication orders was changed to align with QDM, but previously
+    # entered medication orders still have fulfillment history which is no longer
+    # editable in the UI and affects calculations.
     #
     # The script below removes the fulfillment history information. This will likely
     # make patients fail. We will need to send out an email when we make this change.

--- a/lib/tasks/bonnie_run_once.rake
+++ b/lib/tasks/bonnie_run_once.rake
@@ -62,7 +62,7 @@ namespace :bonnie do
         # remove information from the medication list directly on the patient
         for medication in r.medications
           if medication[:description].match(/^Medication, Order/) && medication[:fulfillmentHistory].count > 0
-            puts "\tresetting medication " + medication.description
+            puts "\tResetting medication " + medication.description
             medication.fulfillmentHistory = []
             medication.dose = nil
             medication.administrationTiming = nil
@@ -72,7 +72,7 @@ namespace :bonnie do
         # remove information from the source data criteria patient history
         for sdc in r.source_data_criteria
           if sdc[:description] && sdc[:description].match(/^Medication, Order/) && sdc[:fulfillments] && sdc[:fulfillments].count > 0
-            puts "\tresetting source data criteria " + sdc[:description]
+            puts "\tResetting source data criteria " + sdc[:description]
             sdc[:fulfillments] = []
             sdc[:dose_value] = ""
             sdc[:dose_unit] = ""

--- a/lib/tasks/bonnie_run_once.rake
+++ b/lib/tasks/bonnie_run_once.rake
@@ -53,6 +53,8 @@ namespace :bonnie do
     # make patients fail. We will need to send out an email when we make this change.
     desc 'Converts Medication Order fulfillment histories to allowed administrations'
     task :convert_fulfillment_history => :environment do
+      # find records that include a medication order and that medication order
+      # contains at least one fulfillment history.
       Record.where({"medications.description" => /^Medication, Order/, "medications.fulfillmentHistory" => {'$ne' => []}}).each do |r|
         puts "\nRECORD " + r._id
         


### PR DESCRIPTION
Script for deleting the fulfillment history for medication orders.

Medication orders previously contained fulfillment histories. This actually doesn't make sense as an order is a future concept and a fulfillment history is what happened. This also does not align with the QDM specification. This became an issue when trying to do QRDA exports because the 
medication order QDM model did not support fulfillment history information. The UI for medication orders was changed to align with QDM, but previously entered medication orders still have fulfillment history which is no longer editable in the UI and affects calculations.

The script below removes the fulfillment history information. This will likely make patients fail. We will need to send out an email when we make this change.


**To Test**

See instructions here: https://jira.mitre.org/browse/BONNIE-660?focusedCommentId=97482&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-97482