### PR TITLE
uncommented msr poplex fix code

### DIFF
--- a/app/assets/javascripts/cql_calculator.js.coffee
+++ b/app/assets/javascripts/cql_calculator.js.coffee
@@ -193,10 +193,9 @@
         population_results['NUMER'] = 0
       if 'NUMEX' of population_results
         population_results['NUMEX'] = 0
-    # TODO: Temporarily disable the removal of OBSERVs when a member of MSRPOPLEX as to not change actual result values uncomment for 2.1 release
-    #else if (population_results["MSRPOPLEX"]? && !@isValueZero('MSRPOPLEX', population_results))
-    #  if 'values' of population_results
-    #    population_results['values'] = []
+    else if (population_results["MSRPOPLEX"]? && !@isValueZero('MSRPOPLEX', population_results))
+      if 'values' of population_results
+        population_results['values'] = []
     else if @isValueZero('NUMER', population_results)
       if 'NUMEX' of population_results
         population_results['NUMEX'] = 0

--- a/spec/javascripts/models/result_spec.js.coffee
+++ b/spec/javascripts/models/result_spec.js.coffee
@@ -137,33 +137,32 @@ describe 'Continuous Variable Calculations', ->
     expectedEpisodeResults = { IPP: 1, MSRPOPL: 1, MSRPOPLEX: 0, values: [15] }
     expect(result.get('episode_results')['5a20544b5cc97509451ab203']).toEqual(expectedEpisodeResults)
   
-  # TODO: These tests can be added back in when the MSRPOPLEX removal of OBSERVs is added back to cql_calculator in 2.1 release
-  # it 'can handle multiple episodes observed with one excluded', ->
-  #   patient = @patients.findWhere(last: '2 ED ', first: 'Visits 1 Excl')
-  #   result = @population.calculate(patient)
-  #   expect(result.get('values')).toEqual([25])
-  #   expect(result.get('population_relevance')['values']).toBe(true)
-  #   expect(result.get('population_relevance')['MSRPOPL']).toBe(true)
-  #   expect(result.get('population_relevance')['MSRPOPLEX']).toBe(true)
-  # 
-  #   # check the results for the episode
-  #   expectedEpisodeResults = { IPP: 1, MSRPOPL: 1, MSRPOPLEX: 0, values: [25] }
-  #   expect(result.get('episode_results')['5a2056095cc97509451ab210']).toEqual(expectedEpisodeResults)
-  #   # check the results for the second episode
-  #   expectedEpisodeResults = { IPP: 1, MSRPOPL: 1, MSRPOPLEX: 1, values: [] }
-  #   expect(result.get('episode_results')['5a2056095cc97509451ab211']).toEqual(expectedEpisodeResults)
-  # 
-  # it 'can handle multiple episodes observed with both excluded', ->
-  #   patient = @patients.findWhere(last: '2 ED ', first: 'Visits 2 Excl')
-  #   result = @population.calculate(patient)
-  #   expect(result.get('values')).toEqual([])
-  #   expect(result.get('population_relevance')['values']).toBe(false)
-  #   expect(result.get('population_relevance')['MSRPOPL']).toBe(true)
-  #   expect(result.get('population_relevance')['MSRPOPLEX']).toBe(true)
-  # 
-  #   # check the results for the episode
-  #   expectedEpisodeResults = { IPP: 1, MSRPOPL: 1, MSRPOPLEX: 1, values: [] }
-  #   expect(result.get('episode_results')['5a2055955cc97509451ab20b']).toEqual(expectedEpisodeResults)
-  #   # check the results for the second episode
-  #   expectedEpisodeResults = { IPP: 1, MSRPOPL: 1, MSRPOPLEX: 1, values: [] }
-  #   expect(result.get('episode_results')['5a2055955cc97509451ab20d']).toEqual(expectedEpisodeResults)
+  it 'can handle multiple episodes observed with one excluded', ->
+    patient = @patients.findWhere(last: '2 ED ', first: 'Visits 1 Excl')
+    result = @population.calculate(patient)
+    expect(result.get('values')).toEqual([25])
+    expect(result.get('population_relevance')['values']).toBe(true)
+    expect(result.get('population_relevance')['MSRPOPL']).toBe(true)
+    expect(result.get('population_relevance')['MSRPOPLEX']).toBe(true)
+
+    # check the results for the episode
+    expectedEpisodeResults = { IPP: 1, MSRPOPL: 1, MSRPOPLEX: 0, values: [25] }
+    expect(result.get('episode_results')['5a2056095cc97509451ab210']).toEqual(expectedEpisodeResults)
+    # check the results for the second episode
+    expectedEpisodeResults = { IPP: 1, MSRPOPL: 1, MSRPOPLEX: 1, values: [] }
+    expect(result.get('episode_results')['5a2056095cc97509451ab211']).toEqual(expectedEpisodeResults)
+
+  it 'can handle multiple episodes observed with both excluded', ->
+    patient = @patients.findWhere(last: '2 ED ', first: 'Visits 2 Excl')
+    result = @population.calculate(patient)
+    expect(result.get('values')).toEqual([])
+    expect(result.get('population_relevance')['values']).toBe(false)
+    expect(result.get('population_relevance')['MSRPOPL']).toBe(true)
+    expect(result.get('population_relevance')['MSRPOPLEX']).toBe(true)
+
+    # check the results for the episode
+    expectedEpisodeResults = { IPP: 1, MSRPOPL: 1, MSRPOPLEX: 1, values: [] }
+    expect(result.get('episode_results')['5a2055955cc97509451ab20b']).toEqual(expectedEpisodeResults)
+    # check the results for the second episode
+    expectedEpisodeResults = { IPP: 1, MSRPOPL: 1, MSRPOPLEX: 1, values: [] }
+    expect(result.get('episode_results')['5a2055955cc97509451ab20d']).toEqual(expectedEpisodeResults)


### PR DESCRIPTION
Makes it so if an episode is in the MRSPOPLEX, it isn't calculated within the OBSERV.

Pull requests into Bonnie require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] JIRA ticket for this PR: https://jira.mitre.org/browse/BONNIE-1224
- [x] JIRA ticket links to this PR
- [x] Code diff has been done and been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] If UI changes have been made, google WAVE plug-in has been executed to ensure no 508 issues were introduced. N/A
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Code coverage has not gone down and all code touched or added is covered. 
     * See [front-end testing instructions](https://github.com/projecttacoma/bonnie/wiki/Testing#frontend-testing) for getting coverage for front-end tests
     * In rare situations, this may not be possible or applicable to a PR. In those situations:
         1. Note why this could not be done or is not applicable here: 
         2. Add TODOs in the code noting that it requires a test
         3. Add a JIRA task to add the test and link it here: 

```
=============================== Coverage summary ===============================
Statements   : 56.78% ( 6784/11947 )
Branches     : 39.5% ( 1762/4461 )
Functions    : 47.17% ( 1117/2368 )
Lines        : 54.51% ( 6067/11131 )
================================================================================
```

to

```
=============================== Coverage summary ===============================
Statements   : 56.79% ( 6787/11950 )
Branches     : 39.58% ( 1768/4467 )
Functions    : 47.17% ( 1117/2368 )
Lines        : 54.52% ( 6070/11134 )
================================================================================
```

- [x] Automated regression test(s) pass. PASS WITH EXPECTED DIFFERENCES

If JIRA tests were used to supplement or replace automated tests:
- [x] JIRA test links: N/A
- [x] Justification for using JIRA tests: N/A
- [x] JIRA tests have been added to sprint N/A


**Reviewer 1:**

Name: @c-monkey
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

If JIRA tests were used to supplement or replace automated tests:
- [x] JIRA tests have been run and pass N/A
- [x] You agree with the justification for use of JIRA tests or have provided input on why you disagree N/A


**Reviewer 2:**

Name: @hossenlopp 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

If JIRA tests were used to supplement or replace automated tests:
- [x] JIRA tests have been run and pass N/A
- [x] You agree with the justification for use of JIRA tests or have provided input on why you disagree N/A
