### PR TITLE
Update db:prune_dumps to make it more aggressive (QDM-Logic)

### DIFF
--- a/lib/tasks/bonnie.rake
+++ b/lib/tasks/bonnie.rake
@@ -316,7 +316,7 @@ namespace :bonnie do
         files.delete f
       end
       # File from older than three months, keep most recent in each month
-      files.select { |f| file_time(f) < 3.month.ago }.group_by { |f| file_time(f).strftime('%Y month %m') }.each do |week, ff|
+      files.select { |f| file_time(f) < 3.month.ago }.group_by { |f| file_time(f).strftime('%Y month %m') }.each do |month, ff|
         sorted = ff.sort_by { |f| file_time(f) }
         puts "Keeping #{sorted.pop}"
         sorted.each do |f|

--- a/test/unit/prune_dumps_test.rb
+++ b/test/unit/prune_dumps_test.rb
@@ -1,0 +1,102 @@
+require 'test_helper'
+
+# Tests for bonnie:db:prune_dumps rake task. Note that coverage for the task is not being calculated correctly.
+class PruneDumpsTest < ActiveSupport::TestCase
+
+  DUMP_TIME_FORMAT = "%Y-%m-%d-%H-%M-%S"
+  DUMPS_FOLDER = File.join('db', 'backups')
+
+  def create_mock_dump(date)
+    filename = "bonnie_production-#{date.strftime(DUMP_TIME_FORMAT)}.tgz"
+    FileUtils.touch File.join(DUMPS_FOLDER, filename)
+    filename
+  end
+
+  setup do
+    if !Dir.exist?(DUMPS_FOLDER)
+      Dir.mkdir(DUMPS_FOLDER)
+    end
+    Dir.glob(File.join(DUMPS_FOLDER, '*.tgz')).each { |f| File.delete(f) }
+    Bonnie::Application.load_tasks
+  end
+
+  test "dumps things older than a year old" do
+    remove_filenames = []
+    keep_filenames = []
+    remove_filenames << create_mock_dump(13.months.ago)
+    remove_filenames << create_mock_dump(2.years.ago)
+    keep_filenames << create_mock_dump(11.months.ago)
+    keep_filenames << create_mock_dump(2.months.ago)
+    keep_filenames << create_mock_dump(DateTime.now)
+
+    Rake::Task['bonnie:db:prune_dumps'].execute
+
+    remove_filenames.each { |f| assert_equal false, File.exist?(File.join(DUMPS_FOLDER, f)), "#{f} should have been removed" }
+    keep_filenames.each { |f| assert_equal true, File.exist?(File.join(DUMPS_FOLDER, f)), "#{f} should have been kept" }
+  end
+
+  test "keeps newest monthly older than 3 months" do
+    remove_filenames = []
+    keep_filenames = []
+
+    firstMonth = 5.months.ago
+    firstOfMonth = Date.new(firstMonth.year, firstMonth.month, 1)
+    remove_filenames << create_mock_dump(firstOfMonth)
+    remove_filenames << create_mock_dump(firstOfMonth.next_day(6))
+    keep_filenames << create_mock_dump(firstOfMonth.next_day(18))
+
+    firstMonth = 6.months.ago
+    firstOfMonth = Date.new(firstMonth.year, firstMonth.month, 1)
+    remove_filenames << create_mock_dump(firstOfMonth)
+    remove_filenames << create_mock_dump(firstOfMonth.next_day(6))
+    keep_filenames << create_mock_dump(firstOfMonth.next_day(18))
+
+    Rake::Task['bonnie:db:prune_dumps'].execute
+
+    remove_filenames.each { |f| assert_equal false, File.exist?(File.join(DUMPS_FOLDER, f)), "#{f} should have been removed" }
+    keep_filenames.each { |f| assert_equal true, File.exist?(File.join(DUMPS_FOLDER, f)), "#{f} should have been kept" }
+  end
+
+  test "keeps most recent weekly dump within last 3 months" do
+    remove_filenames = []
+    keep_filenames = []
+
+    # figure out the first day of the week approximately 2 months ago
+    twoMonthsAgo = 2.months.ago
+    twoMonthsAgoDT = DateTime.new(twoMonthsAgo.year, twoMonthsAgo.month, twoMonthsAgo.day)
+    firstOfWeek = twoMonthsAgoDT.prev_day(twoMonthsAgoDT.wday - 1)
+
+    # create a few mocks for this week. the last will be kept
+    remove_filenames << create_mock_dump(firstOfWeek)
+    remove_filenames << create_mock_dump(firstOfWeek.next_day(2))
+    keep_filenames << create_mock_dump(firstOfWeek.next_day(5))
+
+    # for the following week do the same.
+    remove_filenames << create_mock_dump(firstOfWeek.next_day(7))
+    remove_filenames << create_mock_dump(firstOfWeek.next_day(10))
+    keep_filenames << create_mock_dump(firstOfWeek.next_day(13))
+
+    Rake::Task['bonnie:db:prune_dumps'].execute
+
+    remove_filenames.each { |f| assert_equal false, File.exist?(File.join(DUMPS_FOLDER, f)), "#{f} should have been removed" }
+    keep_filenames.each { |f| assert_equal true, File.exist?(File.join(DUMPS_FOLDER, f)), "#{f} should have been kept" }
+  end
+
+  test "keeps most recent daily dump within last month" do
+    remove_filenames = []
+    keep_filenames = []
+
+    sixDaysAgo = DateTime.new(6.days.ago.year, 6.days.ago.month, 6.days.ago.day)
+    remove_filenames << create_mock_dump(sixDaysAgo)
+    keep_filenames << create_mock_dump(sixDaysAgo.advance(minutes: 30, hours: 1))
+    keep_filenames << create_mock_dump(sixDaysAgo.next_day)
+    keep_filenames << create_mock_dump(sixDaysAgo.next_day(2))
+    remove_filenames << create_mock_dump(sixDaysAgo.next_day(3))
+    keep_filenames << create_mock_dump(sixDaysAgo.next_day(3).advance(hours: 4))
+
+    Rake::Task['bonnie:db:prune_dumps'].execute
+
+    remove_filenames.each { |f| assert_equal false, File.exist?(File.join(DUMPS_FOLDER, f)), "#{f} should have been removed" }
+    keep_filenames.each { |f| assert_equal true, File.exist?(File.join(DUMPS_FOLDER, f)), "#{f} should have been kept" }
+  end
+end


### PR DESCRIPTION
now pruning everything older than a year, keeping monthly for 3-12 months ago, weekly for past three months, daily for past month

Pull requests into Bonnie require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] JIRA ticket for this PR: https://jira.mitre.org/browse/BONNIE-1223
- [x] JIRA ticket links to this PR
- [x] Code diff has been done and been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] If UI changes have been made, google WAVE plug-in has been executed to ensure no 508 issues were introduced. N/A
- [x] Tests are included and test edge cases. Edge cases are difficult to create because of the moving date.
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Code coverage has not gone down and all code touched or added is covered. 
     * See [front-end testing instructions](https://github.com/projecttacoma/bonnie/wiki/Testing#frontend-testing) for getting coverage for front-end tests
     * In rare situations, this may not be possible or applicable to a PR. In those situations:
         1. Note why this could not be done or is not applicable here: 
              This destroys coverage. 82.69% to 56.98% because of the loading of rake tasks. Additionally the coverage tool fails to properly count coverage for most parts of the new code.
         2. Add TODOs in the code noting that it requires a test
         3. Add a JIRA task to add the test and link it here: 
- [x] Automated regression test(s) pass. N/A does not touch calculation code

If JIRA tests were used to supplement or replace automated tests:
- [x] JIRA test links: N/A
- [x] Justification for using JIRA tests: N/A
- [x] JIRA tests have been added to sprint N/A


**Reviewer 1:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

If JIRA tests were used to supplement or replace automated tests:
- [x] JIRA tests have been run and pass
- [x] You agree with the justification for use of JIRA tests or have provided input on why you disagree


**Reviewer 2:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

If JIRA tests were used to supplement or replace automated tests:
- [x] JIRA tests have been run and pass
- [x] You agree with the justification for use of JIRA tests or have provided input on why you disagree
