### PR TITLE
BONNIE-800 no end date for patient builder elements with Authored time

### DIFF
--- a/app/assets/javascripts/views/patient_builder/data_criteria.js.coffee
+++ b/app/assets/javascripts/views/patient_builder/data_criteria.js.coffee
@@ -127,7 +127,9 @@ class Thorax.Views.EditCriteriaView extends Thorax.Views.BuilderChildView
         startDate += " #{attr.start_time}" if attr.start_time
         attr.start_date = moment.utc(startDate, 'L LT').format('X') * 1000
       delete attr.start_time
-      if attr.end_date_is_undefined
+      # If the user indicates that there is no end date, or if this is a criteria with a single "Authored"
+      # time (ie negated, or not a period type) then the end date should always be undefined
+      if attr.end_date_is_undefined || @model.get('negation') || !@model.isPeriodType()
         attr.end_date = undefined
       else if endDate = attr.end_date
         endDate += " #{attr.end_time}" if attr.end_time


### PR DESCRIPTION
Fixes BONNIE-800

This pull request changes Bonnie so that in the patient builder, patient elements that have an "Authored" time (and therefore no end time to specify in the UI) do not store an end time when being saved. This addresses an issue where, if an element with an "Authored" time was being dragged onto another element with a start and stop time, the stop time would be invisibly stored on the new element and cause possible validation issues.

JIRA test: https://jira.mitre.org/browse/BONNIE-811