### PR TITLE
If there is a Result just allow one Result

### DIFF
--- a/app/assets/javascripts/views/patient_builder/data_criteria.js.coffee
+++ b/app/assets/javascripts/views/patient_builder/data_criteria.js.coffee
@@ -389,8 +389,7 @@ class Thorax.Views.EditCriteriaValueView extends Thorax.Views.BuilderChildView
       codes: @measure?.valueSets().map((vs) -> vs.toJSON()) or []
       # QDM say that per instance of a data criteria there can be only 1 Result
       # The function Thorax.Models.PatientDataCriteria.canHaveResult determines which criteria those are
-      onlySingleResultAllowed =  @values.models.length > 0
-      hideEditValueView: onlySingleResultAllowed
+      hideEditValueView: @values.models.length > 0
 
   # When we serialize the form, we want to put the description for any CD codes into the submission
   events:

--- a/app/assets/javascripts/views/patient_builder/data_criteria.js.coffee
+++ b/app/assets/javascripts/views/patient_builder/data_criteria.js.coffee
@@ -387,7 +387,9 @@ class Thorax.Views.EditCriteriaValueView extends Thorax.Views.BuilderChildView
   context: ->
     _(super).extend
       codes: @measure?.valueSets().map((vs) -> vs.toJSON()) or []
-      hideEditValueView: @criteriaType == 'risk_category_assessments' && @values.models.length > 0
+      # Certain data criteria allow for only a single Result per criteria
+      onlySingleResultAllowed = @criteriaType in ['risk_category_assessments', 'physical_exams', 'procedures', 'interventions', 'laboratory_tests', 'diagnostic_studies'] && @values.models.length > 0
+      hideEditValueView: onlySingleResultAllowed
 
   # When we serialize the form, we want to put the description for any CD codes into the submission
   events:

--- a/app/assets/javascripts/views/patient_builder/data_criteria.js.coffee
+++ b/app/assets/javascripts/views/patient_builder/data_criteria.js.coffee
@@ -387,8 +387,9 @@ class Thorax.Views.EditCriteriaValueView extends Thorax.Views.BuilderChildView
   context: ->
     _(super).extend
       codes: @measure?.valueSets().map((vs) -> vs.toJSON()) or []
-      # Certain data criteria allow for only a single Result per criteria
-      onlySingleResultAllowed = @criteriaType in ['risk_category_assessments', 'physical_exams', 'procedures', 'interventions', 'laboratory_tests', 'diagnostic_studies'] && @values.models.length > 0
+      # QDM say that per instance of a data criteria there can be only 1 Result
+      # The function Thorax.Models.PatientDataCriteria.canHaveResult determines which criteria those are
+      onlySingleResultAllowed =  @values.models.length > 0
       hideEditValueView: onlySingleResultAllowed
 
   # When we serialize the form, we want to put the description for any CD codes into the submission

--- a/spec/javascripts/views/patient_builder_spec.js.coffee
+++ b/spec/javascripts/views/patient_builder_spec.js.coffee
@@ -191,6 +191,15 @@ describe 'PatientBuilderView', ->
       expect(@firstCriteria.get('value').first().get('code_list_id')).toEqual '2.16.840.1.113883.3.464.1003.101.12.1061'
       expect(@firstCriteria.get('value').first().get('title')).toEqual 'Ambulatory/ED Visit'
 
+    it "only allows for a single result", ->
+      expect(@firstCriteria.get('value').length).toEqual 0
+      # Want the option to select a Result value to be visible
+      expect(@patientBuilder.$('.edit_value_view.hide')).not.toExist()
+      @addCodedValue '2.16.840.1.113883.3.464.1003.101.12.1061'
+      expect(@firstCriteria.get('value').length).toEqual 1
+      # Once a Result value has been added don't want to be able to add more
+      expect(@patientBuilder.$('.edit_value_view.hide')).toExist()
+    
     it "materializes the patient", ->
       expect(@patientBuilder.model.materialize).not.toHaveBeenCalled()
       @addScalarValue 1, 'mg'


### PR DESCRIPTION
https://jira.mitre.org/browse/BONNIE-853

Align the behavior of Bonnie with the QDM spec (5.02, 5.3) that for certain data criteria there can be up to 1 Result per instance of that criteria.

This change will have the side effect that if a user selects a DateTime that this message will display:
<img width="600" alt="screen shot 2017-08-24 at 6 10 59 pm" src="https://user-images.githubusercontent.com/17731116/29691173-1a38cc58-88f8-11e7-8eda-9804f1745710.png">
(where the measure id will be for whatever measure the user is on.)