### PR TITLE
Cql4bonnie ebr remove msrpoplex observ

### DIFF
--- a/app/assets/javascripts/cql_calculator.js.coffee
+++ b/app/assets/javascripts/cql_calculator.js.coffee
@@ -182,6 +182,7 @@
         population_results['NUMER'] = 0
       if 'NUMEX' of population_results
         population_results['NUMEX'] = 0
+    # TODO: Temporarily disable the removal of OBSERVs when a member of MSRPOPLEX as to not change actual result values uncomment for 2.1 release
     #else if (population_results["MSRPOPLEX"]? && !@isValueZero('MSRPOPLEX', population_results))
     #  if 'values' of population_results
     #    population_results['values'] = []

--- a/app/assets/javascripts/cql_calculator.js.coffee
+++ b/app/assets/javascripts/cql_calculator.js.coffee
@@ -75,7 +75,7 @@
 
       # Calculate results for each CQL statement
       results = executeSimpleELM(elm, patientSource, @valueSetsForCodeService(), population.collection.parent.get('main_cql_library'), main_library_version, params)
-
+      debugger
       # Parse CQL statement results into population values
       [population_results, episode_results] = @createPopulationValues population, results, patient, observation_defs
 
@@ -228,17 +228,18 @@
           # structured (note the single 'value' section in the
           # measureObservationDefinition clause).
           obs_results = results['patientResults']?[patient.id]?[ob_def]
-
+          debugger
           for obs_result in obs_results
           # Add the single result value to the values array on the results of
           # this calculation (allowing for more than one possible observation).
             if obs_result?.hasOwnProperty('value')
               # If result is a cql.Quantity type, add its value
-              population_results['values'].push(obs_result.value)
+              population_results['values'].push(obs_result.observation.value)
             else
               # In all other cases, add result
-              population_results['values'].push(obs_result)
+              population_results['values'].push(obs_result.observation)
     return population_results
+
 
   ###*
   # Create population values (aka results) for all episodes using the results from the calculator. This is
@@ -445,14 +446,29 @@
         return:
           distinct: false,
           expression:
-            name: functionName,
-            type: 'FunctionRef',
-            operand: [
+            type: 'Tuple',
+            element: [
               {
-                type: 'As',
-                operand: {
+                name: "episode",
+                value: {
                   name: 'MP',
                   type: 'AliasRef'
+                }
+              },
+              {
+                name: "observation",
+                value: {
+                  name: functionName,
+                  type: 'FunctionRef',
+                  operand: [
+                    {
+                      type: 'As',
+                      operand: {
+                        name: 'MP',
+                        type: 'AliasRef'
+                      }
+                    }
+                  ]
                 }
               }
             ]

--- a/app/assets/javascripts/cql_calculator.js.coffee
+++ b/app/assets/javascripts/cql_calculator.js.coffee
@@ -122,18 +122,23 @@
     else # episode of care based measure
       # collect results per episode
       episode_results = @createEpisodePopulationValues(population, results, patient, observation_defs)
+
+      # initialize population counts
+      for popCode in Thorax.Models.Measure.allPopulationCodes
+        if population.get(popCode)?
+          if popCode == 'OBSERV'
+            population_results.values = []
+          else
+            population_results[popCode] = 0
+
       # count up all population results for a patient level count
       for _, episode_result of episode_results
         for popCode, popResult of episode_result
           if popCode == 'values'
-            if !population_results.values?
-              population_results.values = []
             for value in popResult
               population_results.values.push(value)
-          else if population_results[popCode]?
-            population_results[popCode] += popResult
           else
-            population_results[popCode] = popResult
+            population_results[popCode] += popResult
     return [population_results, episode_results]
 
   ###*

--- a/app/assets/javascripts/cql_calculator.js.coffee
+++ b/app/assets/javascripts/cql_calculator.js.coffee
@@ -209,8 +209,9 @@
     # Grab the mapping between populations and CQL statements
     cql_map = population.collection.parent.get('populations_cql_map')
     # Grab the correct expected for this population
-    popIndex = population.get('index')
-    expected = patient.get('expected_values').findWhere(measure_id: population.collection.parent.get('hqmf_set_id'), population_index: popIndex)
+    populationIndex = population.get('index')
+    measureId = population.collection.parent.get('hqmf_set_id')
+    expected = patient.get('expected_values').findWhere(measure_id: measureId, population_index: populationIndex)
     # Loop over all population codes ("IPP", "DENOM", etc.)
     for popCode in Thorax.Models.Measure.allPopulationCodes
       if cql_map[popCode]
@@ -271,8 +272,6 @@
     episode_results = {}
     # Grab the mapping between populations and CQL statements
     cql_map = population.collection.parent.get('populations_cql_map')
-    popIndex = population.get('index')
-
     # Loop over all population codes ("IPP", "DENOM", etc.) to deterine ones included in this population.
     popCodesInPopulation = []
     for popCode in Thorax.Models.Measure.allPopulationCodes
@@ -304,7 +303,8 @@
                     newEpisode[pop] = 0 unless pop == 'OBSERV'
                   newEpisode[popCode] = 1
                   episode_results[value.id().value] = newEpisode
-
+          else
+            console.log('WARNING: CQL Results not an array') if console?
       else if popCode == 'OBSERV' && observation_defs?.length > 0
         # Handle observations using the names of the define statements that
         # were added to the ELM to call the observation functions.
@@ -338,6 +338,9 @@
               for pop in popCodesInPopulation
                 newEpisode[pop] = 0 unless pop == 'OBSERV'
               newEpisode.values = [result_value]
+              episode_results[episodeId] = newEpisode
+      else if popCode == 'OBSERV' && observation_defs?.length <= 0
+        console.log('WARNING: No function definition injected for OBSERV') if console?
     # Correct any inconsistencies. ex. In DENEX but also in NUMER using same function used for patients.
     for episodeId, episode_result of episode_results
       episode_results[episodeId] = @handlePopulationValues(episode_result)

--- a/app/assets/javascripts/cql_calculator.js.coffee
+++ b/app/assets/javascripts/cql_calculator.js.coffee
@@ -182,9 +182,9 @@
         population_results['NUMER'] = 0
       if 'NUMEX' of population_results
         population_results['NUMEX'] = 0
-    else if (population_results["MSRPOPLEX"]? && !@isValueZero('MSRPOPLEX', population_results))
-      if 'values' of population_results
-        population_results['values'] = []
+    #else if (population_results["MSRPOPLEX"]? && !@isValueZero('MSRPOPLEX', population_results))
+    #  if 'values' of population_results
+    #    population_results['values'] = []
     else if @isValueZero('NUMER', population_results)
       if 'NUMEX' of population_results
         population_results['NUMEX'] = 0

--- a/spec/javascripts/models/result_spec.js.coffee
+++ b/spec/javascripts/models/result_spec.js.coffee
@@ -96,6 +96,10 @@ describe 'Continuous Variable Calculations', ->
     expect(result.get('population_relevance')['MSRPOPL']).toBe(true)
     expect(result.get('population_relevance')['MSRPOPLEX']).toBe(true)
 
+    # check the results for the episode
+    expectedEpisodeResults = { IPP: 1, MSRPOPL: 1, MSRPOPLEX: 0, values: [15] }
+    expect(result.get('episode_results')['5a15993d5cc9752039b64b8f']).toEqual(expectedEpisodeResults)
+
   it 'can handle multiple episodes observed', ->
     patient = @patients.findWhere(last: '2 ED ', first: 'Visits')
     result = @population.calculate(patient)
@@ -104,20 +108,40 @@ describe 'Continuous Variable Calculations', ->
     expect(result.get('population_relevance')['MSRPOPL']).toBe(true)
     expect(result.get('population_relevance')['MSRPOPLEX']).toBe(true)
 
+    # check the results for the episode
+    expectedEpisodeResults = { IPP: 1, MSRPOPL: 1, MSRPOPLEX: 0, values: [25] }
+    expect(result.get('episode_results')['5a20544b5cc97509451ab202']).toEqual(expectedEpisodeResults)
+    # check the results for the second episode
+    expectedEpisodeResults = { IPP: 1, MSRPOPL: 1, MSRPOPLEX: 0, values: [15] }
+    expect(result.get('episode_results')['5a20544b5cc97509451ab203']).toEqual(expectedEpisodeResults)
+
   it 'can handle multiple episodes observed with one excluded', ->
     patient = @patients.findWhere(last: '2 ED ', first: 'Visits 1 Excl')
     result = @population.calculate(patient)
-    # TODO: after confusion with how exclusions are to be handled, update this. for now exclusions will still be observed
-    expect(result.get('values')).toEqual([25, 15])
+    expect(result.get('values')).toEqual([25])
     expect(result.get('population_relevance')['values']).toBe(true)
     expect(result.get('population_relevance')['MSRPOPL']).toBe(true)
     expect(result.get('population_relevance')['MSRPOPLEX']).toBe(true)
 
+    # check the results for the episode
+    expectedEpisodeResults = { IPP: 1, MSRPOPL: 1, MSRPOPLEX: 0, values: [25] }
+    expect(result.get('episode_results')['5a2056095cc97509451ab210']).toEqual(expectedEpisodeResults)
+    # check the results for the second episode
+    expectedEpisodeResults = { IPP: 1, MSRPOPL: 1, MSRPOPLEX: 1, values: [] }
+    expect(result.get('episode_results')['5a2056095cc97509451ab211']).toEqual(expectedEpisodeResults)
+
+
   it 'can handle multiple episodes observed with both excluded', ->
     patient = @patients.findWhere(last: '2 ED ', first: 'Visits 2 Excl')
     result = @population.calculate(patient)
-    # TODO: after confusion with how exclusions are to be handled, update this. for now exclusions will still be observed
-    expect(result.get('values')).toEqual([25, 15])
+    expect(result.get('values')).toEqual([])
     expect(result.get('population_relevance')['values']).toBe(false)
     expect(result.get('population_relevance')['MSRPOPL']).toBe(true)
     expect(result.get('population_relevance')['MSRPOPLEX']).toBe(true)
+
+    # check the results for the episode
+    expectedEpisodeResults = { IPP: 1, MSRPOPL: 1, MSRPOPLEX: 1, values: [] }
+    expect(result.get('episode_results')['5a2055955cc97509451ab20b']).toEqual(expectedEpisodeResults)
+    # check the results for the second episode
+    expectedEpisodeResults = { IPP: 1, MSRPOPL: 1, MSRPOPLEX: 1, values: [] }
+    expect(result.get('episode_results')['5a2055955cc97509451ab20d']).toEqual(expectedEpisodeResults)

--- a/spec/javascripts/models/result_spec.js.coffee
+++ b/spec/javascripts/models/result_spec.js.coffee
@@ -130,7 +130,6 @@ describe 'Continuous Variable Calculations', ->
     expectedEpisodeResults = { IPP: 1, MSRPOPL: 1, MSRPOPLEX: 1, values: [] }
     expect(result.get('episode_results')['5a2056095cc97509451ab211']).toEqual(expectedEpisodeResults)
 
-
   it 'can handle multiple episodes observed with both excluded', ->
     patient = @patients.findWhere(last: '2 ED ', first: 'Visits 2 Excl')
     result = @population.calculate(patient)

--- a/spec/javascripts/models/result_spec.js.coffee
+++ b/spec/javascripts/models/result_spec.js.coffee
@@ -114,33 +114,34 @@ describe 'Continuous Variable Calculations', ->
     # check the results for the second episode
     expectedEpisodeResults = { IPP: 1, MSRPOPL: 1, MSRPOPLEX: 0, values: [15] }
     expect(result.get('episode_results')['5a20544b5cc97509451ab203']).toEqual(expectedEpisodeResults)
-
-  it 'can handle multiple episodes observed with one excluded', ->
-    patient = @patients.findWhere(last: '2 ED ', first: 'Visits 1 Excl')
-    result = @population.calculate(patient)
-    expect(result.get('values')).toEqual([25])
-    expect(result.get('population_relevance')['values']).toBe(true)
-    expect(result.get('population_relevance')['MSRPOPL']).toBe(true)
-    expect(result.get('population_relevance')['MSRPOPLEX']).toBe(true)
-
-    # check the results for the episode
-    expectedEpisodeResults = { IPP: 1, MSRPOPL: 1, MSRPOPLEX: 0, values: [25] }
-    expect(result.get('episode_results')['5a2056095cc97509451ab210']).toEqual(expectedEpisodeResults)
-    # check the results for the second episode
-    expectedEpisodeResults = { IPP: 1, MSRPOPL: 1, MSRPOPLEX: 1, values: [] }
-    expect(result.get('episode_results')['5a2056095cc97509451ab211']).toEqual(expectedEpisodeResults)
-
-  it 'can handle multiple episodes observed with both excluded', ->
-    patient = @patients.findWhere(last: '2 ED ', first: 'Visits 2 Excl')
-    result = @population.calculate(patient)
-    expect(result.get('values')).toEqual([])
-    expect(result.get('population_relevance')['values']).toBe(false)
-    expect(result.get('population_relevance')['MSRPOPL']).toBe(true)
-    expect(result.get('population_relevance')['MSRPOPLEX']).toBe(true)
-
-    # check the results for the episode
-    expectedEpisodeResults = { IPP: 1, MSRPOPL: 1, MSRPOPLEX: 1, values: [] }
-    expect(result.get('episode_results')['5a2055955cc97509451ab20b']).toEqual(expectedEpisodeResults)
-    # check the results for the second episode
-    expectedEpisodeResults = { IPP: 1, MSRPOPL: 1, MSRPOPLEX: 1, values: [] }
-    expect(result.get('episode_results')['5a2055955cc97509451ab20d']).toEqual(expectedEpisodeResults)
+  
+  # TODO: These tests can be added back in when the MSRPOPLEX removal of OBSERVs is added back to cql_calculator in 2.1 release
+  # it 'can handle multiple episodes observed with one excluded', ->
+  #   patient = @patients.findWhere(last: '2 ED ', first: 'Visits 1 Excl')
+  #   result = @population.calculate(patient)
+  #   expect(result.get('values')).toEqual([25])
+  #   expect(result.get('population_relevance')['values']).toBe(true)
+  #   expect(result.get('population_relevance')['MSRPOPL']).toBe(true)
+  #   expect(result.get('population_relevance')['MSRPOPLEX']).toBe(true)
+  # 
+  #   # check the results for the episode
+  #   expectedEpisodeResults = { IPP: 1, MSRPOPL: 1, MSRPOPLEX: 0, values: [25] }
+  #   expect(result.get('episode_results')['5a2056095cc97509451ab210']).toEqual(expectedEpisodeResults)
+  #   # check the results for the second episode
+  #   expectedEpisodeResults = { IPP: 1, MSRPOPL: 1, MSRPOPLEX: 1, values: [] }
+  #   expect(result.get('episode_results')['5a2056095cc97509451ab211']).toEqual(expectedEpisodeResults)
+  # 
+  # it 'can handle multiple episodes observed with both excluded', ->
+  #   patient = @patients.findWhere(last: '2 ED ', first: 'Visits 2 Excl')
+  #   result = @population.calculate(patient)
+  #   expect(result.get('values')).toEqual([])
+  #   expect(result.get('population_relevance')['values']).toBe(false)
+  #   expect(result.get('population_relevance')['MSRPOPL']).toBe(true)
+  #   expect(result.get('population_relevance')['MSRPOPLEX']).toBe(true)
+  # 
+  #   # check the results for the episode
+  #   expectedEpisodeResults = { IPP: 1, MSRPOPL: 1, MSRPOPLEX: 1, values: [] }
+  #   expect(result.get('episode_results')['5a2055955cc97509451ab20b']).toEqual(expectedEpisodeResults)
+  #   # check the results for the second episode
+  #   expectedEpisodeResults = { IPP: 1, MSRPOPL: 1, MSRPOPLEX: 1, values: [] }
+  #   expect(result.get('episode_results')['5a2055955cc97509451ab20d']).toEqual(expectedEpisodeResults)


### PR DESCRIPTION
For episode of care measures, track the population membership per episode, building a new structure, episode_results, that looks just like the population_results but keyed by the episode id.
This makes use of the episode based results for the patient level counts.

Commented out with a TODO in cql_calculator is the filtering out episodes that should not be "observed" because they are in the MSRPOPLEX. The PR that fixes the input box counts for MSRPOPLEX has been cherrypicked in. This will be re introduced in 2.1 with https://github.com/projecttacoma/bonnie/pull/917

The injected ELM to do the observation has been improved to return a list of tuples of the episode and the observed value. This allows us to match the observation with the episode.
Pull requests into Bonnie require the following. 

Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] JIRA ticket for this PR: https://jira.mitre.org/browse/BONNIE-1234 https://oncprojectracking.healthit.gov/support/browse/BONNIE-402
- [x] JIRA ticket links to this PR
- [x] Code diff has been done and been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] If UI changes have been made, google WAVE plug-in has been executed to ensure no 508 issues were introduced. NA
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Code coverage has not gone down and all code touched or added is covered. 
     * See [front-end testing instructions](https://github.com/projecttacoma/bonnie/wiki/Testing#frontend-testing) for getting coverage for front-end tests
     * In rare situations, this may not be possible or applicable to a PR. In those situations:
         1. Note why this could not be done or is not applicable here: 
         2. Add TODOs in the code noting that it requires a test
         3. Add a JIRA task to add the test and link it here: 
- [x] Automated regression test(s) pass Only regression reported by the script is the buggy patient that is described in the external JIRA ticket

If JIRA tests were used to supplement or replace automated tests:
- [x] JIRA test links: NA
- [x] Justification for using JIRA tests: NA
- [x] JIRA tests have been added to sprint NA


**Reviewer 1:**

Name: @losborne 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

If JIRA tests were used to supplement or replace automated tests:
- [x] JIRA tests have been run and pass: NA
- [x] You agree with the justification for use of JIRA tests or have provided input on why you disagree: NA


**Reviewer 2:**

Name: @c-monkey
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

If JIRA tests were used to supplement or replace automated tests:
- [x] JIRA tests have been run and pass: NA
- [x] You agree with the justification for use of JIRA tests or have provided input on why you disagree: NA

  