### PR TITLE
remove direct ref codes from overlaping section

### DIFF
--- a/app/assets/javascripts/views/measure_value_sets.js.coffee
+++ b/app/assets/javascripts/views/measure_value_sets.js.coffee
@@ -84,7 +84,6 @@ class Thorax.Views.MeasureValueSets extends Thorax.Views.BonnieView
                 valueSet = { name: display, oid: 'Direct Reference Code', version: 'N/A', codes: codes, cid: cid }
 
                 terminology.push(valueSet)
-                @addSummaryValueSet(valueSet, guid, cid, name, codes)
 
         if library.library.valueSets
           library.library.valueSets.def.forEach (value_set) =>

--- a/spec/javascripts/views/measure_view_spec.js.coffee
+++ b/spec/javascripts/views/measure_view_spec.js.coffee
@@ -76,7 +76,7 @@ describe 'MeasureView', ->
 
       it 'has the right number of value sets', ->
         expect(@cqlMeasureValueSetsView.terminology.length).toEqual(25)
-        expect(@cqlMeasureValueSetsView.overlappingValueSets.length).toEqual(6)
+        expect(@cqlMeasureValueSetsView.overlappingValueSets.length).toEqual(2)
 
       it 'renders direct reference codes', ->
         expect(@cqlMeasureValueSetsView.$('#terminology')).toContainText 'Direct Reference Code'


### PR DESCRIPTION
Direct reference codes should not be added to the overlapping valueset section.

Pull requests into Bonnie require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [X] JIRA ticket for this PR: https://jira.mitre.org/browse/BONNIE-1183
- [x] JIRA ticket links to this PR
- [x] Code diff has been done and been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] If UI changes have been made, google WAVE plug-in has been executed to ensure no 508 issues were introduced.
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Code coverage has not gone down and all code touched or added is covered. 
     * See [front-end testing instructions](https://github.com/projecttacoma/bonnie/wiki/Testing#frontend-testing) for getting coverage for front-end tests
     * In rare situations, this may not be possible or applicable to a PR. In those situations:
         1. Note why this could not be done or is not applicable here: 
         2. Add TODOs in the code noting that it requires a test
         3. Add a JIRA task to add the test and link it here: 
- [x] Automated regression test(s) pass

If JIRA tests were used to supplement or replace automated tests:
- [x] JIRA test links:
- [x] Justification for using JIRA tests:
- [x] JIRA tests have been added to sprint


**Reviewer 1:** @mayerm94

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

If JIRA tests were used to supplement or replace automated tests:
- [x] JIRA tests have been run and pass
- [x] You agree with the justification for use of JIRA tests or have provided input on why you disagree


**Reviewer 2:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

If JIRA tests were used to supplement or replace automated tests:
- [x] JIRA tests have been run and pass
- [x] You agree with the justification for use of JIRA tests or have provided input on why you disagree
