### PR TITLE
Add error helper test and check if message exists or blank in error h…

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -562,6 +562,8 @@ Metrics/ClassLength:
 # Offense count: 18
 Metrics/CyclomaticComplexity:
   Max: 30
+  Exclude:
+    - 'lib/tasks/bonnie.rake'
 
 # Offense count: 39
 # Configuration parameters: CountComments.
@@ -571,6 +573,8 @@ Metrics/MethodLength:
 # Offense count: 16
 Metrics/PerceivedComplexity:
   Max: 34
+  Exclude:
+    - 'lib/tasks/bonnie.rake'
 
 # Offense count: 3
 Naming/AccessorMethodName:

--- a/app/helpers/error_helper.rb
+++ b/app/helpers/error_helper.rb
@@ -5,6 +5,9 @@ module ErrorHelper
   # not be categorized, no error message will be shown (but an email
   # will still be sent to the development team, if on production).
   def self.describe_error(error_info, exception, request)
+    # Set the error message if it was not previously set
+    error_info[:msg] = 'An unspecified error has occurred.' unless error_info[:msg] && error_info[:msg] != ''
+
     # Do not process errors if their message includes Costanza. These are
     # errors passed up to Thorax.onException from Costanza, which we do
     # not care about (we've already handled them).

--- a/test/unit/helpers/error_helper_test.rb
+++ b/test/unit/helpers/error_helper_test.rb
@@ -1,0 +1,49 @@
+require 'test_helper'
+require './app/helpers/error_helper'
+
+class ErrorHelperTest < ActionView::TestCase
+  test 'Empty error message from execution engine' do
+    error_info = {section: 'cql-measure-calculation',
+                  cms_id: 'CMSv0', type: 'javascript',
+                  url: 'http://127.0.0.1:3000/#measures/21C422D4-1658-478D-AEC2-B87B73638C41/patients/new',
+                  controller: 'application', action: 'client_error'}
+    exception = {section: 'cql-measure-calculation', cms_id: 'CMSv0', type: 'javascript', 
+                 url: 'http://127.0.0.1:3000/#measures/21C422D4-1658-478D-AEC2-B87B73638C41/patients/new', 
+                 controller: 'application', action: 'client_error'}
+    request = 'empty'
+    error_message = ErrorHelper.describe_error(error_info, exception, request)
+    assert_equal 'One of the data elements associated with the measure is causing an issue. ' \
+                 'Please review the elements associated with the measure to verify that they ' \
+                 'are all constructed properly.<br>Error message: <b>An unspecified error has occurred.</b>', error_message[:body]
+    assert_equal 'Measure Calculation Error', error_message[:title]
+  end
+
+  test 'Unknown error information section' do
+    error_info = {section: 'unknown section',
+                  cms_id: 'CMSv0', type: 'javascript',
+                  url: 'http://127.0.0.1:3000/#measures/21C422D4-1658-478D-AEC2-B87B73638C41/patients/new',
+                  controller: 'application', action: 'client_error', msg: 'Test Error'}
+    exception = {section: 'cql-measure-calculation', cms_id: 'CMSv0', type: 'javascript',
+                 url: 'http://127.0.0.1:3000/#measures/21C422D4-1658-478D-AEC2-B87B73638C41/patients/new',
+                 controller: 'application', action: 'client_error'}
+    request = 'empty'
+    error_message = ErrorHelper.describe_error(error_info, exception, request)
+    assert_equal nil, error_message
+  end
+  
+  test 'Empty error message' do
+    error_info = {section: 'cql-measure-calculation',
+                  cms_id: 'CMSv0', type: 'javascript',
+                  url: 'http://127.0.0.1:3000/#measures/21C422D4-1658-478D-AEC2-B87B73638C41/patients/new',
+                  controller: 'application', action: 'client_error', msg: ''}
+    exception = {section: 'cql-measure-calculation', cms_id: 'CMSv0', type: 'javascript', 
+                 url: 'http://127.0.0.1:3000/#measures/21C422D4-1658-478D-AEC2-B87B73638C41/patients/new', 
+                 controller: 'application', action: 'client_error'}
+    request = 'empty'
+    error_message = ErrorHelper.describe_error(error_info, exception, request)
+    assert_equal 'One of the data elements associated with the measure is causing an issue. ' \
+                 'Please review the elements associated with the measure to verify that they ' \
+                 'are all constructed properly.<br>Error message: <b>An unspecified error has occurred.</b>', error_message[:body]
+    assert_equal 'Measure Calculation Error', error_message[:title]
+  end
+end


### PR DESCRIPTION
When the execution does not provide an error message, Bonnie 500s and chalks the error up to network connectivity issues. What the error message should be set to on line 12 is up for discussion.

Pull requests into Bonnie require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] JIRA ticket for this PR: https://jira.mitre.org/browse/BONNIE-1342
- [x] JIRA ticket links to this PR
- [x] Code diff has been done and been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] If UI changes have been made, google WAVE plug-in has been executed to ensure no 508 issues were introduced.
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Code coverage has not gone down and all code touched or added is covered. 
     * In rare situations, this may not be possible or applicable to a PR. In those situations:
         1. Note why this could not be done or is not applicable here: 
         2. Add TODOs in the code noting that it requires a test
         3. Add a JIRA task to add the test and link it here: 
- [x] Automated regression test(s) pass

If JIRA tests were used to supplement or replace automated tests:
- [x] JIRA test links: NA
- [x] Justification for using JIRA tests: NA
- [x] JIRA tests have been added to sprint NA


**Reviewer 1:**

Name: @hossenlopp
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

If JIRA tests were used to supplement or replace automated tests: N/A
- [x] JIRA tests have been run and pass N/A
- [x] You agree with the justification for use of JIRA tests or have provided input on why you disagree N/A


**Reviewer 2:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

If JIRA tests were used to supplement or replace automated tests:
- [x] JIRA tests have been run and pass
- [x] You agree with the justification for use of JIRA tests or have provided input on why you disagree
