### PR TITLE
Fix let keyword and identifiers highlighting

### DIFF
--- a/app/assets/javascripts/helpers/cql_measure_helpers.js.coffee
+++ b/app/assets/javascripts/helpers/cql_measure_helpers.js.coffee
@@ -85,6 +85,14 @@ class CQLMeasureHelpers
       else if k == 'sort'
         # Sort is a special case that we need to recurse into separately and set the results to the result of the statement the sort clause is in
         @_findAllLocalIdsInSort(v, libraryName, localIds, aliasMap, emptyResultClauses, parentNode)
+      else if k == 'let'
+        # let is a special case where it is an array, one for each defined alias. These aliases work slightly different
+        # and execution engine does return results for them on use. The Initial naming of them needs to be properly pointed
+        # to what they are set to.
+        for aLet in v
+          # Add the localId for the definition of this let to it's source.
+          localIds[aLet.localId] = { localId: aLet.localId, sourceLocalId: aLet.expression.localId }
+          @_findAllLocalIdsInStatement(aLet.expression, libraryName, localIds, aliasMap, emptyResultClauses, statement)
       # If 'First' and 'Last' expressions, the result of source of the clause should be set to the expression
       else if k=='type' && (v =='First' || v == 'Last')
         if statement.source && statement.source.localId?

--- a/app/assets/javascripts/views/logic/cql_clause_view.js.coffee
+++ b/app/assets/javascripts/views/logic/cql_clause_view.js.coffee
@@ -46,7 +46,21 @@ class Thorax.Views.CqlClauseView extends Thorax.Views.BonnieView
         @_setResult false
       else
         @$el.attr('class', '')  # Clear the rationale if we can't make sense of the result
-        
+
+    # if this is a let keyword then we should make it green if the localId it belongs in was hit
+    else if @element.text == 'let '
+      # navigate up to the parent view with a ref_id. Stop if element doesn't exist because we hit the statement.
+      clauseView = @
+      while clauseView.element? && !clauseView.element.ref_id?
+        clauseView = clauseView.parent
+
+      # if we found the parent clause view with a ref_id
+      if clauseView.element?
+        result = results[clauseView.element.ref_id].final
+        # make this clause green if it was 'FALSE' or 'TRUE'. 'UNHIT' and 'NA' shouldn't color.
+        if result == 'FALSE' || result == 'TRUE'
+          @_setResult true
+
   ###*
   # Clear the result for this statement.
   ###


### PR DESCRIPTION
Fix for let keyword and identifiers highlighting.

Keyword has no localid for it. So if the parent localId is hit (i.e. TRUE or FALSE) it will highlight green. It does not always highlight for coverage. This can be open to discussion.

Identifiers now point to the localId for the expression that defines them.

JIRA Task: https://jira.mitre.org/browse/BONNIE-948
JIRA Test: https://jira.mitre.org/browse/BONNIE-963