### PR TITLE
Cql4bonnie revert hquery patientapi reference

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ gem 'simplexml_parser', :git => 'https://github.com/projecttacoma/simplexml_pars
 gem 'hqmf2js', :git => 'https://github.com/projecttacoma/hqmf2js.git', :branch => 'master'
 gem 'bonnie_bundler', :git => 'https://github.com/projecttacoma/bonnie_bundler.git', :branch => 'cql4bonnie'
 gem 'quality-measure-engine', :git => 'https://github.com/projectcypress/quality-measure-engine.git', :branch => 'bump_mongoid'
-gem 'hquery-patient-api', :git => 'https://github.com/projecttacoma/patientapi.git', :branch => 'QDM_5-0'
+gem 'hquery-patient-api', :git => 'https://github.com/projecttacoma/patientapi.git', :branch => 'master'
 
 # gem 'hquery-patient-api', '1.0.4'
 # gem 'health-data-standards', :path => '../health-data-standards'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -32,14 +32,14 @@ GIT
 
 GIT
   remote: https://github.com/projecttacoma/bonnie_bundler.git
-  revision: 3210c51ae7c948999b54d0f3636d0bd9c6ed4e07
+  revision: d7132d764e887fe6a643e3c7b18003ed93ca9774
   branch: cql4bonnie
   specs:
     bonnie_bundler (1.0.0)
 
 GIT
   remote: https://github.com/projecttacoma/cql_qdm_patientapi.git
-  revision: 1b9103db1adb2ee517301e3a3d5c1825edb4ecc8
+  revision: e11701446c0ef6c8f927ea358d4e51634a9751fd
   branch: cql4bonnie
   specs:
     cql_qdm_patientapi (0.1.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -55,8 +55,8 @@ GIT
 
 GIT
   remote: https://github.com/projecttacoma/patientapi.git
-  revision: 5ea68b4e87d8d88385084efcb9d25ecc210fec0b
-  branch: QDM_5-0
+  revision: f56ba28452ab4b2ef4f2f6dbc585cd4e7f64f045
+  branch: master
   specs:
     hquery-patient-api (1.0.4)
 


### PR DESCRIPTION
cql4bonnie was referencing QDM-5_0 branch of hquery-patientapi. However, cql4bonnie doesn't need to use hquery-patientapi period. We should revert this to master to not include unneeded changes.

Pull requests into Bonnie require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [X] This pull request describes why these changes were made.
- [X] JIRA ticket for this PR: https://jira.mitre.org/browse/BONNIE-1182
- [x] JIRA ticket links to this PR
- [X] Code diff has been done and been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [X] If UI changes have been made, google WAVE plug-in has been executed to ensure no 508 issues were introduced.
- [X] Tests are included and test edge cases
   N/A - automated tests and regression test should suffice as no new code was added
- [X] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [X] Code coverage has not gone down and all code touched or added is covered. 
     * See [front-end testing instructions](https://github.com/projecttacoma/bonnie/wiki/Testing#frontend-testing) for getting coverage for front-end tests
     * In rare situations, this may not be possible or applicable to a PR. In those situations:
         1. Note why this could not be done or is not applicable here: 
         2. Add TODOs in the code noting that it requires a test
         3. Add a JIRA task to add the test and link it here: 

  Code coverage is reduced but this appears to be due to the inclusion of rake test in the coverage calculations which is not a result of this commit.
- [x] Automated regression test(s) pass

If JIRA tests were used to supplement or replace automated tests:
- [X] JIRA test links: N/A
- [X] Justification for using JIRA tests: N/A
- [X] JIRA tests have been added to sprint N/A


**Reviewer 1:**

Name: @ahubley
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases - N/A already covered
- [x] You have tried to break the code

If JIRA tests were used to supplement or replace automated tests:
- [x] JIRA tests have been run and pass - N/A
- [x] You agree with the justification for use of JIRA tests or have provided input on why you disagree - N/A


**Reviewer 2:**

Name: @losborne
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases NA
- [x] You have tried to break the code NA

If JIRA tests were used to supplement or replace automated tests:
- [x] JIRA tests have been run and pass NA
- [x] You agree with the justification for use of JIRA tests or have provided input on why you disagree NA
