### PR TITLE
Changed database drop command to comply with new versions of mongo

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -8,9 +8,7 @@ WebMock.enable!
 class ActiveSupport::TestCase
 
   def dump_database
-    Mongoid.default_session.collections.each do |c|
-      c.drop()
-    end
+    Mongoid.default_session.drop()
   end
 
   def collection_fixtures(*collection_names)


### PR DESCRIPTION
This is to fix issues with travis and some of the team having updated versions of mongo that have issues with dropping individual collections. This address BONNIE-886. This still works with older versions of mongo.