### PR TITLE
Remove facility_arrival, facility_departure from encounter

### DIFF
--- a/app/assets/javascripts/models/measure.js.coffee
+++ b/app/assets/javascripts/models/measure.js.coffee
@@ -99,7 +99,7 @@ class Thorax.Models.Measure extends Thorax.Model
       devices: ['removal_time', 'anatomical_structure']
       diagnostic_studies: ['facility', 'method', 'qdm_status', 'result_date_time', 'components']
       encounters: ['admission_source', 'admit_time', 'discharge_time', 'discharge_disposition', 'facility',
-        'facility_arrival', 'facility_departure', 'transfer_to', 'transfer_to_time', 
+        'transfer_to', 'transfer_to_time', 
         'transfer_from', 'transfer_from_time', 'principal_diagnosis', 'diagnosis']
       family_history: ['relationship_to_patient']
       functional_statuses: []


### PR DESCRIPTION
JIRA Test: https://jira.mitre.org/browse/BONNIE-1065

Location Period From/To are now part of the the Facility Location, and therefore should not longer be independent options in the **FIELD VALUES** dropdown for encounters.