### PR TITLE
pointing to latests cql_qdm_patientapi

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,7 +38,7 @@ GIT
 
 GIT
   remote: https://github.com/projecttacoma/cql_qdm_patientapi.git
-  revision: bf8f64c9fe8719eaa52befcd8417246761cff0b3
+  revision: facd42b10fbd412c5ff0eeb8826d2d68ffb7ea2c
   branch: cql4bonnie
   specs:
     cql_qdm_patientapi (0.1.0)


### PR DESCRIPTION
pointing to fixes made in cql_qdm_patient api to make "diagnosis undefined error" no longer show up.