### PR TITLE
Change popIndexfrompopname to return index relative to strats collect…

### DIFF
--- a/app/assets/javascripts/models/population.js.coffee
+++ b/app/assets/javascripts/models/population.js.coffee
@@ -46,7 +46,17 @@ class Thorax.Models.Population extends Thorax.Model
     # that the stratification is on so that the correct (IPOP, DENOM, NUMER..) are retrieved
     if this.get('stratification')?
       # If retrieving the STRAT specifically, set the index to the correct STRAT in the cql_map
-      return if popName == "STRAT" then this.get('stratification_index') else this.get('population_index')
+      if popName == "STRAT"
+        stratCode = this.get('STRAT')['code']
+        # The strat code has the index of the stratification appended to the code ie: STRAT, STRAT_1, STRAT_2...
+        stratCode = stratCode.match(///STRAT_(\d*)///)
+        if(stratCode?[1]?)
+          stratIndex = stratCode[1]
+        else
+          stratIndex = 0
+        return stratIndex
+      else
+        return this.get('population_index')
     else
       return this.get('index')
 

--- a/app/assets/javascripts/models/population.js.coffee
+++ b/app/assets/javascripts/models/population.js.coffee
@@ -42,12 +42,12 @@ class Thorax.Models.Population extends Thorax.Model
     @populationDataCriteriaKeys
 
   getStratIndexFromStratName: (stratName) ->
-   # The strat code has the index of the stratification appended to the code ie: STRAT, STRAT_1, STRAT_2...
-   stratIndex = stratName.match(///STRAT_(\d*)///)
-   if(stratIndex?[1]?)
-     return parseInt(stratIndex[1])
-   else
-     return 0
+    # The strat code has the index of the stratification appended to the code ie: STRAT, STRAT_1, STRAT_2...
+    stratIndex = stratName.match(///STRAT_(\d*)///)
+    if(stratIndex?[1]?)
+      return parseInt(stratIndex[1])
+    else
+      return 0
 
   getPopIndexFromPopName: (popName) ->
     # If displaying a stratification, we need to set the index to the associated populationCriteria

--- a/app/assets/javascripts/models/population.js.coffee
+++ b/app/assets/javascripts/models/population.js.coffee
@@ -41,20 +41,21 @@ class Thorax.Models.Population extends Thorax.Model
     @populationDataCriteriaKeys = _.uniq(criteriaKeys)
     @populationDataCriteriaKeys
 
+  getStratIndexFromStratName: (stratName) ->
+   # The strat code has the index of the stratification appended to the code ie: STRAT, STRAT_1, STRAT_2...
+   stratIndex = stratName.match(///STRAT_(\d*)///)
+   if(stratIndex?[1]?)
+     return parseInt(stratIndex[1])
+   else
+     return 0
+
   getPopIndexFromPopName: (popName) ->
     # If displaying a stratification, we need to set the index to the associated populationCriteria
     # that the stratification is on so that the correct (IPOP, DENOM, NUMER..) are retrieved
     if this.get('stratification')?
       # If retrieving the STRAT specifically, set the index to the correct STRAT in the cql_map
       if popName == "STRAT"
-        stratCode = this.get('STRAT')['code']
-        # The strat code has the index of the stratification appended to the code ie: STRAT, STRAT_1, STRAT_2...
-        stratCode = stratCode.match(///STRAT_(\d*)///)
-        if(stratCode?[1]?)
-          stratIndex = stratCode[1]
-        else
-          stratIndex = 0
-        return stratIndex
+        return @getStratIndexFromStratName(this.get('STRAT')['code'])
       else
         return this.get('population_index')
     else

--- a/spec/javascripts/models/population_spec.js.coffee
+++ b/spec/javascripts/models/population_spec.js.coffee
@@ -1,0 +1,16 @@
+describe 'Population', ->
+  
+  beforeEach ->
+    @population = new Thorax.Models.Population()
+
+  it 'should return index 0 for stratifier without appended index', ->
+    index = @population.getStratIndexFromStratName("STRAT")
+    expect(index).toEqual 0
+    
+  it 'should return single digit index appended to stratifier name', ->
+    index = @population.getStratIndexFromStratName("STRAT_1")
+    expect(index).toEqual 1
+
+  it 'should return double digit index appended to stratifier name', ->
+    index = @population.getStratIndexFromStratName("STRAT_33")
+    expect(index).toEqual 33


### PR DESCRIPTION
This pull request addresses an issue with the getPopIndexFromPopName function. 

Before, the function would just return the stratification_index parameter, which is fine when there is only one population group that has multiple stratifications eg: popgroup1_strat1, popgroup1_strat2 will have strat indexes 0 and 1 respectively, but when there are multiple population groups with multiple stratifications eg: popgroup1_strat1, popgroup1_strat2 popgroup2_strat1, popgroup2_strat2  the stratification_index would be 0,1, 0,1 respectively. This is because the index is relative to the population group and not to the population map. 

NOW, the getPopIndexFromPopName uses the strat name to get the index of the strat within the population map. The name that the index is using follows the pattern STRAT, STRAT_1, STRAT_2, STRAT_3 which have indexes 0,1,2,3... inside the population map.

The only regressions are shown on the account (and measure) in which this bug was reported.
Testing epecqmtelligen@gmail.com
epecqmtelligen
+: Population: -3 SECOND BRANCH HAS MORE PASSES (52 < 55)
+: Population: -5 SECOND BRANCH HAS MORE PASSES (52 < 59)
Measures with no differences: 17/19

====Code Coverage Percentage Regression===========
+: CMS ID: CMS160v6-0-1-2-3-4 SECOND BRANCH HAS MORE COVERAGE (34 < 45)
+: CMS ID: CMS160v6-0-1-2-3-4-5 SECOND BRANCH HAS MORE COVERAGE (72 < 84)
+: CMS ID: CMS160v6-0-1-2-3-4-5-6 SECOND BRANCH HAS MORE COVERAGE (34 < 45)
+: CMS ID: CMS160v6-0-1-2-3-4-5-6-7 SECOND BRANCH HAS MORE COVERAGE (56 < 76)
Measures with no differences: 13/17

Pull requests into Bonnie require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] JIRA ticket for this PR: https://jira.mitre.org/browse/BONNIE-1290
- [x] JIRA ticket links to this PR
- [x] Code diff has been done and been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] If UI changes have been made, google WAVE plug-in has been executed to ensure no 508 issues were introduced.
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Code coverage has not gone down and all code touched or added is covered. 
     * In rare situations, this may not be possible or applicable to a PR. In those situations:
         1. Note why this could not be done or is not applicable here: 
         2. Add TODOs in the code noting that it requires a test
         3. Add a JIRA task to add the test and link it here: 
- [x] Automated regression test(s) pass

If JIRA tests were used to supplement or replace automated tests:
- [x] JIRA test links:
- [x] Justification for using JIRA tests:
- [x] JIRA tests have been added to sprint


**Reviewer 1:**

Name: @c-monkey
- [X] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [X] The tests appropriately test the new code, including edge cases
- [X] You have tried to break the code

If JIRA tests were used to supplement or replace automated tests:
- [X] JIRA tests have been run and pass N/A
- [X] You agree with the justification for use of JIRA tests or have provided input on why you disagree N/A


**Reviewer 2:**

Name: @losborne
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

If JIRA tests were used to supplement or replace automated tests:
- [x] JIRA tests have been run and pass N/A
- [x] You agree with the justification for use of JIRA tests or have provided input on why you disagree N/A
