### PR TITLE
Episode based population relevance calculations

### DIFF
--- a/app/assets/javascripts/cql_calculator.js.coffee
+++ b/app/assets/javascripts/cql_calculator.js.coffee
@@ -90,11 +90,16 @@
 
       if population_results?
         result.set population_results
-        result.set {'episode_results': episode_results} if episode_results?
-        result.set {'population_relevance': @_buildPopulationRelevanceMap(population_results) }
-
+        population_relevance = {}
+        if episode_results?
+          result.set {'episode_results': episode_results}
+          population_relevance = @_populationRelevanceForAllEpisodes(episode_results)
+        else
+          population_relevance = @_buildPopulationRelevanceMap(population_results)
+    
+        result.set {'population_relevance': population_relevance }
         # Add 'statement_relevance', 'statement_results' and 'clause_results' generated in the CQLResultsHelpers class.
-        result.set {'statement_relevance': CQLResultsHelpers.buildStatementRelevanceMap(result.get('population_relevance'), population.collection.parent, population) }
+        result.set {'statement_relevance': CQLResultsHelpers.buildStatementRelevanceMap(population_relevance, population.collection.parent, population) }
         result.set CQLResultsHelpers.buildStatementAndClauseResults(population.collection.parent, results.localIdPatientResultsMap[patient['id']], result.get('statement_relevance'))
 
         result.set {'patient_id': patient['id']} # Add patient_id to result in order to delete patient from population_calculation_view
@@ -440,6 +445,24 @@
       resultShown.values = false if resultShown.values?
 
     return resultShown
+
+  ###
+  # Iterate over episode results, call _buildPopulationRelevanceMap for each result 
+  # OR population relevances together so that populations are marked as relevant
+  # based on all episodes instead of just one
+  # @private
+  # @param {episode_results} result - Population_results for each episode
+  # @returns {object} Map that tells if a population calculation was considered/relevant in any episode
+  ###
+  _populationRelevanceForAllEpisodes: (episode_results) ->
+    masterRelevanceMap = {}
+    for key, episode_result of episode_results
+      popRelMap = @_buildPopulationRelevanceMap(episode_result)
+      for pop, popRel of popRelMap
+        if !masterRelevanceMap[pop]?
+          masterRelevanceMap[pop] = false
+        masterRelevanceMap[pop] = masterRelevanceMap[pop] || popRel
+    return masterRelevanceMap
 
   isValueZero: (value, population_set) ->
     if value of population_set and population_set[value] == 0

--- a/app/assets/javascripts/cql_calculator.js.coffee
+++ b/app/assets/javascripts/cql_calculator.js.coffee
@@ -92,6 +92,10 @@
         result.set population_results
         population_relevance = {}
         if episode_results?
+          # In episode of care based measures, episode_results contains the population results
+          # for EACH episode, so we need to build population_relevance based on a combonation
+          # of the episode_results. IE: If DENEX is irrelevant for one episode but relevant for
+          # another, the logic view should not highlight it as irrelevant
           result.set {'episode_results': episode_results}
           population_relevance = @_populationRelevanceForAllEpisodes(episode_results)
         else

--- a/spec/javascripts/cql_calculator_spec.js.coffee
+++ b/spec/javascripts/cql_calculator_spec.js.coffee
@@ -79,3 +79,25 @@ describe 'cqlCalculator', ->
       expected_relevance_map = { IPP: true, MSRPOPL: true, MSRPOPLEX: false, values: false }
       relevance_map = @cql_calculator._buildPopulationRelevanceMap(population_results)
       expect(relevance_map).toEqual expected_relevance_map
+
+  describe '_populationRelevanceForAllEpisodes', ->
+    it 'correctly builds population_relevance for multiple episodes in all populations', ->
+      episode_results = {
+        episode1: {IPP: 3, DENOM: 0, DENEX: 0, NUMER: 0, NUMEX: 0},
+        episode2: {IPP: 2, DENOM: 1, DENEX: 0, NUMER: 2, NUMEX: 2},
+        episode3: {IPP: 2, DENOM: 0, DENEX: 1, NUMER: 0, NUMEX: 0}
+      }
+      expected_relevance_map = { IPP: true, DENOM: true, DENEX: true, NUMER: true, NUMEX: true }
+      relevance_map = @cql_calculator._populationRelevanceForAllEpisodes(episode_results)
+      expect(relevance_map).toEqual expected_relevance_map
+      
+    it 'correctly builds population_relevance for multiple episodes in no populations', ->
+      episode_results = {
+        episode1: {IPP: 0, DENOM: 0, DENEX: 0, NUMER: 0, NUMEX: 0},
+        episode2: {IPP: 0, DENOM: 0, DENEX: 0, NUMER: 0, NUMEX: 0},
+        episode3: {IPP: 0, DENOM: 0, DENEX: 0, NUMER: 0, NUMEX: 0}
+      }
+      # IPP will be relevant because nothing has rendered it irrelevant
+      expected_relevance_map = { IPP: true, DENOM: false, DENEX: false, NUMER: false, NUMEX: false }
+      relevance_map = @cql_calculator._populationRelevanceForAllEpisodes(episode_results)
+      expect(relevance_map).toEqual expected_relevance_map

--- a/spec/javascripts/cql_calculator_spec.js.coffee
+++ b/spec/javascripts/cql_calculator_spec.js.coffee
@@ -83,11 +83,11 @@ describe 'cqlCalculator', ->
   describe '_populationRelevanceForAllEpisodes', ->
     it 'correctly builds population_relevance for multiple episodes in all populations', ->
       episode_results = {
-        episode1: {IPP: 3, DENOM: 0, DENEX: 0, DENEXCEP: 1, NUMER: 0, NUMEX: 0},
-        episode2: {IPP: 2, DENOM: 1, DENEX: 0, DENEXCEP: 0, NUMER: 2, NUMEX: 2},
-        episode3: {IPP: 2, DENOM: 0, DENEX: 1, DENEXCEP: 0, NUMER: 0, NUMEX: 0}
+        episode1: {IPP: 1, DENOM: 1, DENEX: 0, DENEXCEP: 1, NUMER: 0, NUMEX: 0},
+        episode2: {IPP: 1, DENOM: 1, DENEX: 0, DENEXCEP: 0, NUMER: 1, NUMEX: 1},
+        episode3: {IPP: 1, DENOM: 1, DENEX: 1, DENEXCEP: 0, NUMER: 0, NUMEX: 0}
       }
-      expected_relevance_map = { IPP: true, DENOM: true, DENEX: true, DENEXCEP: false, NUMER: true, NUMEX: true }
+      expected_relevance_map = { IPP: true, DENOM: true, DENEX: true, DENEXCEP: true, NUMER: true, NUMEX: true }
       relevance_map = @cql_calculator._populationRelevanceForAllEpisodes(episode_results)
       expect(relevance_map).toEqual expected_relevance_map
       

--- a/spec/javascripts/cql_calculator_spec.js.coffee
+++ b/spec/javascripts/cql_calculator_spec.js.coffee
@@ -83,21 +83,21 @@ describe 'cqlCalculator', ->
   describe '_populationRelevanceForAllEpisodes', ->
     it 'correctly builds population_relevance for multiple episodes in all populations', ->
       episode_results = {
-        episode1: {IPP: 3, DENOM: 0, DENEX: 0, NUMER: 0, NUMEX: 0},
-        episode2: {IPP: 2, DENOM: 1, DENEX: 0, NUMER: 2, NUMEX: 2},
-        episode3: {IPP: 2, DENOM: 0, DENEX: 1, NUMER: 0, NUMEX: 0}
+        episode1: {IPP: 3, DENOM: 0, DENEX: 0, DENEXCEP: 1, NUMER: 0, NUMEX: 0},
+        episode2: {IPP: 2, DENOM: 1, DENEX: 0, DENEXCEP: 0, NUMER: 2, NUMEX: 2},
+        episode3: {IPP: 2, DENOM: 0, DENEX: 1, DENEXCEP: 0, NUMER: 0, NUMEX: 0}
       }
-      expected_relevance_map = { IPP: true, DENOM: true, DENEX: true, NUMER: true, NUMEX: true }
+      expected_relevance_map = { IPP: true, DENOM: true, DENEX: true, DENEXCEP: false, NUMER: true, NUMEX: true }
       relevance_map = @cql_calculator._populationRelevanceForAllEpisodes(episode_results)
       expect(relevance_map).toEqual expected_relevance_map
       
     it 'correctly builds population_relevance for multiple episodes in no populations', ->
       episode_results = {
-        episode1: {IPP: 0, DENOM: 0, DENEX: 0, NUMER: 0, NUMEX: 0},
-        episode2: {IPP: 0, DENOM: 0, DENEX: 0, NUMER: 0, NUMEX: 0},
-        episode3: {IPP: 0, DENOM: 0, DENEX: 0, NUMER: 0, NUMEX: 0}
+        episode1: {IPP: 0, DENOM: 0, DENEX: 0, DENEXCEP: 0, NUMER: 0, NUMEX: 0},
+        episode2: {IPP: 0, DENOM: 0, DENEX: 0, DENEXCEP: 0, NUMER: 0, NUMEX: 0},
+        episode3: {IPP: 0, DENOM: 0, DENEX: 0, DENEXCEP: 0, NUMER: 0, NUMEX: 0}
       }
       # IPP will be relevant because nothing has rendered it irrelevant
-      expected_relevance_map = { IPP: true, DENOM: false, DENEX: false, NUMER: false, NUMEX: false }
+      expected_relevance_map = { IPP: true, DENOM: false, DENEX: false, DENEXCEP: false, NUMER: false, NUMEX: false }
       relevance_map = @cql_calculator._populationRelevanceForAllEpisodes(episode_results)
       expect(relevance_map).toEqual expected_relevance_map


### PR DESCRIPTION
When there are episode_results, calculate population_relevance based on all episode_results. Any EOC measure can be used to test this, look at hmdmmathematica CMS333 for a good example.

Pull requests into Bonnie require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] JIRA ticket for this PR: https://jira.mitre.org/browse/BONNIE-1272
- [x] JIRA ticket links to this PR
- [x] Code diff has been done and been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] If UI changes have been made, google WAVE plug-in has been executed to ensure no 508 issues were introduced. NA
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Code coverage has not gone down and all code touched or added is covered. 
     * In rare situations, this may not be possible or applicable to a PR. In those situations:
         1. Note why this could not be done or is not applicable here: 
         2. Add TODOs in the code noting that it requires a test
         3. Add a JIRA task to add the test and link it here: 
- [x] Automated regression test(s) pass

If JIRA tests were used to supplement or replace automated tests:
- [x] JIRA test links: NA
- [x] Justification for using JIRA tests: NA
- [x] JIRA tests have been added to sprint NA


**Reviewer 1:**

Name: @hossenlopp
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

If JIRA tests were used to supplement or replace automated tests:
- [x] JIRA tests have been run and pass
- [x] You agree with the justification for use of JIRA tests or have provided input on why you disagree


**Reviewer 2:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

If JIRA tests were used to supplement or replace automated tests:
- [x] JIRA tests have been run and pass
- [x] You agree with the justification for use of JIRA tests or have provided input on why you disagree
