### PR TITLE
prevent infinite finalize loop if 2 measures have same hqmf_set_id

### DIFF
--- a/app/controllers/measures_controller.rb
+++ b/app/controllers/measures_controller.rb
@@ -81,7 +81,6 @@ class MeasuresController < ApplicationController
         existing = CqlMeasure.by_user(current_user).where(hqmf_set_id: measure.hqmf_set_id)
         qdm_existing = Measure.by_user(current_user).where(hqmf_set_id: measure.hqmf_set_id)
         # Check if there is already a CQL measure with the given hqmf_set_id, this is intentionally different than checking if qdm based is already uploaded (>0 vs >1)
-        # TODO: Duplication checks should be more smoothly managed before CQL is fully incorperated
         if existing.count > 0 || qdm_existing.count > 0
           flash[:error] = {title: "Error Loading Measure", summary: "A version of this measure is already loaded.", body: "You have a version of this measure loaded already.  Try deleting that measure and re-uploading it."}
           redirect_to "#{root_path}##{params[:redirect_route]}"
@@ -293,7 +292,7 @@ class MeasuresController < ApplicationController
         end
       rescue Exception => e
         operator_error = true
-        flash[:error] = {title: "Error Loading Measure", summary: "Error Finalizing Measure", body: "An unexpected error occurred while finalizing this measure.  Please delete the measure, re-export the measure from the MAT, and re-upload the measure."}
+        flash[:error] = {title: "Error Loading Measure", summary: "Error Finalizing Measure", body: "An unexpected error occurred while finalizing this measure.  Please delete the measure, re-package and re-export the measure from the MAT, and re-upload the measure."}
       ensure
         # These 2 steps need to be run even if there was an error, otherwise there will be an infinite loop with the finalize dialog
         measure['needs_finalize'] = false


### PR DESCRIPTION
This change checks if there is another measure with the same hqmf_set_id, which should be unique, upon creation. Previously, only CQL measures were checked for a new CQL measure and only QDM measures were checked for a new QDM measure.  Now both CQL and QDM measures are checked in both cases.

JIRA Test: https://jira.mitre.org/browse/BONNIE-906

Regression test script passed.