### PR TITLE
Fixed coverage model from not updating after patient delete.

### DIFF
--- a/app/assets/javascripts/models/coverage.js.coffee
+++ b/app/assets/javascripts/models/coverage.js.coffee
@@ -3,16 +3,16 @@ class Thorax.Model.Coverage extends Thorax.Model
     @population = options.population
     @differences = @population.differencesFromExpected()
     @measureCriteria = @population.dataCriteriaKeys()
-    @clauseResults = []
-    for difference in @differences.models
-      clauseResult = difference.result.get('clause_results')
-      @clauseResults.push(clauseResult)
-      
+
     @listenTo @differences, 'change add reset destroy remove', @update
     @update()
 
   update: ->
     if @population.measure().get('cql')
+
+      # get the latest set of clause_results
+      @clauseResults = @differences.map (difference) -> difference.result.get('clause_results')
+
       # Coverage is 0 if there are no patients
       if @clauseResults.length == 0
         @set coverage: 0


### PR DESCRIPTION
Moved the code that grabs the clause_results used for calculation of coverage into the update function so calculations actually use the updated data. Also shortened it to use the .map function on the collection.

Test. https://jira.mitre.org/browse/BONNIE-900