### PR TITLE
Excel export now uses toString for datatype results

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -572,6 +572,8 @@ Metrics/CyclomaticComplexity:
 # Configuration parameters: CountComments.
 Metrics/MethodLength:
   Max: 129
+  Exclude:
+    - 'lib/patient_export.rb'
 
 # Offense count: 16
 Metrics/PerceivedComplexity:

--- a/Gemfile
+++ b/Gemfile
@@ -13,19 +13,19 @@ gem 'less-rails'
 # We want non-digest versions of our assets for font-awesome
 gem "non-stupid-digest-assets"
 
-gem 'health-data-standards', '~> 4.0.4'
+# gem 'health-data-standards', '~> 4.0.4'
 # gem 'cql_qdm_patientapi', '~> 1.1.1'
 gem 'simplexml_parser', '~> 1.0'
 gem 'hqmf2js', '~> 1.4'
-gem 'bonnie_bundler', '~> 2.1.0'
+# gem 'bonnie_bundler', '~> 2.1.0'
 gem 'quality-measure-engine', '~> 3.2'
 gem 'hquery-patient-api', '~> 1.1'
 
-# gem 'health-data-standards', :git => 'https://github.com/projectcypress/health-data-standards.git', :branch => 'master_bonnie'
-gem 'cql_qdm_patientapi', :git => 'https://github.com/projecttacoma/cql_qdm_patientapi.git', :branch => 'master'
+gem 'health-data-standards', :git => 'https://github.com/projectcypress/health-data-standards.git', :branch => 'bonnie-v2.2'
+gem 'cql_qdm_patientapi', :git => 'https://github.com/projecttacoma/cql_qdm_patientapi.git', :branch => 'bonnie-v2.2'
 # gem 'simplexml_parser', :git => 'https://github.com/projecttacoma/simplexml_parser.git', :branch => 'master'
 # gem 'hqmf2js', :git => 'https://github.com/projecttacoma/hqmf2js.git', :branch => 'master'
-# gem 'bonnie_bundler', :git => 'https://github.com/projecttacoma/bonnie_bundler.git', :branch => 'master'
+gem 'bonnie_bundler', :git => 'https://github.com/projecttacoma/bonnie_bundler.git', :branch => 'bonnie-v2.2'
 # gem 'quality-measure-engine', :git => 'https://github.com/projectcypress/quality-measure-engine.git', :branch => 'master'
 # gem 'hquery-patient-api', :git => 'https://github.com/projecttacoma/patientapi.git', :branch => 'master'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,46 @@
 GIT
+  remote: https://github.com/projectcypress/health-data-standards.git
+  revision: a8575b16bd0c54876b1b586c2cff05378fd34337
+  branch: bonnie-v2.2
+  specs:
+    health-data-standards (4.0.4)
+      activesupport (~> 4.2.0)
+      builder (~> 3.1)
+      erubis (~> 2.7.0)
+      highline (~> 1.7.0)
+      log4r (~> 1.1.10)
+      memoist (~> 0.9.1)
+      mongoid (~> 5.0.0)
+      mongoid-tree (~> 2.0.0)
+      nokogiri (~> 1.8.2)
+      protected_attributes (~> 1.0.5)
+      rest-client (~> 1.8.0)
+      rubyzip (~> 1.2.1)
+      uuid (~> 2.3.7)
+      zip-zip (~> 0.3)
+
+GIT
+  remote: https://github.com/projecttacoma/bonnie_bundler.git
+  revision: 40a63c671ef6c3f0fc89dbafd15c31de767183b4
+  branch: bonnie-v2.2
+  specs:
+    bonnie_bundler (2.1.0)
+      diffy (~> 3.0.0)
+      health-data-standards (~> 4.0)
+      hqmf2js (~> 1.4)
+      hquery-patient-api (~> 1.1)
+      mongoid (~> 5.0)
+      quality-measure-engine (~> 3.2)
+      rails (~> 4.2)
+      roo (~> 1.13)
+      rubyzip (~> 1.2, >= 1.2.1)
+      simplexml_parser (~> 1.0)
+      zip-zip (~> 0.3)
+
+GIT
   remote: https://github.com/projecttacoma/cql_qdm_patientapi.git
   revision: e97079366baaa94697c1eb8c4a9c803568c7db85
-  branch: master
+  branch: bonnie-v2.2
   specs:
     cql_qdm_patientapi (1.1.1)
       coffee-rails (~> 4.1)
@@ -73,18 +112,6 @@ GEM
       ice_nine (~> 0.11.0)
       thread_safe (~> 0.3, >= 0.3.1)
     bcrypt (3.1.11)
-    bonnie_bundler (2.1.0)
-      diffy (~> 3.0.0)
-      health-data-standards (~> 4.0)
-      hqmf2js (~> 1.4)
-      hquery-patient-api (~> 1.1)
-      mongoid (~> 5.0)
-      quality-measure-engine (~> 3.2)
-      rails (~> 4.2)
-      roo (~> 1.13)
-      rubyzip (~> 1.2, >= 1.2.1)
-      simplexml_parser (~> 1.0)
-      zip-zip (~> 0.3)
     brakeman (4.0.1)
     browser (2.5.0)
     bson (4.2.1)
@@ -160,21 +187,6 @@ GEM
       sprockets (>= 2.0.3)
       tilt
     hashdiff (0.3.0)
-    health-data-standards (4.0.4)
-      activesupport (~> 4.2.0)
-      builder (~> 3.1)
-      erubis (~> 2.7.0)
-      highline (~> 1.7.0)
-      log4r (~> 1.1.10)
-      memoist (~> 0.9.1)
-      mongoid (~> 5.0.0)
-      mongoid-tree (~> 2.0.0)
-      nokogiri (~> 1.8.2)
-      protected_attributes (~> 1.0.5)
-      rest-client (~> 1.8.0)
-      rubyzip (~> 1.2.1)
-      uuid (~> 2.3.7)
-      zip-zip (~> 0.3)
     highline (1.7.10)
     hike (1.2.3)
     hqmf2js (1.4.0)
@@ -383,7 +395,7 @@ GEM
       unf_ext
     unf_ext (0.0.7.5)
     unicode-display_width (1.3.0)
-    uuid (2.3.8)
+    uuid (2.3.9)
       macaddr (~> 1.0)
     vcr (3.0.3)
     virtus (1.0.5)
@@ -405,7 +417,7 @@ PLATFORMS
 
 DEPENDENCIES
   axlsx!
-  bonnie_bundler (~> 2.1.0)
+  bonnie_bundler!
   brakeman
   browser
   bundler-audit
@@ -416,7 +428,7 @@ DEPENDENCIES
   exception_notification!
   foreman
   handlebars_assets (= 0.16)
-  health-data-standards (~> 4.0.4)
+  health-data-standards!
   hqmf2js (~> 1.4)
   hquery-patient-api (~> 1.1)
   jquery-rails

--- a/app/assets/javascripts/calculator_selector.js.coffee
+++ b/app/assets/javascripts/calculator_selector.js.coffee
@@ -1,9 +1,9 @@
 # Selector class that will choose which calculator to call the functions on.
 @CalculatorSelector = class CalculatorSelector
 
-  calculate: (population, patient) ->
+  calculate: (population, patient, options = {}) ->
     if population.collection.parent.has('cql')
-      bonnie.cql_calculator.calculate population, patient
+      bonnie.cql_calculator.calculate population, patient, options
     else
       bonnie.qdm_calculator.calculate population, patient
 

--- a/app/assets/javascripts/cql_calculator.js.coffee
+++ b/app/assets/javascripts/cql_calculator.js.coffee
@@ -10,8 +10,9 @@
   # deferred manner like we did for QDM calcuations.
   # @param {Population} population - The population set to calculate on.
   # @param {Patient} patient - The patient to run calculations on.
+  # @param {Object} options - miscellaneous options.
   ###
-  calculate: (population, patient) ->
+  calculate: (population, patient, options = {}) ->
     # We store both the calculation result and the calcuation code based on keys derived from the arguments
     cacheKey = @cacheKey(population, patient)
     calcKey = @calculationKey(population)
@@ -112,7 +113,7 @@
         result.set {'population_relevance': population_relevance }
         # Add 'statement_relevance', 'statement_results' and 'clause_results' generated in the CQLResultsHelpers class.
         result.set {'statement_relevance': CQLResultsHelpers.buildStatementRelevanceMap(population_relevance, population.collection.parent, population) }
-        result.set CQLResultsHelpers.buildStatementAndClauseResults(population.collection.parent, results.localIdPatientResultsMap[patient['id']], result.get('statement_relevance'))
+        result.set CQLResultsHelpers.buildStatementAndClauseResults(population.collection.parent, results.localIdPatientResultsMap[patient['id']], result.get('statement_relevance'), !!options['doPretty'])
 
         result.set {'patient_id': patient['id']} # Add patient_id to result in order to delete patient from population_calculation_view
         result.state = 'complete'

--- a/app/assets/javascripts/helpers/cql_results_helpers.js.coffee
+++ b/app/assets/javascripts/helpers/cql_results_helpers.js.coffee
@@ -295,7 +295,7 @@ class CQLResultsHelpers
       "Quantity: #{result['unit']}: #{result['value']}"
     else if result instanceof CQL_QDM.QDMDatatype
       result.toString()
-    else if result instanceof String
+    else if result instanceof String or typeof(result) == 'string'
       result
     else if result instanceof Array
       result = _.map result, (value) => @_prettyResult(value)

--- a/app/assets/javascripts/helpers/cql_results_helpers.js.coffee
+++ b/app/assets/javascripts/helpers/cql_results_helpers.js.coffee
@@ -207,7 +207,6 @@ class CQLResultsHelpers
   ###*
   # Generates a pretty human readable representation of a result.
   #
-  # @private
   # @param {(Array|object|boolean|???)} result - The result from the calculation engine.
   # @returns {String} a pretty version of the given result
   ###

--- a/app/assets/javascripts/models/population.js.coffee
+++ b/app/assets/javascripts/models/population.js.coffee
@@ -10,8 +10,8 @@ class Thorax.Models.Population extends Thorax.Model
 
   populationCriteria: -> (criteria for criteria in Thorax.Models.Measure.allPopulationCodes when @has(criteria))
 
-  calculate: (patient) ->
-    bonnie.calculator_selector.calculate this, patient
+  calculate: (patient, options = {}) ->
+    bonnie.calculator_selector.calculate this, patient, options
 
   # Calculates results for all measure patients
   calculationResults: -> new Thorax.Collections.Results @measure().get('patients').map (p) => @calculate(p)

--- a/app/assets/javascripts/views/measure_view.js.coffee
+++ b/app/assets/javascripts/views/measure_view.js.coffee
@@ -169,13 +169,15 @@ class Thorax.Views.Measure extends Thorax.Views.BonnieView
         statement_details: JSON.stringify(statement_details)
         file_name: file_name
       }
+
   # Iterates through the results to remove extraneous fields.
   removeRaw: (results) ->
     ret = {}
     for libKey of results
       ret[libKey] = {}
       for statementKey of results[libKey]
-        ret[libKey][statementKey] = results[libKey][statementKey].final
+        result = results[libKey][statementKey]
+        ret[libKey][statementKey] = if result.raw && result.raw.length > 0 then result.raw.join('\n').replace(/\n$/, '') else result.final
     return ret
 
   deleteMeasure: (e) ->

--- a/app/assets/javascripts/views/measure_view.js.coffee
+++ b/app/assets/javascripts/views/measure_view.js.coffee
@@ -129,7 +129,9 @@ class Thorax.Views.Measure extends Thorax.Views.BonnieView
       for patient in @model.get('patients').models
         if calc_results[pop.cid] == undefined
           calc_results[pop.cid] = {}
-        result = pop.calculate(patient)
+        # Re-calculate results before excel export (we need to include pretty result generation)
+        bonnie.calculator_selector.clearResult pop, patient
+        result = pop.calculate(patient, {doPretty: true})
         result_criteria = {}
         for pop_crit of result.get('population_relevance')
           result_criteria[pop_crit] = result.get(pop_crit)

--- a/app/assets/javascripts/views/measure_view.js.coffee
+++ b/app/assets/javascripts/views/measure_view.js.coffee
@@ -56,7 +56,7 @@ class Thorax.Views.Measure extends Thorax.Views.BonnieView
       populationLogicView = new Thorax.Views.CqlPopulationLogic(model: @model, population: @population)
     else
       populationLogicView = new Thorax.Views.PopulationLogic(model: @population)
-  
+
     # Determine which populations logic view to use
     if @populations.length > 1
       if @model.has('cql') # CQL Based measure with multiple populations
@@ -117,7 +117,7 @@ class Thorax.Views.Measure extends Thorax.Views.BonnieView
 
   exportExcelPatients: (e) ->
     @exportPatientsView.exporting()
-    
+
     calc_results = {}
     patient_details = {}
     population_details = {}
@@ -133,7 +133,7 @@ class Thorax.Views.Measure extends Thorax.Views.BonnieView
         result_criteria = {}
         for pop_crit of result.get('population_relevance')
           result_criteria[pop_crit] = result.get(pop_crit)
-        calc_results[pop.cid][patient.cid] = {statement_results: @removeRaw(result.get("statement_results")), criteria: result_criteria}
+        calc_results[pop.cid][patient.cid] = {statement_results: @removeExtra(result.get("statement_results")), criteria: result_criteria}
         # Populates the patient details
         if (patient_details[patient.cid] == undefined)
           patient_details[patient.cid] = {
@@ -171,13 +171,15 @@ class Thorax.Views.Measure extends Thorax.Views.BonnieView
       }
 
   # Iterates through the results to remove extraneous fields.
-  removeRaw: (results) ->
+  removeExtra: (results) ->
     ret = {}
     for libKey of results
       ret[libKey] = {}
       for statementKey of results[libKey]
-        result = results[libKey][statementKey]
-        ret[libKey][statementKey] = if result.raw && result.raw.length > 0 then result.raw.join('\n').replace(/\n$/, '') else result.final
+        if results[libKey][statementKey].pretty
+          ret[libKey][statementKey] = results[libKey][statementKey].pretty
+        else
+          ret[libKey][statementKey] = results[libKey][statementKey].final
     return ret
 
   deleteMeasure: (e) ->

--- a/lib/patient_export.rb
+++ b/lib/patient_export.rb
@@ -25,7 +25,8 @@ class PatientExport
                                    :bg_color => "FFFFFFF",
                                    :border => { :style => :thin,
                                                 :color => "DDDDDD",
-                                                :edges => [:bottom] })
+                                                :edges => [:bottom] },
+                                   :alignment => { :wrap_text => true })
         rotated_style = styles.add_style(:b => true,
                                          :sz => 12,
                                          :alignment => { :textRotation => 90 },
@@ -52,7 +53,8 @@ class PatientExport
                                      :border => { :style => :thin,
                                                   :color =>"DDDDDD",
                                                   :edges => [:bottom] },
-                                     :fg_color => "FF0000")
+                                     :fg_color => "FF0000",
+                                     :alignment => { :wrap_text => true })
         pop_index = 0
         
         if calc_results.length == 0

--- a/spec/javascripts/cql_calculator_spec.js.coffee
+++ b/spec/javascripts/cql_calculator_spec.js.coffee
@@ -124,7 +124,7 @@ describe 'cqlCalculator', ->
       expected_relevance_map = { IPP: true, DENOM: true, DENEX: true, DENEXCEP: true, NUMER: true, NUMEX: true }
       relevance_map = @cql_calculator._populationRelevanceForAllEpisodes(episode_results)
       expect(relevance_map).toEqual expected_relevance_map
-      
+
     it 'correctly builds population_relevance for multiple episodes in no populations', ->
       episode_results = {
         episode1: {IPP: 0, DENOM: 0, DENEX: 0, DENEXCEP: 0, NUMER: 0, NUMEX: 0},
@@ -137,6 +137,58 @@ describe 'cqlCalculator', ->
       expect(relevance_map).toEqual expected_relevance_map
 
   describe 'calculate', ->
+
+      describe 'pretty statement results', ->
+        it 'for CMS107 correctly', ->
+          bonnie.valueSetsByOid = getJSONFixture('/measure_data/CQL/CMS107/value_sets.json')
+          measure1 = new Thorax.Models.Measure getJSONFixture('measure_data/CQL/CMS107/CMS107v6.json'), parse: true
+          patients1 = new Thorax.Collections.Patients getJSONFixture('records/CQL/CMS107/patients.json'), parse: true
+          patient1 = patients1.findWhere(last: 'DENEXPass', first: 'CMOduringED')
+          result1 = @cql_calculator.calculate(measure1.get('populations').first(), patient1)
+          expect(result1.get('statement_results').TJC_Overall['Encounter with Principal Diagnosis and Age'].pretty).toEqual('[Encounter, Performed: Non-Elective Inpatient Encounter\nSTART: 10/10/2012 9:30 AM\nSTOP: 10/12/2012 12:15 AM\nCODE: SNOMED-CT 32485007]')
+          expect(result1.get('statement_results').StrokeEducation.Numerator.pretty).toEqual('UNHIT')
+
+        it 'for CMS760 correctly', ->
+          bonnie.valueSetsByOid = getJSONFixture('/measure_data/special_measures/CMS760/value_sets.json')
+          measure2 = new Thorax.Models.Measure getJSONFixture('measure_data/special_measures/CMS760/CMS760v0.json'), parse: true
+          patients2 = new Thorax.Collections.Patients getJSONFixture('records/special_measures/CMS760/patients.json'), parse: true
+          patient2 = patients2.models[0]
+          result2 = @cql_calculator.calculate(measure2.get('populations').first(), patient2)
+          expect(result2.get('statement_results').PD0329.IntervalWithTZOffsets.pretty).toEqual('Interval: 08/01/2012 12:00 AM - 12/31/2012 12:00 AM')
+
+        it 'for CMS32 correctly', ->
+          bonnie.valueSetsByOid = getJSONFixture('/measure_data/CQL/CMS32/value_sets.json')
+          measure3 = new Thorax.Models.Measure getJSONFixture('measure_data/CQL/CMS32/CMS721v0.json'), parse: true
+          patients3 = new Thorax.Collections.Patients getJSONFixture('records/CQL/CMS32/patients.json'), parse: true
+          bonnie.valueSetsByOid = getJSONFixture('/measure_data/CQL/CMS32/value_sets.json')
+          patient3 = patients3.models[0]
+          result3 = @cql_calculator.calculate(measure3.get('populations').first(), patient3)
+          expect(result3.get('statement_results').Test32['Measure Observation'].pretty).toEqual('FALSE (undefined)')
+          expect(result3.get('statement_results').Test32['ED Visit'].pretty).toEqual('[Encounter, Performed: Emergency department patient visit (procedure)\nSTART: 11/22/2012 8:00 AM\nSTOP: 11/22/2012 8:15 AM\nCODE: SNOMED-CT 4525004]')
+          expect(result3.get('statement_results').Test32['Measure Population Exclusions'].pretty).toEqual('FALSE ([])')
+
+        it 'for CMS347 correctly', ->
+          bonnie.valueSetsByOid = getJSONFixture('/measure_data/CQL/CMS347/value_sets.json')
+          measure4 = new Thorax.Models.Measure getJSONFixture('measure_data/CQL/CMS347/CMS735v0.json'), parse: true
+          patients4 = new Thorax.Collections.Patients getJSONFixture('records/CQL/CMS347/patients.json'), parse: true
+          bonnie.valueSetsByOid = getJSONFixture('/measure_data/CQL/CMS347/value_sets.json')
+          patient4 = patients4.models[0]
+          result4 = @cql_calculator.calculate(measure4.get('populations').first(), patient4)
+          expect(result4.get('statement_results').StatinTherapy['In Demographic'].pretty).toEqual('true')
+
+         it 'for CMS460 correctly', ->
+          bonnie.valueSetsByOid = getJSONFixture('/measure_data/special_measures/CMS460/value_sets.json')
+          measure5 = new Thorax.Models.Measure getJSONFixture('measure_data/special_measures/CMS460/CMS460v0.json'), parse: true
+          patients5 = new Thorax.Collections.Patients getJSONFixture('records/special_measures/CMS460/patients.json'), parse: true
+          bonnie.valueSetsByOid = getJSONFixture('/measure_data/special_measures/CMS460/value_sets.json')
+          patient5 = patients5.models[0]
+          result5 = @cql_calculator.calculate(measure5.get('populations').first(), patient5)
+          expect(result5.get('statement_results').OpioidData.Days29.pretty).toEqual('[1,\n2,\n3,\n4,\n5,\n6,\n7,\n8,\n9,\n10,\n11,\n12,\n13,\n14,\n15,\n16,\n17,\n18,\n19,\n20,\n21,\n22,\n23,\n24,\n25,\n26,\n27,\n28,\n29]')
+          expect(result5.get('statement_results').PotentialOpioidOveruse.PrescriptionDays.pretty).toContain('05/09/2012 12:00 AM')
+          expect(result5.get('statement_results').PotentialOpioidOveruse.PrescriptionDays.pretty).toContain('"rxNormCode": "Code: RxNorm: 1053647"')
+          expect(result5.get('statement_results').PotentialOpioidOveruse.PrescriptionsWithMME.pretty).toContain('"conversionFactor": "0.13"')
+          expect(result5.get('statement_results').PotentialOpioidOveruse.PrescriptionsWithMME.pretty).toContain('"effectivePeriod": "Interval: 05/09/2012 8:00 AM - 12/28/2012 8:15 AM"')
+          expect(result5.get('statement_results').PotentialOpioidOveruse.PrescriptionsWithMME.pretty).toContain('"daysSupply": "Quantity: undefined: 120"')
 
     describe 'episode of care based relevance map', ->
       beforeEach ->

--- a/spec/javascripts/cql_calculator_spec.js.coffee
+++ b/spec/javascripts/cql_calculator_spec.js.coffee
@@ -189,6 +189,7 @@ describe 'cqlCalculator', ->
           expect(result5.get('statement_results').PotentialOpioidOveruse.PrescriptionsWithMME.pretty).toContain('"conversionFactor": "0.13"')
           expect(result5.get('statement_results').PotentialOpioidOveruse.PrescriptionsWithMME.pretty).toContain('"effectivePeriod": "Interval: 05/09/2012 8:00 AM - 12/28/2012 8:15 AM"')
           expect(result5.get('statement_results').PotentialOpioidOveruse.PrescriptionsWithMME.pretty).toContain('"daysSupply": "Quantity: undefined: 120"')
+          expect(result5.get('statement_results').OpioidData.DrugIngredients.pretty).toContain('"drugName": "72 HR Fentanyl 0.075 MG/HR Transdermal System"')
 
     describe 'episode of care based relevance map', ->
       beforeEach ->

--- a/spec/javascripts/cql_calculator_spec.js.coffee
+++ b/spec/javascripts/cql_calculator_spec.js.coffee
@@ -138,13 +138,13 @@ describe 'cqlCalculator', ->
 
   describe 'calculate', ->
 
-      describe 'pretty statement results', ->
+      describe 'pretty statement results when requested', ->
         it 'for CMS107 correctly', ->
           bonnie.valueSetsByOid = getJSONFixture('/measure_data/CQL/CMS107/value_sets.json')
           measure1 = new Thorax.Models.Measure getJSONFixture('measure_data/CQL/CMS107/CMS107v6.json'), parse: true
           patients1 = new Thorax.Collections.Patients getJSONFixture('records/CQL/CMS107/patients.json'), parse: true
           patient1 = patients1.findWhere(last: 'DENEXPass', first: 'CMOduringED')
-          result1 = @cql_calculator.calculate(measure1.get('populations').first(), patient1)
+          result1 = @cql_calculator.calculate(measure1.get('populations').first(), patient1, {doPretty: true})
           expect(result1.get('statement_results').TJC_Overall['Encounter with Principal Diagnosis and Age'].pretty).toEqual('[Encounter, Performed: Non-Elective Inpatient Encounter\nSTART: 10/10/2012 9:30 AM\nSTOP: 10/12/2012 12:15 AM\nCODE: SNOMED-CT 32485007]')
           expect(result1.get('statement_results').StrokeEducation.Numerator.pretty).toEqual('UNHIT')
 
@@ -153,7 +153,7 @@ describe 'cqlCalculator', ->
           measure2 = new Thorax.Models.Measure getJSONFixture('measure_data/special_measures/CMS760/CMS760v0.json'), parse: true
           patients2 = new Thorax.Collections.Patients getJSONFixture('records/special_measures/CMS760/patients.json'), parse: true
           patient2 = patients2.models[0]
-          result2 = @cql_calculator.calculate(measure2.get('populations').first(), patient2)
+          result2 = @cql_calculator.calculate(measure2.get('populations').first(), patient2, {doPretty: true})
           expect(result2.get('statement_results').PD0329.IntervalWithTZOffsets.pretty).toEqual('Interval: 08/01/2012 12:00 AM - 12/31/2012 12:00 AM')
 
         it 'for CMS32 correctly', ->
@@ -162,7 +162,7 @@ describe 'cqlCalculator', ->
           patients3 = new Thorax.Collections.Patients getJSONFixture('records/CQL/CMS32/patients.json'), parse: true
           bonnie.valueSetsByOid = getJSONFixture('/measure_data/CQL/CMS32/value_sets.json')
           patient3 = patients3.models[0]
-          result3 = @cql_calculator.calculate(measure3.get('populations').first(), patient3)
+          result3 = @cql_calculator.calculate(measure3.get('populations').first(), patient3, {doPretty: true})
           expect(result3.get('statement_results').Test32['Measure Observation'].pretty).toEqual('FALSE (undefined)')
           expect(result3.get('statement_results').Test32['ED Visit'].pretty).toEqual('[Encounter, Performed: Emergency department patient visit (procedure)\nSTART: 11/22/2012 8:00 AM\nSTOP: 11/22/2012 8:15 AM\nCODE: SNOMED-CT 4525004]')
           expect(result3.get('statement_results').Test32['Measure Population Exclusions'].pretty).toEqual('FALSE ([])')
@@ -173,7 +173,7 @@ describe 'cqlCalculator', ->
           patients4 = new Thorax.Collections.Patients getJSONFixture('records/CQL/CMS347/patients.json'), parse: true
           bonnie.valueSetsByOid = getJSONFixture('/measure_data/CQL/CMS347/value_sets.json')
           patient4 = patients4.models[0]
-          result4 = @cql_calculator.calculate(measure4.get('populations').first(), patient4)
+          result4 = @cql_calculator.calculate(measure4.get('populations').first(), patient4, {doPretty: true})
           expect(result4.get('statement_results').StatinTherapy['In Demographic'].pretty).toEqual('true')
 
          it 'for CMS460 correctly', ->
@@ -182,7 +182,7 @@ describe 'cqlCalculator', ->
           patients5 = new Thorax.Collections.Patients getJSONFixture('records/special_measures/CMS460/patients.json'), parse: true
           bonnie.valueSetsByOid = getJSONFixture('/measure_data/special_measures/CMS460/value_sets.json')
           patient5 = patients5.models[0]
-          result5 = @cql_calculator.calculate(measure5.get('populations').first(), patient5)
+          result5 = @cql_calculator.calculate(measure5.get('populations').first(), patient5, {doPretty: true})
           expect(result5.get('statement_results').OpioidData.Days29.pretty).toEqual('[1,\n2,\n3,\n4,\n5,\n6,\n7,\n8,\n9,\n10,\n11,\n12,\n13,\n14,\n15,\n16,\n17,\n18,\n19,\n20,\n21,\n22,\n23,\n24,\n25,\n26,\n27,\n28,\n29]')
           expect(result5.get('statement_results').PotentialOpioidOveruse.PrescriptionDays.pretty).toContain('05/09/2012 12:00 AM')
           expect(result5.get('statement_results').PotentialOpioidOveruse.PrescriptionDays.pretty).toContain('"rxNormCode": "Code: RxNorm: 1053647"')
@@ -190,6 +190,16 @@ describe 'cqlCalculator', ->
           expect(result5.get('statement_results').PotentialOpioidOveruse.PrescriptionsWithMME.pretty).toContain('"effectivePeriod": "Interval: 05/09/2012 8:00 AM - 12/28/2012 8:15 AM"')
           expect(result5.get('statement_results').PotentialOpioidOveruse.PrescriptionsWithMME.pretty).toContain('"daysSupply": "Quantity: undefined: 120"')
           expect(result5.get('statement_results').OpioidData.DrugIngredients.pretty).toContain('"drugName": "72 HR Fentanyl 0.075 MG/HR Transdermal System"')
+
+      describe 'no pretty statement results when not requested', ->
+        it 'for CMS107 correctly', ->
+          bonnie.valueSetsByOid = getJSONFixture('/measure_data/CQL/CMS107/value_sets.json')
+          measure1 = new Thorax.Models.Measure getJSONFixture('measure_data/CQL/CMS107/CMS107v6.json'), parse: true
+          patients1 = new Thorax.Collections.Patients getJSONFixture('records/CQL/CMS107/patients.json'), parse: true
+          patient1 = patients1.findWhere(last: 'DENEXPass', first: 'CMOduringED')
+          result1 = @cql_calculator.calculate(measure1.get('populations').first(), patient1)
+          expect(result1.get('statement_results').TJC_Overall['Encounter with Principal Diagnosis and Age'].pretty).toEqual(undefined)
+          expect(result1.get('statement_results').StrokeEducation.Numerator.pretty).toEqual(undefined)
 
     describe 'episode of care based relevance map', ->
       beforeEach ->

--- a/spec/javascripts/views/measure_view_spec.js.coffee
+++ b/spec/javascripts/views/measure_view_spec.js.coffee
@@ -88,6 +88,12 @@ describe 'MeasureView', ->
       expect(@measureView.$("button[data-call-method=exportQrdaPatients]")).toBeDisabled()
       @measureView.remove()
 
+    it 'can click excel export button', ->
+      @measureView = new Thorax.Views.Measure(model: @cqlMeasure, patients: @cqlPatients, populations: @cqlMeasure.get('populations'), population: @cqlMeasure.get('displayedPopulation'))
+      @measureView.appendTo 'body'
+      spyOn($, 'fileDownload')
+      @measureView.$("button[data-call-method=exportExcelPatients]").click()
+      expect($.fileDownload).toHaveBeenCalled()
 
     describe 'value sets view', ->
       it 'exists', ->

--- a/spec/javascripts/views/measure_view_spec.js.coffee
+++ b/spec/javascripts/views/measure_view_spec.js.coffee
@@ -91,7 +91,8 @@ describe 'MeasureView', ->
     it 'can click excel export button', ->
       @measureView = new Thorax.Views.Measure(model: @cqlMeasure, patients: @cqlPatients, populations: @cqlMeasure.get('populations'), population: @cqlMeasure.get('displayedPopulation'))
       @measureView.appendTo 'body'
-      spyOn($, 'fileDownload')
+      spyOn($, 'fileDownload').and.callFake () ->
+        expect(arguments[0]).toEqual('patients/excel_export')
       @measureView.$("button[data-call-method=exportExcelPatients]").click()
       expect($.fileDownload).toHaveBeenCalled()
 


### PR DESCRIPTION
Excel export now uses toString for datatype results. This means that results in the excel export show the data criteria (description, start/stop time/ code) that resulted when a define statement was calculated against a patient.

Example:

![screen shot 2018-05-22 at 11 03 36 am](https://user-images.githubusercontent.com/14923551/40373195-62b0d2c8-5db4-11e8-9ece-90d1861e6f9b.png)

---

Pull requests into Bonnie require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] JIRA ticket for this PR: https://jira.mitre.org/browse/BONNIE-1442
- [x] JIRA ticket links to this PR
- [x] Code diff has been done and been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] If UI changes have been made, google WAVE plug-in has been executed to ensure no 508 issues were introduced.
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Test fixtures updated and documented as necessary ( see [internal wiki](https://gitlab.mitre.org/bonnie/internal-documentation/wikis/testing#test-fixtures) )
- [x] Code coverage has not gone down and all code touched or added is covered. 
     * In rare situations, this may not be possible or applicable to a PR. In those situations:
         1. Note why this could not be done or is not applicable here: 
         2. Add TODOs in the code noting that it requires a test
         3. Add a JIRA task to add the test and link it here: 

Branch | Back End Coverage | Front End Coverage
-- | -- | --
master | 1746 / 1964 LOC (88.9%) covered | ![screen shot 2018-05-14 at 11 52 44 am](https://user-images.githubusercontent.com/14923551/40008447-585e0662-576d-11e8-86f1-8ef14e92e8c7.png)
excel_datatype_toString | 1746 / 1964 LOC (88.9%) covered | ![screen shot 2018-05-24 at 2 58 32 pm](https://user-images.githubusercontent.com/14923551/40505670-fee962fe-5f62-11e8-8d2d-360dfd04d4ac.png)







- [x] Automated regression test(s) pass

If JIRA tests were used to supplement or replace automated tests:
- [x] JIRA test links: N/A
- [x] Justification for using JIRA tests: N/A
- [x] JIRA tests have been added to sprint N/A


**Reviewer 1:**

Name: @losborne 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

If JIRA tests were used to supplement or replace automated tests:
- [x] JIRA tests have been run and pass
- [x] You agree with the justification for use of JIRA tests or have provided input on why you disagree


**Reviewer 2:**

Name: @mayerm94 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

If JIRA tests were used to supplement or replace automated tests:
- [x] JIRA tests have been run and pass
- [x] You agree with the justification for use of JIRA tests or have provided input on why you disagree
