### PR TITLE
Excel export empty values fix

### DIFF
--- a/lib/measure_exported_results.rb
+++ b/lib/measure_exported_results.rb
@@ -13,7 +13,12 @@ class MeasureExportedResults
 
   def value_for_population_type(population_type)
     if population_type == 'OBSERV'
-      if @patient.key?('values') && @patient[:rationale].key?('OBSERV')
+      # TODO the check for the 'OBSERV' key was removed in order for patients that were in a broken state
+      # to match between the excel export and Bonnie to address BONNIE-1230.
+      # If those patients can be fixed in the future, that check should be re-integrated.
+
+      # if @patient.key?('values') && @patient[:rationale].key?('OBSERV') && @patient[:values] != ''
+      if @patient.key?('values') && @patient[:values] != ''
         # Convert the array of strings to an array of integers. 
         return @patient[:values].map { |x| x.to_i }.to_s
       else

--- a/lib/measure_exported_results.rb
+++ b/lib/measure_exported_results.rb
@@ -15,10 +15,10 @@ class MeasureExportedResults
     if population_type == 'OBSERV'
       # TODO the check for the 'OBSERV' key was removed in order for patients that were in a broken state
       # to match between the excel export and Bonnie to address BONNIE-1230.
-      # If those patients can be fixed in the future, that check should be re-integrated.
+      # If those patients can be fixed in the future, that check should be re-integrated by using the line below instead:
+      # if @patient.key?('values') && @patient[:rationale].key?('OBSERV') && @patient[:values] != ''
       # TODO: This change needs a unit test (JIRA test used).
 
-      # if @patient.key?('values') && @patient[:rationale].key?('OBSERV') && @patient[:values] != ''
       if @patient.key?('values') && @patient[:values] != ''
         # Convert the array of strings to an array of integers. 
         return @patient[:values].map { |x| x.to_i }.to_s

--- a/lib/measure_exported_results.rb
+++ b/lib/measure_exported_results.rb
@@ -16,6 +16,7 @@ class MeasureExportedResults
       # TODO the check for the 'OBSERV' key was removed in order for patients that were in a broken state
       # to match between the excel export and Bonnie to address BONNIE-1230.
       # If those patients can be fixed in the future, that check should be re-integrated.
+      # TODO: This change needs a unit test (JIRA test used).
 
       # if @patient.key?('values') && @patient[:rationale].key?('OBSERV') && @patient[:values] != ''
       if @patient.key?('values') && @patient[:values] != ''

--- a/lib/patient_export.rb
+++ b/lib/patient_export.rb
@@ -182,7 +182,7 @@ class PatientExport
         expected_values = patient[:expected_values].select{ |expected_values| expected_values[:measure_id] == measure.hqmf_set_id && 
                                                                               expected_values[:population_index] == population_index }.try(:first)
         # populate array with expected values
-        if expected_values && expected_values[population_category]  
+        if expected_values && expected_values[population_category] && expected_values[population_category] != []
           patient_row.push(expected_values[population_category])
         else
           patient_row.push(0)

--- a/test/functional/patients_controller_test.rb
+++ b/test/functional/patients_controller_test.rb
@@ -438,6 +438,9 @@ include Devise::Test::ControllerHelpers
     collection_fixtures(records_set)
     associate_user_with_patients(@user, Record.all)
     associate_measures_with_patients([@measure_two], Record.all)
+    # TODO: Fix this test
+    # This test exports 0 patients because the line above associates @measure_two and the line
+    # below uses @measure.  Making the same results in an error because results is nil.
     get :excel_export, hqmf_set_id: @measure.hqmf_set_id
     assert_response :success
     # TODO Get measures to pass the opposite of these tests. (Assert_equal)


### PR DESCRIPTION
This PR addresses two issues related to excel export.

1. The excel export was producing an error due to an empty string, which is now checked.
2. Some patients incorrectly have both MSRPOPLEX of 1 and OBSERV expected/actual values. A UI change was made to prevent this, but those patients that already had this state were not changed (https://github.com/projecttacoma/bonnie/commit/5f26759a9571af637a71f0c788b29a7187ac23a7).  Before this change, if these patients were exported, the excel export would not match what the user sees in the Bonnie UI because the OBSERV actual would be set to 0.  This change allows the user to see consistent results, despite the fact that those patients shouldn't really be in that state.

TODOs were added to revert the 2nd change if the patients are able to be fixed in the future, but changing them is too big of a task currently.

Additionally, a problem was discovered with the excel_export test, so a TODO was added to that as well.

Pull requests into Bonnie require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] JIRA ticket for this PR: https://jira.mitre.org/browse/BONNIE-1230
- [x] JIRA ticket links to this PR
- [x] Code diff has been done and been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] N/A If UI changes have been made, google WAVE plug-in has been executed to ensure no 508 issues were introduced.
- [x] Tests are included and test edge cases (JIRA Test)
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Code coverage has not gone down and all code touched or added is covered. 
     * See [front-end testing instructions](https://github.com/projecttacoma/bonnie/wiki/Testing#frontend-testing) for getting coverage for front-end tests
     * In rare situations, this may not be possible or applicable to a PR. In those situations:
         1. Note why this could not be done or is not applicable here: See justification for JIRA task below.
         2. Add TODOs in the code noting that it requires a test
         3. Add a JIRA task to add the test and link it here:  https://jira.mitre.org/browse/BONNIE-1241
- [x] Automated regression test(s) pass

If JIRA tests were used to supplement or replace automated tests:
- [x] JIRA test links: https://jira.mitre.org/browse/BONNIE-1240
- [x] Justification for using JIRA tests: The existing test for excel_export is broken, and this change is really more of a hack than something that should be unit tested.  The existing class MeasureExportedResults currently has no coverage, but it would be too time consuming for this task to build up the entire tests for excel_export on bonnie-prior.
- [x] JIRA tests have been added to sprint


**Reviewer 1:** @mayerm94

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

If JIRA tests were used to supplement or replace automated tests:
- [x] JIRA tests have been run and pass
- [x] You agree with the justification for use of JIRA tests or have provided input on why you disagree


**Reviewer 2:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

If JIRA tests were used to supplement or replace automated tests:
- [x] JIRA tests have been run and pass
- [x] You agree with the justification for use of JIRA tests or have provided input on why you disagree

  