### PR TITLE
Fix for code dropdowns not populating

### DIFF
--- a/lib/tasks/bonnie.rake
+++ b/lib/tasks/bonnie.rake
@@ -495,7 +495,7 @@ namespace :bonnie do
         record.source_data_criteria.each do |sdc|
           if sdc['hqmf_set_id'] && sdc['hqmf_set_id'] != hqmf_set_id
             sdc['hqmf_set_id'] = hqmf_set_id
-            changed = true
+            has_changed = true
           end
         end
         begin

--- a/lib/tasks/bonnie.rake
+++ b/lib/tasks/bonnie.rake
@@ -692,42 +692,6 @@ namespace :bonnie do
       puts "Materialized #{count} of #{records.count} patients"
     end
 
-    desc "Updated source_data_criteria to include title and description from measure(s)"
-    task :update_source_data_criteria=> :environment do
-      puts "Updating patient source_data_criteria to include title and description"
-      Record.each do |patient|
-        measures = Measure.in(hqmf_set_id:  patient.measure_ids).to_a
-        puts "\tUpdating source data criteria for record #{patient.first} #{patient.last}"
-        patient.source_data_criteria.each do |patient_data_criteria|
-          measures.each do |measure|
-            measure_data_criteria = measure.source_data_criteria[patient_data_criteria['id']]
-            if  measure_data_criteria && measure_data_criteria['code_list_id'] == patient_data_criteria['oid']
-              patient_data_criteria['hqmf_set_id'] = measure['hqmf_set_id']
-              patient_data_criteria['cms_id'] = measure['cms_id']
-              patient_data_criteria['code_list_id'] = patient_data_criteria['oid']
-              patient_data_criteria['title'] = measure_data_criteria['title']
-              patient_data_criteria['description'] = measure_data_criteria['description']
-              patient_data_criteria['negation'] = patient_data_criteria['negation'] == "true"
-              patient_data_criteria['type'] = measure_data_criteria['type']
-              patient_data_criteria['end_date']=nil if patient_data_criteria['end_date'] == 32503698000000
-
-              # FIXME Not sure why field_values has no keys now, did the Cypress patient set change?
-              unless patient_data_criteria['field_values'].blank?
-                patient_data_criteria['field_values'].keys.each do |key|
-                  field_value = patient_data_criteria['field_values'][key]
-                  if (field_value['type'] == 'TS')
-                    field_value['value'] = Time.strptime(field_value['value'],"%m/%d/%Y %H:%M").to_i*1000 rescue field_value['value']
-                  end
-                end
-              end if patient_data_criteria['field_values']
-            end
-          end
-        end
-        patient.save
-      end
-
-    end
-
     desc 'Update measure ids from NQF to HQMF.'
     task :update_measure_ids => :environment do
       puts "Updating patient measure_ids from NQF to HQMF"
@@ -840,6 +804,22 @@ namespace :bonnie do
           if sdc['hqmf_set_id'] && sdc['hqmf_set_id'] != dest_measure.hqmf_set_id
             sdc['hqmf_set_id'] = dest_measure.hqmf_set_id
           end
+
+          measure_sdc = dest_measure.source_data_criteria[sdc['id']]
+          if measure_sdc
+            if sdc['cms_id'] && sdc['cms_id'] != measure_sdc['cms_id']
+              sdc['cms_id'] = measure_sdc['cms_id']
+            end
+            if sdc['title'] && sdc['title'] != measure_sdc['title']
+              sdc['title'] = measure_sdc['title']
+            end
+            if sdc['description'] && sdc['description'] != measure_sdc['description']
+              sdc['description'] = measure_sdc['description']
+            end
+            if sdc['type'] && sdc['type'] != measure_sdc['type']
+              sdc['type'] = measure_sdc['type']
+            end
+          end
         end
         r.save
       end
@@ -893,6 +873,12 @@ namespace :bonnie do
     def print_success(success_string)
       print "\e[#{32}m#{"[Success]"}\e[0m\t"
       puts success_string
+    end
+
+    # Prints a message with a warning "[Warning]" string ahead of it.
+    def print_warning(warning_string)
+      print "\e[#{33}m#{"[Warning]"}\e[0m\t"
+      puts warning_string
     end
 
   end

--- a/lib/tasks/bonnie.rake
+++ b/lib/tasks/bonnie.rake
@@ -477,38 +477,6 @@ namespace :bonnie do
 
   namespace :patients do
 
-    desc %{Ensures that all patients' hqmf_set_ids match their source_data_criteria's hqmf_set_ids
-
-    $ rake bonnie:patients:fix_source_data_criteria_hqmf_set_ids}
-    task :fix_source_data_criteria_hqmf_set_ids => :environment do
-      Record.all.each do |record|
-        email = User.find_by(_id: record[:user_id]).email
-        first = record.first
-        last = record.last
-        has_changed = false
-
-        hqmf_set_id = record.measure_ids[0]
-        if !hqmf_set_id
-          print_error("#{last}, #{first} does not have an HQMF Set ID.")
-        end
-
-        record.source_data_criteria.each do |sdc|
-          if sdc['hqmf_set_id'] && sdc['hqmf_set_id'] != hqmf_set_id
-            sdc['hqmf_set_id'] = hqmf_set_id
-            has_changed = true
-          end
-        end
-        begin
-          record.save!
-          if has_changed
-            print_success("Fixing mismatch on User: #{email}, first: #{first}, last: #{last}")
-          end
-        rescue Mongo::Error::OperationFailure => e
-          print_error("#{e}: #{email}, first: #{first}, last: #{last}")
-        end
-      end
-    end
-
     desc %{Copy measure patients from one user account to another
 
     You must identify the source user by SOURCE_EMAIL,

--- a/lib/tasks/bonnie.rake
+++ b/lib/tasks/bonnie.rake
@@ -477,6 +477,38 @@ namespace :bonnie do
 
   namespace :patients do
 
+    desc %{Ensures that all patients' hqmf_set_ids match their source_data_criteria's hqmf_set_ids
+
+    $ rake bonnie:patients:fix_source_data_criteria_hqmf_set_ids}
+    task :fix_source_data_criteria_hqmf_set_ids => :environment do
+      Record.all.each do |record|
+        email = User.find_by(_id: record[:user_id]).email
+        first = record.first
+        last = record.last
+        has_changed = false
+
+        hqmf_set_id = record.measure_ids[0]
+        if !hqmf_set_id
+          print_error("#{last}, #{first} does not have an HQMF Set ID.")
+        end
+
+        record.source_data_criteria.each do |sdc|
+          if sdc['hqmf_set_id'] && sdc['hqmf_set_id'] != hqmf_set_id
+            sdc['hqmf_set_id'] = hqmf_set_id
+            changed = true
+          end
+        end
+        begin
+          record.save!
+          if has_changed
+            print_success("Fixing mismatch on User: #{email}, first: #{first}, last: #{last}")
+          end
+        rescue Mongo::Error::OperationFailure => e
+          print_error("#{e}: #{email}, first: #{first}, last: #{last}")
+        end
+      end
+    end
+
     desc %{Copy measure patients from one user account to another
 
     You must identify the source user by SOURCE_EMAIL,
@@ -834,6 +866,11 @@ namespace :bonnie do
         r.expected_values.each do |expected_value|
           if expected_value['measure_id'] == src_measure.hqmf_set_id
             expected_value['measure_id'] = dest_measure.hqmf_set_id
+          end
+        end
+        r.source_data_criteria.each do |sdc|
+          if sdc['hqmf_set_id'] && sdc['hqmf_set_id'] != dest_measure.hqmf_set_id
+            sdc['hqmf_set_id'] = dest_measure.hqmf_set_id
           end
         end
         r.save

--- a/test/unit/rake_test.rb
+++ b/test/unit/rake_test.rb
@@ -180,10 +180,12 @@ class RakeTest < ActiveSupport::TestCase
 
     source_patients = Record.where(measure_ids:@source_hqmf_set_id)
     dest_patients = Record.where(measure_ids:@dest_hqmf_set_id)
+    dest_measures = CqlMeasure.where(hqmf_set_id:@dest_hqmf_set_id)
+    assert_equal dest_measures.length, 1
+    dest_measure = dest_measures.first
 
     # Make fake sdc items in measure as if measure has relevant sdc
     source_patients.each do |record|
-      dest_measure = CqlMeasure.find_by(hqmf_set_id:@dest_hqmf_set_id, user_id: record[:user_id])
       record.source_data_criteria.each do |sdc|
         fake_sdc = {cms_id: 'Testv1', title: 'FakeTitle', description: 'FakeDescription', type: 'FakeType'}
         dest_measure.source_data_criteria[sdc['id']] = fake_sdc

--- a/test/unit/rake_test.rb
+++ b/test/unit/rake_test.rb
@@ -180,10 +180,10 @@ class RakeTest < ActiveSupport::TestCase
 
     source_patients = Record.where(measure_ids:@source_hqmf_set_id)
     dest_patients = Record.where(measure_ids:@dest_hqmf_set_id)
-    dest_measure = CqlMeasure.find_by(hqmf_set_id:@dest_hqmf_set_id)
 
     # Make fake sdc items in measure as if measure has relevant sdc
     source_patients.each do |record|
+      dest_measure = CqlMeasure.find_by(hqmf_set_id:@dest_hqmf_set_id, user_id: record[:user_id])
       record.source_data_criteria.each do |sdc|
         fake_sdc = {cms_id: 'Testv1', title: 'FakeTitle', description: 'FakeDescription', type: 'FakeType'}
         dest_measure.source_data_criteria[sdc['id']] = fake_sdc

--- a/test/unit/rake_test.rb
+++ b/test/unit/rake_test.rb
@@ -17,7 +17,6 @@ class RakeTest < ActiveSupport::TestCase
 
     @source_email = 'bonnie@example.com'
     @dest_email = 'user_admin@example.com'
-
     @source_hqmf_set_id = '5375D6A9-203B-4FFF-B851-AFA9B68D2AC2'
     @dest2_hqmf_set_id = '93F3479F-75D8-4731-9A3F-B7749D8BCD37'
     @dest_hqmf_set_id = 'A4B9763C-847E-4E02-BB7E-ACC596E90E2C'

--- a/test/unit/rake_test.rb
+++ b/test/unit/rake_test.rb
@@ -17,6 +17,7 @@ class RakeTest < ActiveSupport::TestCase
 
     @source_email = 'bonnie@example.com'
     @dest_email = 'user_admin@example.com'
+
     @source_hqmf_set_id = '5375D6A9-203B-4FFF-B851-AFA9B68D2AC2'
     @dest2_hqmf_set_id = '93F3479F-75D8-4731-9A3F-B7749D8BCD37'
     @dest_hqmf_set_id = 'A4B9763C-847E-4E02-BB7E-ACC596E90E2C'
@@ -172,7 +173,7 @@ class RakeTest < ActiveSupport::TestCase
     assert_equal(7, dest_patients.count)
   end
 
-  test "copy_measure_patients updates source data criteria hqmf_set_id" do
+  test "copy_measure_patients updates source data criteria" do
     ENV['SOURCE_EMAIL'] = @source_email
     ENV['DEST_EMAIL'] = @dest_email
     ENV['SOURCE_HQMF_SET_ID'] = @source_hqmf_set_id
@@ -180,6 +181,16 @@ class RakeTest < ActiveSupport::TestCase
 
     source_patients = Record.where(measure_ids:@source_hqmf_set_id)
     dest_patients = Record.where(measure_ids:@dest_hqmf_set_id)
+    dest_measure = CqlMeasure.find_by(hqmf_set_id:@dest_hqmf_set_id)
+
+    # Make fake sdc items in measure as if measure has relevant sdc
+    source_patients.each do |record|
+      record.source_data_criteria.each do |sdc|
+        fake_sdc = {cms_id: 'Testv1', title: 'FakeTitle', description: 'FakeDescription', type: 'FakeType'}
+        dest_measure.source_data_criteria[sdc['id']] = fake_sdc
+      end
+      dest_measure.save
+    end
 
     assert_output(
                   "Copying patients from '5375D6A9-203B-4FFF-B851-AFA9B68D2AC2' in 'bonnie@example.com' to 'A4B9763C-847E-4E02-BB7E-ACC596E90E2C' in 'user_admin@example.com'\n" +
@@ -191,6 +202,22 @@ class RakeTest < ActiveSupport::TestCase
       record.source_data_criteria.each do |sdc|
         if sdc['hqmf_set_id']
           assert_equal(sdc['hqmf_set_id'], @dest_hqmf_set_id)
+        end
+
+        measure_sdc = dest_measure.source_data_criteria[sdc['id']]
+        if measure_sdc
+          if sdc['cms_id']
+            assert_equal(sdc['cms_id'], measure_sdc['cms_id'])
+          end
+          if sdc['title']
+            assert_equal(sdc['title'], measure_sdc['title'])
+          end
+          if sdc['description']
+            assert_equal(sdc['description'], measure_sdc['description'])
+          end
+          if sdc['type']
+            assert_equal(sdc['type'], measure_sdc['type'])
+          end
         end
       end
     end

--- a/test/unit/rake_test.rb
+++ b/test/unit/rake_test.rb
@@ -172,6 +172,30 @@ class RakeTest < ActiveSupport::TestCase
     assert_equal(7, dest_patients.count)
   end
 
+  test "copy_measure_patients updates source data criteria hqmf_set_id" do
+    ENV['SOURCE_EMAIL'] = @source_email
+    ENV['DEST_EMAIL'] = @dest_email
+    ENV['SOURCE_HQMF_SET_ID'] = @source_hqmf_set_id
+    ENV['DEST_HQMF_SET_ID'] = @dest_hqmf_set_id
+
+    source_patients = Record.where(measure_ids:@source_hqmf_set_id)
+    dest_patients = Record.where(measure_ids:@dest_hqmf_set_id)
+
+    assert_output(
+                  "Copying patients from '5375D6A9-203B-4FFF-B851-AFA9B68D2AC2' in 'bonnie@example.com' to 'A4B9763C-847E-4E02-BB7E-ACC596E90E2C' in 'user_admin@example.com'\n" +
+                  "\e[#{32}m#{"[Success]"}\e[0m\tSuccessfully copied patients from '5375D6A9-203B-4FFF-B851-AFA9B68D2AC2' in 'bonnie@example.com' to 'A4B9763C-847E-4E02-BB7E-ACC596E90E2C' in 'user_admin@example.com'\n"
+                 ) { Rake::Task['bonnie:patients:copy_measure_patients'].execute }
+
+    dest_patients = Record.where(measure_ids:@dest_hqmf_set_id)
+    dest_patients.each do |record|
+      record.source_data_criteria.each do |sdc|
+        if sdc['hqmf_set_id']
+          assert_equal(sdc['hqmf_set_id'], @dest_hqmf_set_id)
+        end
+      end
+    end
+  end
+
   test "move_patients_csv moves patients" do
     ENV['CSV_PATH'] = File.join(Rails.root, 'test', 'fixtures', 'csv', 'good_transfers.csv')
 


### PR DESCRIPTION
This PR is to fix the issue of code dropdowns not populating, which was caused by the underlying issue of patients' source_data_criteria having different hqmf_set_ids than the patient itself.  This difference was a result of an omission in the rake tasks that move patients.  This PR includes a fix for that omission as well as a rake task to fix up the database that needs only be run once.

A suggestion to remove this duplicated hqmf_set_id in the database was also added to the wiki here: https://gitlab.mitre.org/bonnie/internal-documentation/wikis/Bonnie-Improvements

Pull requests into Bonnie require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

NOTE: There is one patient that fails to update due to having a dotted field:
```
[Error]         The dotted field '2.16.840.1.113883.6.12' in 'source_data_criteria.1.codes.2.16.840.1.113883.6.12' is not valid for storage. (57): epecqmncqa@gmail.com, first: EncInMPInvldCustCode, last: IPPFail
```
So this rake task should be run after that issue gets resolved.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] JIRA ticket for this PR: https://jira.mitre.org/browse/BONNIE-1233
- [x] JIRA ticket links to this PR
- [x] Code diff has been done and been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] If UI changes have been made, google WAVE plug-in has been executed to ensure no 508 issues were introduced.
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Code coverage has not gone down and all code touched or added is covered. 
     * See [front-end testing instructions](https://github.com/projecttacoma/bonnie/wiki/Testing#frontend-testing) for getting coverage for front-end tests
     * In rare situations, this may not be possible or applicable to a PR. In those situations:
         1. Note why this could not be done or is not applicable here: 
         2. Add TODOs in the code noting that it requires a test
         3. Add a JIRA task to add the test and link it here: 
- [x] Automated regression test(s) pass

If JIRA tests were used to supplement or replace automated tests:
- [x] N/A JIRA test links:
- [x] N/A Justification for using JIRA tests:
- [x] N/A JIRA tests have been added to sprint


**Reviewer 1:** @mayerm94

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

If JIRA tests were used to supplement or replace automated tests:
- [x] JIRA tests have been run and pass
- [x] You agree with the justification for use of JIRA tests or have provided input on why you disagree


**Reviewer 2:** @c-monkey 

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

If JIRA tests were used to supplement or replace automated tests:
- [x] JIRA tests have been run and pass
- [x] You agree with the justification for use of JIRA tests or have provided input on why you disagree
