### PR TITLE
Fixed ordering of populations to match human readable

### DIFF
--- a/app/assets/javascripts/constants.js.coffee.erb
+++ b/app/assets/javascripts/constants.js.coffee.erb
@@ -12,13 +12,13 @@ Thorax.Models.Measure.PopulationMap =
   'STRAT': 'Stratification'
   'IPP': 'Initial Population'
   'DENOM': 'Denominator'
+  'DENEX': 'Denominator Exclusion'
   'NUMER': 'Numerator'
   'NUMEX': 'Numerator Exclusion'
   'DENEXCEP': 'Denominator Exception'
-  'DENEX': 'Denominator Exclusion'
   'MSRPOPL': 'Measure Population'
-  'OBSERV': 'Measure Observation'
   'MSRPOPLEX': 'Measure Population Exclusion'
+  'OBSERV': 'Measure Observation'
 
 # List of CQL define statements added by the MAT that do not need to be shown.
 Thorax.Models.Measure.cqlSkipStatements = ["SDE Ethnicity", "SDE Payer", "SDE Race", "SDE Sex"]

--- a/spec/javascripts/fixtures/json/measure_data/CQL/CMS347/CMS735v0.json
+++ b/spec/javascripts/fixtures/json/measure_data/CQL/CMS347/CMS735v0.json
@@ -17373,6 +17373,8 @@
   ],
   "populations_cql_map": {
     "IPP": [
+      "Initial Population",
+      "Initial Population",
       "Initial Population"
     ],
     "DENOM": [
@@ -17381,13 +17383,18 @@
       "Denominator 3"
     ],
     "DENEX": [
+      "Denex",
+      "Denex",
       "Denex"
     ],
     "DENEXCEP": [
       "Denexcep",
+      "Denexcep",
       "Denexcep Den3"
     ],
     "NUMER": [
+      "Numerator",
+      "Numerator",
       "Numerator"
     ]
   },

--- a/spec/javascripts/views/cql_logic_view_spec.js.coffee
+++ b/spec/javascripts/views/cql_logic_view_spec.js.coffee
@@ -32,7 +32,7 @@ describe 'CqlLogicView', ->
 
     populationLogicView.showRationale(results)
 
-  it 'sorts logic properly', ->
+  it 'sorts logic properly for observation measure', ->
     bonnie.valueSetsByOid = getJSONFixture('/measure_data/cqltest/value_sets.json')
 
     population = @cqlMeasure.get('populations').first()
@@ -46,10 +46,10 @@ describe 'CqlLogicView', ->
     expect(populationLogicView.populationStatementViews[0].cqlPopulations).toEqual(['IPP'])
     expect(populationLogicView.populationStatementViews[1].name).toEqual('Measure Population')
     expect(populationLogicView.populationStatementViews[1].cqlPopulations).toEqual(['MSRPOPL'])
-    expect(populationLogicView.populationStatementViews[2].name).toEqual('MeasureObservation')
-    expect(populationLogicView.populationStatementViews[2].cqlPopulations).toEqual(['OBSERV_1'])
-    expect(populationLogicView.populationStatementViews[3].name).toEqual('Measure Population Exclusion')
-    expect(populationLogicView.populationStatementViews[3].cqlPopulations).toEqual(['MSRPOPLEX'])
+    expect(populationLogicView.populationStatementViews[2].name).toEqual('Measure Population Exclusion')
+    expect(populationLogicView.populationStatementViews[2].cqlPopulations).toEqual(['MSRPOPLEX'])
+    expect(populationLogicView.populationStatementViews[3].name).toEqual('MeasureObservation')
+    expect(populationLogicView.populationStatementViews[3].cqlPopulations).toEqual(['OBSERV_1'])
 
     expect(populationLogicView.defineStatementViews.length).toBe(1)
     expect(populationLogicView.defineStatementViews[0].name).toEqual('Inpatient Encounter')
@@ -61,7 +61,7 @@ describe 'CqlLogicView', ->
     expect(populationLogicView.unusedStatementViews[0].name).toEqual('Startification1')
     expect(populationLogicView.unusedStatementViews[1].name).toEqual('Stratification2')
 
-  it 'sorts logic properly with stratification', ->
+  it 'sorts logic properly for observation measure with stratification', ->
     bonnie.valueSetsByOid = getJSONFixture('/measure_data/cqltest/value_sets.json')
 
     population = @cqlMeasure.get('populations').at(1)
@@ -77,10 +77,10 @@ describe 'CqlLogicView', ->
     expect(populationLogicView.populationStatementViews[1].cqlPopulations).toEqual(['IPP'])
     expect(populationLogicView.populationStatementViews[2].name).toEqual('Measure Population')
     expect(populationLogicView.populationStatementViews[2].cqlPopulations).toEqual(['MSRPOPL'])
-    expect(populationLogicView.populationStatementViews[3].name).toEqual('MeasureObservation')
-    expect(populationLogicView.populationStatementViews[3].cqlPopulations).toEqual(['OBSERV_1'])
-    expect(populationLogicView.populationStatementViews[4].name).toEqual('Measure Population Exclusion')
-    expect(populationLogicView.populationStatementViews[4].cqlPopulations).toEqual(['MSRPOPLEX'])
+    expect(populationLogicView.populationStatementViews[3].name).toEqual('Measure Population Exclusion')
+    expect(populationLogicView.populationStatementViews[3].cqlPopulations).toEqual(['MSRPOPLEX'])
+    expect(populationLogicView.populationStatementViews[4].name).toEqual('MeasureObservation')
+    expect(populationLogicView.populationStatementViews[4].cqlPopulations).toEqual(['OBSERV_1'])
 
     expect(populationLogicView.defineStatementViews.length).toBe(1)
     expect(populationLogicView.defineStatementViews[0].name).toEqual('Inpatient Encounter')
@@ -90,3 +90,24 @@ describe 'CqlLogicView', ->
 
     expect(populationLogicView.unusedStatementViews.length).toBe(1)
     expect(populationLogicView.unusedStatementViews[0].name).toEqual('Stratification2')
+
+  it 'sorts logic properly for proportion measure', ->
+    measure = new Thorax.Models.Measure getJSONFixture('measure_data/CQL/CMS347/CMS735v0.json'), parse: true
+    bonnie.valueSetsByOid = getJSONFixture('/measure_data/CQL/CMS347/value_sets.json')
+
+    population = measure.get('populations').at(0)
+    populationLogicView = new Thorax.Views.CqlPopulationLogic(model: measure, highlightPatientDataEnabled: true, population: population)
+    populationLogicView.render()
+
+    expect(populationLogicView.allStatementViews.length).toBe(38)
+    expect(populationLogicView.populationStatementViews.length).toBe(5)
+    expect(populationLogicView.populationStatementViews[0].name).toEqual('Initial Population')
+    expect(populationLogicView.populationStatementViews[0].cqlPopulations).toEqual(['IPP'])
+    expect(populationLogicView.populationStatementViews[1].name).toEqual('Denominator 1')
+    expect(populationLogicView.populationStatementViews[1].cqlPopulations).toEqual(['DENOM'])
+    expect(populationLogicView.populationStatementViews[2].name).toEqual('Denex')
+    expect(populationLogicView.populationStatementViews[2].cqlPopulations).toEqual(['DENEX'])
+    expect(populationLogicView.populationStatementViews[3].name).toEqual('Numerator')
+    expect(populationLogicView.populationStatementViews[3].cqlPopulations).toEqual(['NUMER'])
+    expect(populationLogicView.populationStatementViews[4].name).toEqual('Denexcep')
+    expect(populationLogicView.populationStatementViews[4].cqlPopulations).toEqual(['DENEXCEP'])


### PR DESCRIPTION
This fixes the ordering of populations in the logic view to match the MAT human readable. Unit tests were updated. An additional a test was added to cover the change in order for proportion measures. Note that there was a broken fixture that was fixed. It had an old/faulty populations_cql_map.

Pull requests into Bonnie require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] JIRA ticket for this PR: https://jira.mitre.org/browse/BONNIE-1100
- [x] JIRA ticket links to this PR
- [x] Code diff has been done and been reviewed
- [x] If UI changes have been made, google WAVE plug-in has been executed to ensure no 508 issues were introduced. N/A because code that changes the eventual ordering shouldn't change 508 things.
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Automated regression test(s) pass

If JIRA tests were used to supplement or replace automated tests:
- [x] JIRA test links: N/A
- [x] Justification for using JIRA tests: N/A
- [x] JIRA tests have been added to sprint N/A


**Reviewer 1:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

If JIRA tests were used to supplement or replace automated tests:
- [x] JIRA tests have been run and pass
- [x] You agree with the justification for use of JIRA tests or have provided input on why you disagree


**Reviewer 2:**

Name: @losborne
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

If JIRA tests were used to supplement or replace automated tests:
- [x] JIRA tests have been run and pass (N/A)
- [x] You agree with the justification for use of JIRA tests or have provided input on why you disagree (N/A)
