### PR TITLE
remove files accidentally added in previous PR

### DIFF
--- a/bonnie_production-2017-11-06-15-27-09/bonnie_production/patient_cache.metadata.json
+++ b/bonnie_production-2017-11-06-15-27-09/bonnie_production/patient_cache.metadata.json
@@ -1,1 +1,0 @@
-{ "options" : { "create" : "patient_cache" }, "indexes" : [ { "v" : 1, "name" : "_id_", "key" : { "_id" : 1 }, "ns" : "bonnie_production.patient_cache" }, { "v" : 1, "name" : "value.last_1", "key" : { "value.last" : 1 }, "ns" : "bonnie_production.patient_cache" }, { "v" : 1, "name" : "bundle_id_1", "key" : { "bundle_id" : 1 }, "ns" : "bonnie_production.patient_cache" } ] }


### PR DESCRIPTION
Removing bonnie production files that got accidentally added in https://github.com/projecttacoma/bonnie/pull/888

Pull requests into Bonnie require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Code diff has been done and been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Automated regression test(s) pass


**Reviewer 1:**

Name: @mayerm94  
- [x] The tests appropriately test the new code, including edge cases
- [x] Sanity check passes that these files are OK to remove

