### PR TITLE
Add change event to data criteria inputs to check for validation

### DIFF
--- a/app/assets/javascripts/views/patient_builder/data_criteria.js.coffee
+++ b/app/assets/javascripts/views/patient_builder/data_criteria.js.coffee
@@ -479,6 +479,7 @@ class Thorax.Views.EditCriteriaValueView extends Thorax.Views.BuilderChildView
       @validateForAddition()
       @advanceFocusToInput()
     'keyup input': 'validateForAddition'
+    'change input': 'validateForAddition'
     'change select[name=key]': 'changeFieldValueKey'
     # hide date-picker if it's still visible and focus is not on a .date-picker input (occurs with JAWS SR arrow-key navigation)
     'focus .form-control': (e) -> if not @$(e.target).hasClass('date-picker') and $('.datepicker').is(':visible') then @$('.date-picker').datepicker('hide')

--- a/spec/javascripts/views/patient_builder_spec.js.coffee
+++ b/spec/javascripts/views/patient_builder_spec.js.coffee
@@ -431,3 +431,28 @@ describe 'PatientBuilderView', ->
       # These are from direct reference codes
       expect(codesInDropdown['Birthdate']).toBeDefined()
       expect(codesInDropdown['Dead']).toBeDefined()
+
+    it "EditCriteriaValueView allows for input field validation to happen on change event", ->
+      bonnie.valueSetsByOid = getJSONFixture('/measure_data/core_measures/CMS160/value_sets.json')
+      cqlMeasure = new Thorax.Models.Measure getJSONFixture('measure_data/core_measures/CMS160/CMS160v6.json'), parse: true
+      bonnie.measures.add(cqlMeasure, { parse: true });
+      patients = new Thorax.Collections.Patients getJSONFixture('records/core_measures/CMS160/patients.json'), parse: true
+      patientBuilder = new Thorax.Views.PatientBuilder(model: patients.first(), measure: cqlMeasure)
+      assessmentPerformed = patientBuilder.model.get('source_data_criteria').at(2)
+      editCriteriaView = new Thorax.Views.EditCriteriaView(model: assessmentPerformed, measure: cqlMeasure)
+
+      # getting the element result edit view
+      editFieldValueView = editCriteriaView.editValueView
+      editFieldValueView.render()
+
+      # change it to scalar
+      editFieldValueView.$('select[name="type"]').val('PQ').change()
+
+      # expect add button to be disabled
+      expect(editFieldValueView.$('button[data-call-method=addValue]').prop('disabled')).toEqual(true)
+
+      # change the value
+      editFieldValueView.$('input[name="value"]').val(3).change()
+
+      # expect add button to be enabled
+      expect(editFieldValueView.$('button[data-call-method=addValue]').prop('disabled')).toEqual(false)


### PR DESCRIPTION
From external BONNIE-450. Add `change` event as something that kicks off validation of data criteria attributes. We were only looking at the `keyup` event. The browser sometimes provides a dropdown or increment/decrement buttons that can fill the field.

Pull requests into Bonnie require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] JIRA ticket for this PR: https://jira.mitre.org/browse/BONNIE-1405
- [x] JIRA ticket links to this PR
- [x] Code diff has been done and been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] If UI changes have been made, google WAVE plug-in has been executed to ensure no 508 issues were introduced.
- [x] Tests are included and test edge cases N/A would be overly burdensome to add tests
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Test fixtures updated and documented as necessary ( see [internal wiki](https://gitlab.mitre.org/bonnie/internal-documentation/wikis/testing#test-fixtures) )
- [x] Code coverage has not gone down and all code touched or added is covered. 
     * In rare situations, this may not be possible or applicable to a PR. In those situations:
         1. Note why this could not be done or is not applicable here: 
         2. Add TODOs in the code noting that it requires a test
         3. Add a JIRA task to add the test and link it here: 

Branch | Back End Coverage | Front End Coverage
-- | -- | --
master | N/A | ![450_coverage_before](https://user-images.githubusercontent.com/11613067/39061262-bfdd9cce-4491-11e8-9d33-4fced0fd5aed.png)
[New Branch] | N/A | ![450_coverage_after](https://user-images.githubusercontent.com/11613067/39060669-fce7e2ac-448f-11e8-82c0-2f45a06643b6.png)


- [x] Automated regression test(s) pass N/A Does not affect calculation

If JIRA tests were used to supplement or replace automated tests: Would be overly burdensome to create tests.
- [x] JIRA test links: N/A
- [x] Justification for using JIRA tests: N/A
- [x] JIRA tests have been added to sprint N/A


**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

If JIRA tests were used to supplement or replace automated tests:
- [ ] JIRA tests have been run and pass
- [ ] You agree with the justification for use of JIRA tests or have provided input on why you disagree


**Reviewer 2:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

If JIRA tests were used to supplement or replace automated tests:
- [ ] JIRA tests have been run and pass
- [ ] You agree with the justification for use of JIRA tests or have provided input on why you disagree
