### PR TITLE
Revert move patients

### DIFF
--- a/lib/tasks/bonnie.rake
+++ b/lib/tasks/bonnie.rake
@@ -804,22 +804,6 @@ namespace :bonnie do
           if sdc['hqmf_set_id'] && sdc['hqmf_set_id'] != dest_measure.hqmf_set_id
             sdc['hqmf_set_id'] = dest_measure.hqmf_set_id
           end
-
-          measure_sdc = dest_measure.source_data_criteria[sdc['id']]
-          if measure_sdc
-            if sdc['cms_id'] && sdc['cms_id'] != measure_sdc['cms_id']
-              sdc['cms_id'] = measure_sdc['cms_id']
-            end
-            if sdc['title'] && sdc['title'] != measure_sdc['title']
-              sdc['title'] = measure_sdc['title']
-            end
-            if sdc['description'] && sdc['description'] != measure_sdc['description']
-              sdc['description'] = measure_sdc['description']
-            end
-            if sdc['type'] && sdc['type'] != measure_sdc['type']
-              sdc['type'] = measure_sdc['type']
-            end
-          end
         end
         r.save
       end

--- a/test/unit/rake_test.rb
+++ b/test/unit/rake_test.rb
@@ -204,22 +204,6 @@ class RakeTest < ActiveSupport::TestCase
         if sdc['hqmf_set_id']
           assert_equal(sdc['hqmf_set_id'], @dest_hqmf_set_id)
         end
-
-        measure_sdc = dest_measure.source_data_criteria[sdc['id']]
-        if measure_sdc
-          if sdc['cms_id']
-            assert_equal(sdc['cms_id'], measure_sdc['cms_id'])
-          end
-          if sdc['title']
-            assert_equal(sdc['title'], measure_sdc['title'])
-          end
-          if sdc['description']
-            assert_equal(sdc['description'], measure_sdc['description'])
-          end
-          if sdc['type']
-            assert_equal(sdc['type'], measure_sdc['type'])
-          end
-        end
       end
     end
   end


### PR DESCRIPTION
…t (only update hqmf_set_id)

This PR is to remove the part of the `move_patients()` function that caused issues with the 12/20 release.
The `source_data_criteria` fields on patients that have moved from one measure to another do not match the destination measure, but those fields cannot be directly pulled from the destination measure.  There is string parsing and manipulating on the front end that happens before those fields are saved on the patient.

`hqmf_set_id` remains because it is necessary to populate the dropdowns and can be derived from the patient itself without needing to look at a measure.

Pull requests into Bonnie require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] This PR is into the correct branch.
- [X] JIRA ticket for this PR: https://jira.mitre.org/browse/BONNIE-1233
- [x] JIRA ticket links to this PR
- [X] Code diff has been done and been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [X] N/A If UI changes have been made, google WAVE plug-in has been executed to ensure no 508 issues were introduced.
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [X] Code coverage has not gone down and all code touched or added is covered. 

Before: 1461 / 2531 LOC (57.72%) covered.
After:  1451 / 2521 LOC (57.56%) covered.
Since 10 covered lines were removed, the coverage % actually goes down.  But only those 10 lines were changed in the coverage, and every line in the `move_patients()` function is covered.

- [X] Automated regression test(s) pass

Steps: 
Pull latest alpha backup
- run 'before' branch with branch cql4bonnie
- run `bundle exec rake bonnie:patients:update_source_data_criteria` with `bonnie_alpha` database
- run 'after' branch with branch revert_move_patients

If JIRA tests were used to supplement or replace automated tests:
- [x] N/A JIRA test links:
- [x] N/A Justification for using JIRA tests:
- [x] N/A JIRA tests have been added to sprint


**Reviewer 1:** @mayerm94

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

If JIRA tests were used to supplement or replace automated tests:
- [x] JIRA tests have been run and pass NA
- [x] You agree with the justification for use of JIRA tests or have provided input on why you disagree NA


**Reviewer 2:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

If JIRA tests were used to supplement or replace automated tests:
- [x] JIRA tests have been run and pass
- [x] You agree with the justification for use of JIRA tests or have provided input on why you disagree

  