### PR TITLE
Cql4bonnie 1163

### DIFF
--- a/app/assets/javascripts/cql_calculator.js.coffee
+++ b/app/assets/javascripts/cql_calculator.js.coffee
@@ -201,10 +201,6 @@
     else if @isValueZero('NUMER', population_results)
       if 'NUMEX' of population_results
         population_results['NUMEX'] = 0
-    # Can not be in the numerator if explicitly excluded
-    else if population_results["NUMEX"]? && !@isValueZero('NUMEX', population_results)
-      if 'NUMER' of population_results
-        population_results['NUMER'] = 0
     else if !@isValueZero('NUMER', population_results)
       if 'DENEXCEP' of population_results
         population_results["DENEXCEP"] = 0

--- a/spec/javascripts/models/result_spec.js.coffee
+++ b/spec/javascripts/models/result_spec.js.coffee
@@ -25,3 +25,25 @@ describe 'Result', ->
     expect(result1.calculation.state()).toEqual 'resolved'
     result2 = new Thorax.Models.Result({ rationale: 'RATIONALE' }, population: @measure.get('populations').first(), patient: @patient)
     expect(result2.calculation.state()).toEqual 'resolved'
+
+  it 'NUMER population not modified by inclusion in NUMEX', ->
+    initial_results = {IPP: 1, DENOM: 1, DENEX: 0, NUMER: 1, NUMEX: 1}
+    processed_results = bonnie.cql_calculator.handlePopulationValues(initial_results)
+    expect(processed_results).toEqual initial_results
+    
+  it 'NUMEX membership removed when not a member of NUMER', ->
+    initial_results = {IPP: 1, DENOM: 1, DENEX: 0, NUMER: 0, NUMEX: 1}
+    expected_results = {IPP: 1, DENOM: 1, DENEX: 0, NUMER: 0, NUMEX: 0}
+    processed_results = bonnie.cql_calculator.handlePopulationValues(initial_results)
+    expect(processed_results).toEqual expected_results
+
+  it 'DENOM population not modified by inclusion in DENEX', ->
+    initial_results = {IPP: 1, DENOM: 1, DENEX: 1, NUMER: 0, NUMEX: 0}
+    processed_results = bonnie.cql_calculator.handlePopulationValues(initial_results)
+    expect(processed_results).toEqual initial_results
+    
+  it 'DENEX membership removed when not a member of DENOM', ->
+    initial_results = {IPP: 1, DENOM: 0, DENEX: 1, NUMER: 0, NUMEX: 0}
+    expected_results = {IPP: 1, DENOM: 0, DENEX: 0, NUMER: 0, NUMEX: 0}
+    processed_results = bonnie.cql_calculator.handlePopulationValues(initial_results)
+    expect(processed_results).toEqual expected_results


### PR DESCRIPTION
Should be tested with cql_qdm_patientapi branch cql4bonnie_393
Internal JIRA: https://jira.mitre.org/browse/BONNIE-1163
External JIRA: https://oncprojectracking.healthit.gov/support/browse/BONNIE-393

This change fixes behavior regarding the relationship between NUMEX and NUMER. Before, the results for NUMER would be discounted if the patient was a member of NUMEX. Now, the NUMER results persist when the patient is a member of NUMEX.

Pull requests into Bonnie require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] JIRA ticket for this PR:
- [x] JIRA ticket links to this PR
- [x] Code diff has been done and been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] If UI changes have been made, google WAVE plug-in has been executed to ensure no 508 issues were introduced.
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Code coverage has not gone down and all code touched or added is covered. 
     * See [front-end testing instructions](https://github.com/projecttacoma/bonnie/wiki/Testing#frontend-testing) for getting coverage for front-end tests
     * In rare situations, this may not be possible or applicable to a PR. In those situations:
         1. Note why this could not be done or is not applicable here: 
         2. Add TODOs in the code noting that it requires a test
         3. Add a JIRA task to add the test and link it here: 
- [x] Automated regression test(s) pass

If JIRA tests were used to supplement or replace automated tests:
- [x] JIRA test links:
- [x] Justification for using JIRA tests:
- [x] JIRA tests have been added to sprint


**Reviewer 1:** @holmesie

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

If JIRA tests were used to supplement or replace automated tests:
- [x] N/A - JIRA tests have been run and pass
- [x] N/A - You agree with the justification for use of JIRA tests or have provided input on why you disagree


**Reviewer 2:** @ahubley

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

If JIRA tests were used to supplement or replace automated tests:
- [x] N/A - JIRA tests have been run and pass
- [x] N/A - You agree with the justification for use of JIRA tests or have provided input on why you disagree
