### PR TITLE
BONNIE-821 Support patient characteristic payer Medicare Fee For Service

### DIFF
--- a/app/assets/javascripts/models/data_criteria.js.coffee
+++ b/app/assets/javascripts/models/data_criteria.js.coffee
@@ -149,7 +149,7 @@ class Thorax.Models.PatientDataCriteria extends Thorax.Model
     criteriaType in ['adverse_event', 'care_goal', 'device_applied', 'diagnostic_study_performed',
                      'encounter_active', 'encounter_performed', 'intervention_performed', 'laboratory_test_performed',
                      'medication_active', 'medication_administered', 'physical_exam_performed', 'procedure_performed',
-                     'substance_administered', 'allergy_intolerance', 'diagnosis', 'symptom']
+                     'substance_administered', 'allergy_intolerance', 'diagnosis', 'symptom', 'patient_characteristic_payer']
 
   # determines if a data criteria describes an issue or problem with a person
   # allergy/intolerance, diagnosis, and symptom fall into this

--- a/app/assets/javascripts/views/patient_builder/patient_builder.js.coffee
+++ b/app/assets/javascripts/views/patient_builder/patient_builder.js.coffee
@@ -40,14 +40,15 @@ class Thorax.Views.PatientBuilder extends Thorax.Views.BonnieView
     categories = {}
     @measure?.get('source_data_criteria').each (criteria) ->
       type = criteria.get('type').replace(/_/g, ' ')
-      # Filter out negations and specific occurrences
+      # Filter out negations, certain patient characteristics, and specific occurrences
+      # Note: we previously filtered out patient_characteristic_payer, but that was needed on the elements list
+      # because a payer can have a start and stop date in QDM 5
       filter_criteria = criteria.get('negation') or
       ( criteria.get('definition') is 'patient_characteristic_birthdate' ) or
       ( criteria.get('definition') is 'patient_characteristic_gender' ) or
       ( criteria.get('definition') is 'patient_characteristic_expired' ) or
       ( criteria.get('definition') is 'patient_characteristic_race' ) or
       ( criteria.get('definition') is 'patient_characteristic_ethnicity' ) or
-      ( criteria.get('definition') is 'patient_characteristic_payer' ) or
       ( criteria.has('specific_occurrence') )
       unless filter_criteria
         categories[type] ||= new Thorax.Collection


### PR DESCRIPTION
This pull request addresses BONNIE-821 by allowing Patient Characteristic Payer: Medicare Fee For Service to be selected from the elements and added to a patient history in the patient builder.

There are associated pull requests in health-data-standards and cql_qdm_patientapi that must be merged first.

Note that this also causes the basic Patient Characteristic Payer: Payer (a supplemental data criteria) to appear in the elements. QDM 5 specifies that a Patient Characteristic Payer should have a Relevant Period, so it makes sense for this to be specified on the patient history, but it appears in the element list even for measures that don't use it in the logic. Also, there is an existing payer field in the basic patient form where Medicare, Medicaid, and Other can be selected; this could perhaps be removed, keeping in mind that there are existing patients that have selected one of these options.

Another potential minor issue is that the Patient Characteristic Payer: Medicare Fee For Service data criteria is listed as a supplemental data criteria on the measure page, when perhaps it should just be listed as a data criteria.

JIRA test: https://jira.mitre.org/browse/BONNIE-867