### PR TITLE
Fix population relevance calculation for patients with no episodes on episode of care measures

### DIFF
--- a/app/assets/javascripts/cql_calculator.js.coffee
+++ b/app/assets/javascripts/cql_calculator.js.coffee
@@ -88,14 +88,22 @@
       if population_results?
         result.set population_results
         population_relevance = {}
-        if episode_results?
-          # In episode of care based measures, episode_results contains the population results
-          # for EACH episode, so we need to build population_relevance based on a combonation
-          # of the episode_results. IE: If DENEX is irrelevant for one episode but relevant for
-          # another, the logic view should not highlight it as irrelevant
+
+        # handle episode of care measure results
+        if population.collection.parent.get('episode_of_care')
           result.set {'episode_results': episode_results}
-          population_relevance = @_populationRelevanceForAllEpisodes(episode_results)
+          # calculate relevance only if there were recorded episodes
+          if Object.keys(episode_results).length > 0
+            # In episode of care based measures, episode_results contains the population results
+            # for EACH episode, so we need to build population_relevance based on a combonation
+            # of the episode_results. IE: If DENEX is irrelevant for one episode but relevant for
+            # another, the logic view should not highlight it as irrelevant
+            population_relevance = @_populationRelevanceForAllEpisodes(episode_results)
+          else
+            # use the patient based relevance if there are no episodes. This will properly set IPP or STRAT to true.
+            population_relevance = @_buildPopulationRelevanceMap(population_results)
         else
+          # calculate relevance for patient based measure
           population_relevance = @_buildPopulationRelevanceMap(population_results)
     
         result.set {'population_relevance': population_relevance }

--- a/spec/javascripts/cql_calculator_spec.js.coffee
+++ b/spec/javascripts/cql_calculator_spec.js.coffee
@@ -130,7 +130,7 @@ describe 'cqlCalculator', ->
         @patients = new Thorax.Collections.Patients getJSONFixture('records/CQL/CMS107/patients.json'), parse: true
 
       it 'is correct for patient with no episodes', ->
-        # this patient fails the IPP
+        # this patient has no episodes in the IPP
         patient = @patients.findWhere(last: 'IPPFail', first: 'LOS=121Days')
         result = @cql_calculator.calculate(@measure.get('populations').first(), patient)
 
@@ -140,7 +140,7 @@ describe 'cqlCalculator', ->
         expect(result.get('population_relevance')).toEqual({ IPP: true, DENOM: false, DENEX: false, NUMER: false })
 
       it 'is correct for patient with episodes', ->
-        # this patient fails the IPP
+        # this patient has an episode that is in the IPP, DENOM and DENEX
         patient = @patients.findWhere(last: 'DENEXPass', first: 'CMOduringED')
         result = @cql_calculator.calculate(@measure.get('populations').first(), patient)
 
@@ -163,5 +163,5 @@ describe 'cqlCalculator', ->
 
         # there will not be episode_results on the result object
         expect(result.has('episode_results')).toEqual(false)
-        # NUMER should be the only not relevant population
+        # the IPP should be the only relevant population
         expect(result.get('population_relevance')).toEqual({ IPP: true, DENOM: false, DENEX: false, NUMER: false, DENEXCEP: false})

--- a/spec/javascripts/cql_calculator_spec.js.coffee
+++ b/spec/javascripts/cql_calculator_spec.js.coffee
@@ -119,3 +119,49 @@ describe 'cqlCalculator', ->
       expected_relevance_map = { IPP: true, DENOM: false, DENEX: false, DENEXCEP: false, NUMER: false, NUMEX: false }
       relevance_map = @cql_calculator._populationRelevanceForAllEpisodes(episode_results)
       expect(relevance_map).toEqual expected_relevance_map
+
+  describe 'calculate', ->
+
+    describe 'episode of care based relevance map', ->
+      beforeEach ->
+        # TODO: Update this set of tests with new fixtures when fixture overhaul is brought in
+        bonnie.valueSetsByOid = getJSONFixture('/measure_data/CQL/CMS107/value_sets.json')
+        @measure = new Thorax.Models.Measure getJSONFixture('measure_data/CQL/CMS107/CMS107v6.json'), parse: true
+        @patients = new Thorax.Collections.Patients getJSONFixture('records/CQL/CMS107/patients.json'), parse: true
+
+      it 'is correct for patient with no episodes', ->
+        # this patient fails the IPP
+        patient = @patients.findWhere(last: 'IPPFail', first: 'LOS=121Days')
+        result = @cql_calculator.calculate(@measure.get('populations').first(), patient)
+
+        # no results will be in the episode_results
+        expect(result.get('episode_results')).toEqual({})
+        # the IPP should be the only relevant population
+        expect(result.get('population_relevance')).toEqual({ IPP: true, DENOM: false, DENEX: false, NUMER: false })
+
+      it 'is correct for patient with episodes', ->
+        # this patient fails the IPP
+        patient = @patients.findWhere(last: 'DENEXPass', first: 'CMOduringED')
+        result = @cql_calculator.calculate(@measure.get('populations').first(), patient)
+
+        # there will be a single result in the episode_results
+        expect(result.get('episode_results')).toEqual({'59cbf4f0942c6d40640067cf': { IPP: 1, DENOM: 1, DENEX: 1, NUMER: 0}})
+        # NUMER should be the only not relevant population
+        expect(result.get('population_relevance')).toEqual({ IPP: true, DENOM: true, DENEX: true, NUMER: false })
+
+    describe 'patient based relevance map', ->
+      beforeEach ->
+        # TODO: Update this set of tests with new fixtures when fixutre overhaul is brought in
+        bonnie.valueSetsByOid = getJSONFixture('/measure_data/CQL/CMS347/value_sets.json')
+        @measure = new Thorax.Models.Measure getJSONFixture('measure_data/CQL/CMS347/CMS735v0.json'), parse: true
+        @patients = new Thorax.Collections.Patients getJSONFixture('records/CQL/CMS347/patients.json'), parse: true
+
+      it 'is correct', ->
+        # this patient fails the IPP
+        patient = @patients.findWhere(last: 'last', first: 'first')
+        result = @cql_calculator.calculate(@measure.get('populations').first(), patient)
+
+        # there will not be episode_results on the result object
+        expect(result.has('episode_results')).toEqual(false)
+        # NUMER should be the only not relevant population
+        expect(result.get('population_relevance')).toEqual({ IPP: true, DENOM: false, DENEX: false, NUMER: false, DENEXCEP: false})


### PR DESCRIPTION
Fix empty relevance map for patients without episodes. i.e. IPPFail tests

If there are no episodes recorded, the nominal patient based relevance call is used. This will set the root population IPP or STRAT to be relevant.

Pull requests into Bonnie require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] JIRA ticket for this PR: https://jira.mitre.org/browse/BONNIE-1280
- [x] JIRA ticket links to this PR
- [x] Code diff has been done and been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] If UI changes have been made, google WAVE plug-in has been executed to ensure no 508 issues were introduced. N/A
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Code coverage has not gone down and all code touched or added is covered. 
     * In rare situations, this may not be possible or applicable to a PR. In those situations:
         1. Note why this could not be done or is not applicable here: 
         2. Add TODOs in the code noting that it requires a test
         3. Add a JIRA task to add the test and link it here: 
- [x] Automated regression test(s) pass

If JIRA tests were used to supplement or replace automated tests: N/A
- [x] JIRA test links: N/A
- [x] Justification for using JIRA tests: N/A
- [x] JIRA tests have been added to sprint


**Reviewer 1:** @mayerm94

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

If JIRA tests were used to supplement or replace automated tests:
- [x] JIRA tests have been run and pass NA
- [x] You agree with the justification for use of JIRA tests or have provided input on why you disagree NA


**Reviewer 2:**

Name: @-cmonkey
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

If JIRA tests were used to supplement or replace automated tests:
- [X] JIRA tests have been run and pass - N/A
- [X] You agree with the justification for use of JIRA tests or have provided input on why you disagree - N/A
