### PR TITLE
Display warning for any Internet Explorer users.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -84,3 +84,6 @@ gem 'foreman'
 
 gem 'handlebars_assets', '0.16'
 gem 'jquery-rails'
+
+# Browser Detection
+gem 'browser'

--- a/app/assets/stylesheets/errors.less
+++ b/app/assets/stylesheets/errors.less
@@ -18,3 +18,12 @@
     margin-top: 1em;
   }
 }
+
+#ie-warning {
+  h1 {
+    text-align: center;
+  }
+  p {
+    text-align: center;
+  }
+}

--- a/app/views/layouts/_ie8_alert.html.erb
+++ b/app/views/layouts/_ie8_alert.html.erb
@@ -1,6 +1,0 @@
-<!--[if lte IE 8]>
-<div class="jumbotron alert-danger">
-  <h1>Warning!</h1>
-  <p>Your web browser (IE8 or older) is not supported. Please <a href="http://www.updateyourbrowser.net/">update your browser</a> to continue using Bonnie.</p>
-</div>
-<![endif]-->

--- a/app/views/layouts/_ie_alert.html.erb
+++ b/app/views/layouts/_ie_alert.html.erb
@@ -1,0 +1,6 @@
+<% if browser.ie? %>
+  <div id="ie-warning" class="jumbotron alert-danger">
+    <h1>Warning!</h1>
+    <p>Your web browser (<%= browser.name %>) is not supported. Please use an alternative browser to continue using Bonnie.</p>
+  </div>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,7 +12,7 @@
 
   <body>
     <a href class="sr-only skip-content">Skip to main content</a>
-    <%= render 'layouts/ie8_alert' %>
+      <%= render 'layouts/ie_alert'%>
     <div class="container">
       <%= render 'layouts/header' %>
       <div id="bonnie" role="main">

--- a/app/views/layouts/devise.html.erb
+++ b/app/views/layouts/devise.html.erb
@@ -11,7 +11,7 @@
 </head>
 
 <body>
-  <%= render 'layouts/ie8_alert' %>
+  <%= render 'layouts/ie_alert' %>
   <div class="auth container">
     <% if current_user %>
       <%= render 'layouts/header' %>

--- a/app/views/layouts/errors.html.erb
+++ b/app/views/layouts/errors.html.erb
@@ -12,7 +12,7 @@
 
   <body>
     <a href class="sr-only skip-content">Skip to main content</a>
-    <%= render 'layouts/ie8_alert' %>
+    <%= render 'layouts/ie_alert' %>
     <div class="container">
       <%= render 'layouts/header' if signed_in? %>
       <div id="bonnie" role="main">


### PR DESCRIPTION
  - Add gem 'browser'
  - Replace _ie8_alert.html.erb with _ie_alert.html.erb
    This now detects any Internet Explorer rather than just versions <8
  - Replace references to 'ie8_alert' with 'ie_alert'

JIRA Test: https://jira.mitre.org/browse/BONNIE-845