### PR TITLE
Add backwards compatibility for clean_cql_db.js for MongoDB < 2.6

### DIFF
--- a/db/clean_cql_db.js
+++ b/db/clean_cql_db.js
@@ -33,27 +33,25 @@ bundle_ids = db.getCollection('users').distinct("bundle_id", {}, {bundle_id: 1})
 // remove orphans
 print("## DELETING ORPHANED PATIENTS");
 removed_result = db.getCollection('records').remove({"user_id": {$nin: user_ids}})
-print("\t" + removed_result.nRemoved.toString() + " removed");
+print_if_defined(removed_result);
 
 print("## DELETING ORPHANED MEASURES");
 removed_result = db.getCollection('cql_measures').remove({"user_id": {$nin: user_ids}})
-print("\t" + removed_result.nRemoved.toString() + " removed");
+print_if_defined(removed_result);
 
 print("## DELETING ORPHANED VALUE SETS");
 removed_result = db.getCollection('health_data_standards_svs_value_sets').remove({"user_id": {$nin: user_ids}})
-print("\t" + removed_result.nRemoved.toString() + " removed");
+print_if_defined(removed_result);
 
 print("## DELETING ORPHANED BUNDLES");
 removed_result = db.getCollection('bundles').remove({"_id": {$nin: bundle_ids}})
-print("\t" + removed_result.nRemoved.toString() + " removed");
+print_if_defined(removed_result);
 
 print("## DELETING FIELDS 'too_big', 'has_measure_history', 'calc_results' FROM RECORDS");
 db.getCollection('records').update( {}, {$unset: {too_big:"", has_measure_history:"", calc_results:""}}, {multi:true});
 
 print("## CHANGE RECORD FIELD 'is_shared' TO FALSE");
 db.getCollection('records').update( {}, {$set: {is_shared:false}}, {multi:true});
-
-
 
 // delete the users and all data associated with the users
 function delete_users_information(query) {
@@ -63,21 +61,27 @@ function delete_users_information(query) {
 
   print("* DELETING PATIENTS")
   removed_result = db.getCollection('records').remove({"user_id": {$in: user_ids}})
-  print("\t" + removed_result.nRemoved.toString() + " removed");
-  
+  print_if_defined(removed_result);
+
   print("* DELETING MEASURES")
   removed_result = db.getCollection('cql_measures').remove({"user_id": {$in: user_ids}})
-  print("\t" + removed_result.nRemoved.toString() + " removed");
-  
+  print_if_defined(removed_result);
+
   print("* DELETING VALUESETS")
   removed_result = db.getCollection('health_data_standards_svs_value_sets').remove({"user_id": {$in: user_ids}})
-  print("\t" + removed_result.nRemoved.toString() + " removed");
-  
+  print_if_defined(removed_result);
+
   print("* DELETING BUNDLES")
   removed_result = db.getCollection('bundles').remove({"_id": {$in: bundle_ids}})
-  print("\t" + removed_result.nRemoved.toString() + " removed");
-  
+  print_if_defined(removed_result);
+
   print("* DELETING USERS")
   removed_result = db.getCollection('users').remove({"_id": {$in: user_ids}})
-  print("\t" + removed_result.nRemoved.toString() + " removed");
+  print_if_defined(removed_result);
 };
+
+function print_if_defined(removed_result) {
+  if (typeof(removed_result) !== "undefined") {
+    print("\t" + removed_result.nRemoved.toString() + " removed");
+  }
+}


### PR DESCRIPTION
MongoDB versions < 2.6 don't return a record removed count from `.remove()`, which `clean_cql_db.js` was relying on to provide statistics for the DB cleaning script. This pull request adds a function `print_if_defined`, which only prints the number of removed results if it's actually returned from the function call.

Pull requests into Bonnie require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] JIRA ticket for this PR: https://jira.mitre.org/browse/BONNIE-1184
- [x] JIRA ticket links to this PR
- [x] Code diff has been done and been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] If UI changes have been made, google WAVE plug-in has been executed to ensure no 508 issues were introduced. N/A
- [x] Tests are included and test edge cases N/A
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable) 
     * Tested locally with MongoDB `2.4.14` and `3.4.4`, works with both (though, as expected, only 3.4.4 provides remove counts)
- [x] Code coverage has not gone down and all code touched or added is covered. N/A
     * See [front-end testing instructions](https://github.com/projecttacoma/bonnie/wiki/Testing#frontend-testing) for getting coverage for front-end tests
     * In rare situations, this may not be possible or applicable to a PR. In those situations:
         1. Note why this could not be done or is not applicable here: 
         2. Add TODOs in the code noting that it requires a test
         3. Add a JIRA task to add the test and link it here: 
- [x] Automated regression test(s) pass N/A

If JIRA tests were used to supplement or replace automated tests:
- [x] JIRA test links: N/A
- [x] Justification for using JIRA tests: N/A
- [x] JIRA tests have been added to sprint N/A


**Reviewer 1:**

Name: @ahubley
- [X] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [X] The tests appropriately test the new code, including edge cases - N/A, manual testing with mongo 2.4.14
- [X] You have tried to break the code

If JIRA tests were used to supplement or replace automated tests:
- [X] JIRA tests have been run and pass - N/A
- [X] You agree with the justification for use of JIRA tests or have provided input on why you disagree - N/A


**Reviewer 2:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

If JIRA tests were used to supplement or replace automated tests:
- [x] JIRA tests have been run and pass
- [x] You agree with the justification for use of JIRA tests or have provided input on why you disagree
