### PR TITLE
Bonnie 1090

### DIFF
--- a/spec/javascripts/views/measure_view_spec.js.coffee
+++ b/spec/javascripts/views/measure_view_spec.js.coffee
@@ -78,6 +78,10 @@ describe 'MeasureView', ->
         expect(@cqlMeasureValueSetsView.terminology.length).toEqual(25)
         expect(@cqlMeasureValueSetsView.overlappingValueSets.length).toEqual(6)
 
+      it 'renders direct reference codes', ->
+        expect(@cqlMeasureValueSetsView.$('#terminology')).toContainText 'Direct Reference Code'
+
+
       it 'renders terminology section', ->
         expect(@cqlMeasureValueSetsView.$('#terminology')).toExist()
         expect(@cqlMeasureValueSetsView.$('#terminology')).toBeVisible()

--- a/spec/javascripts/views/measure_view_spec.js.coffee
+++ b/spec/javascripts/views/measure_view_spec.js.coffee
@@ -75,8 +75,8 @@ describe 'MeasureView', ->
         expect(@cqlMeasureValueSetsView.$('.value_sets')).toBeVisible()
 
       it 'has the right number of value sets', ->
-        expect(@cqlMeasureValueSetsView.terminology.length).toEqual(23)
-        expect(@cqlMeasureValueSetsView.overlappingValueSets.length).toEqual(2)
+        expect(@cqlMeasureValueSetsView.terminology.length).toEqual(25)
+        expect(@cqlMeasureValueSetsView.overlappingValueSets.length).toEqual(6)
 
       it 'renders terminology section', ->
         expect(@cqlMeasureValueSetsView.$('#terminology')).toExist()


### PR DESCRIPTION
Originally, only direct reference codes from the main library were added to the data criteria section.

With the most recent change, no direct reference codes were added to the "terminology section", which replaced the "data criteria" section.

With this change, all direct reference codes will be added to the "terminology" section.
Pull requests into Bonnie require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [X] This pull request describes why these changes were made.
- [X] JIRA ticket for this PR: https://jira.mitre.org/browse/BONNIE-1090
- [x] JIRA ticket links to this PR 
- [X] Code diff has been done and been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [X] If UI changes have been made, google WAVE plug-in has been executed to ensure no 508 issues were introduced.
- [X] Tests are included and test edge cases
- [X] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [X] Code coverage has not gone down and all code touched or added is covered. 
     * See [front-end testing instructions](https://github.com/projecttacoma/bonnie/wiki/Testing#frontend-testing) for getting coverage for front-end tests
     * In rare situations, this may not be possible or applicable to a PR. In those situations:
         1. Note why this could not be done or is not applicable here: 
         2. Add TODOs in the code noting that it requires a test
         3. Add a JIRA task to add the test and link it here: 
- [x] Automated regression test(s) pass

If JIRA tests were used to supplement or replace automated tests:
- [X] JIRA test links: NA
- [X] Justification for using JIRA tests: NA
- [X] JIRA tests have been added to sprint NA


**Reviewer 1:**

Name: @holmesie
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

If JIRA tests were used to supplement or replace automated tests:
- [x] JIRA tests have been run and pass
- [x] You agree with the justification for use of JIRA tests or have provided input on why you disagree


**Reviewer 2:**

Name: @alexanderelliott121 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

If JIRA tests were used to supplement or replace automated tests:
- [x] N/A - JIRA tests have been run and pass
- [x] N/A - You agree with the justification for use of JIRA tests or have provided input on why you disagree
