### PR TITLE
ignore db/backups folder, which now is used by tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@
 /db/measures
 /db/value_sets
 /db/hqmf_vs_oid_cache
+/db/backups
 /coverage
 /coverage-frontend
 .DS_Store


### PR DESCRIPTION
The db/backups folder has new bonnie-test-*.tgz database backup files which currently show up in the `git status` section "Untracked files" but should be ignored. Trivial fix.

Pull requests into Bonnie require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [X] This pull request describes why these changes were made.
- [X] This PR is into the correct branch.
- [X] JIRA ticket for this PR: N/A
- [X] JIRA ticket links to this PR N/A
- [X] Code diff has been done and been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [X] If UI changes have been made, google WAVE plug-in has been executed to ensure no 508 issues were introduced.
- [X] Tests are included and test edge cases N/A
- [X] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [X] Code coverage has not gone down and all code touched or added is covered. 
     * See [front-end testing instructions](https://github.com/projecttacoma/bonnie/wiki/Testing#frontend-testing) for getting coverage for front-end tests
     * In rare situations, this may not be possible or applicable to a PR. In those situations:
         1. Note why this could not be done or is not applicable here: 
         2. Add TODOs in the code noting that it requires a test
         3. Add a JIRA task to add the test and link it here: 
- [X] Automated regression test(s) pass N/A

If JIRA tests were used to supplement or replace automated tests:
- [X] JIRA test links: N/A
- [X] Justification for using JIRA tests: N/A
- [X] JIRA tests have been added to sprint


**Reviewer 1: lizzie**
Trivial clean-up change.

Name:
- [X] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [X] The tests appropriately test the new code, including edge cases N/A

