### PR TITLE
Add XFS Protection

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,12 @@ class ApplicationController < ActionController::Base
   before_filter :log_additional_data
   layout :layout_by_resource
 
+  after_action :allow_no_iframe
+
+  def allow_no_iframe
+    response.headers['X-Frame-Options'] = 'DENY'
+  end
+
   def layout_by_resource
     if devise_controller?
       "devise"

--- a/app/views/home/show.html.erb
+++ b/app/views/home/show.html.erb
@@ -8,6 +8,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <%= stylesheet_link_tag "application", :media => "all" %>
     <%= render 'layouts/shim' %>
+    <%= render 'layouts/framebreaker' %>
   </head>
   <body>
     <div class="landing-masthead">

--- a/app/views/layouts/_framebreaker.html.erb
+++ b/app/views/layouts/_framebreaker.html.erb
@@ -1,0 +1,9 @@
+<style id="antiClickjack">body{display:none !important;}</style>
+<script type="text/javascript">
+   if (self === top) {
+       var antiClickjack = document.getElementById("antiClickjack");
+       antiClickjack.parentNode.removeChild(antiClickjack);
+   } else {
+       top.location = self.location;
+   }
+</script>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,6 +8,7 @@
     <%= stylesheet_link_tag "application", :media => "all" %>
     <%= csrf_meta_tags %>
     <%= render 'layouts/shim' %>
+    <%= render 'layouts/framebreaker' %>
   </head>
 
   <body>

--- a/app/views/layouts/debug.html.erb
+++ b/app/views/layouts/debug.html.erb
@@ -6,6 +6,7 @@
   <%= stylesheet_link_tag :application %>
   <%= javascript_include_tag :application %>
   <%= csrf_meta_tag %>
+  <%= render 'layouts/framebreaker' %>
 </head>
 
 <body>

--- a/app/views/layouts/devise.html.erb
+++ b/app/views/layouts/devise.html.erb
@@ -8,6 +8,7 @@
   <%= stylesheet_link_tag :application %>
   <%= javascript_include_tag :application %>
   <%= csrf_meta_tag %>
+  <%= render 'layouts/framebreaker' %>
 </head>
 
 <body>

--- a/app/views/layouts/errors.html.erb
+++ b/app/views/layouts/errors.html.erb
@@ -8,6 +8,7 @@
     <%= stylesheet_link_tag "application", :media => "all" %>
     <%= csrf_meta_tags %>
     <%= render 'layouts/shim' %>
+    <%= render 'layouts/framebreaker' %>
   </head>
 
   <body>


### PR DESCRIPTION
Sets the `X-Frame-Options` response header to `DENY` for every request. Adds a framebreaker script. Will blank out the page and attempt to navigate the window to bonnie if it finds it is in a frame.

JIRA test for framebreaker can only be run in development because it needs a code change to actually be capable on a modern browser. https://jira.mitre.org/browse/BONNIE-947

JIRA test for header changes PR and regression. https://jira.mitre.org/browse/BONNIE-946