### PR TITLE
Update cql_qdm_patientapi, hds, bonnie_bundler gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,19 +13,19 @@ gem 'less-rails'
 # We want non-digest versions of our assets for font-awesome
 gem "non-stupid-digest-assets"
 
-# gem 'health-data-standards', '~> 4.0.5'
-# gem 'cql_qdm_patientapi', '~> 1.1.3'
+gem 'health-data-standards', '~> 4.0.6'
+gem 'cql_qdm_patientapi', '~> 1.1.4'
 gem 'simplexml_parser', '~> 1.0'
 gem 'hqmf2js', '~> 1.4'
-# gem 'bonnie_bundler', '~> 2.1.1'
+gem 'bonnie_bundler', '~> 2.1.2'
 gem 'quality-measure-engine', '~> 3.2'
 gem 'hquery-patient-api', '~> 1.1'
 
-gem 'health-data-standards', :git => 'https://github.com/projectcypress/health-data-standards.git', :branch => 'master_bonnie'
-gem 'cql_qdm_patientapi', :git => 'https://github.com/projecttacoma/cql_qdm_patientapi.git', :branch => 'master'
+# gem 'health-data-standards', :git => 'https://github.com/projectcypress/health-data-standards.git', :branch => 'master_bonnie'
+# gem 'cql_qdm_patientapi', :git => 'https://github.com/projecttacoma/cql_qdm_patientapi.git', :branch => 'master'
 # gem 'simplexml_parser', :git => 'https://github.com/projecttacoma/simplexml_parser.git', :branch => 'master'
 # gem 'hqmf2js', :git => 'https://github.com/projecttacoma/hqmf2js.git', :branch => 'master'
-gem 'bonnie_bundler', :git => 'https://github.com/projecttacoma/bonnie_bundler.git', :branch => 'master'
+# gem 'bonnie_bundler', :git => 'https://github.com/projecttacoma/bonnie_bundler.git', :branch => 'master'
 # gem 'quality-measure-engine', :git => 'https://github.com/projectcypress/quality-measure-engine.git', :branch => 'master'
 # gem 'hquery-patient-api', :git => 'https://github.com/projecttacoma/patientapi.git', :branch => 'master'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,53 +1,4 @@
 GIT
-  remote: https://github.com/projectcypress/health-data-standards.git
-  revision: 27bfbead369470b9317eaab7ab071b3b88ae15fe
-  branch: master_bonnie
-  specs:
-    health-data-standards (4.0.5)
-      activesupport (~> 4.2.0)
-      builder (~> 3.1)
-      erubis (~> 2.7.0)
-      highline (~> 1.7.0)
-      log4r (~> 1.1.10)
-      memoist (~> 0.9.1)
-      mongoid (~> 5.0.0)
-      mongoid-tree (~> 2.0.0)
-      nokogiri (~> 1.8.2)
-      protected_attributes (~> 1.0.5)
-      rest-client (~> 1.8.0)
-      rubyzip (~> 1.2.1)
-      uuid (~> 2.3.7)
-      zip-zip (~> 0.3)
-
-GIT
-  remote: https://github.com/projecttacoma/bonnie_bundler.git
-  revision: f7b96a82ee4b7d43bf4a7d6e47ce88ca2d1cf35d
-  branch: master
-  specs:
-    bonnie_bundler (2.1.1)
-      diffy (~> 3.0.0)
-      health-data-standards (~> 4.0)
-      hqmf2js (~> 1.4)
-      hquery-patient-api (~> 1.1)
-      mongoid (~> 5.0)
-      quality-measure-engine (~> 3.2)
-      rails (~> 4.2)
-      roo (~> 1.13)
-      rubyzip (~> 1.2, >= 1.2.1)
-      simplexml_parser (~> 1.0)
-      zip-zip (~> 0.3)
-
-GIT
-  remote: https://github.com/projecttacoma/cql_qdm_patientapi.git
-  revision: 1d1a06130b1dcda652d1e0248dfe2c0290c92ea5
-  branch: master
-  specs:
-    cql_qdm_patientapi (1.1.3)
-      coffee-rails (~> 4.1)
-      rails (~> 4.2)
-      sprockets-rails (~> 2.3)
-
-GIT
   remote: https://github.com/randym/axlsx
   revision: c8ac844572b25fda358cc01d2104720c4c42f450
   branch: master
@@ -112,6 +63,18 @@ GEM
       ice_nine (~> 0.11.0)
       thread_safe (~> 0.3, >= 0.3.1)
     bcrypt (3.1.11)
+    bonnie_bundler (2.1.2)
+      diffy (~> 3.0.0)
+      health-data-standards (~> 4.0)
+      hqmf2js (~> 1.4)
+      hquery-patient-api (~> 1.1)
+      mongoid (~> 5.0)
+      quality-measure-engine (~> 3.2)
+      rails (~> 4.2)
+      roo (~> 1.13)
+      rubyzip (~> 1.2, >= 1.2.1)
+      simplexml_parser (~> 1.0)
+      zip-zip (~> 0.3)
     brakeman (4.0.1)
     browser (2.5.0)
     bson (4.2.1)
@@ -150,6 +113,10 @@ GEM
     colorize (0.7.7)
     columnize (0.9.0)
     commonjs (0.2.7)
+    cql_qdm_patientapi (1.1.4)
+      coffee-rails (~> 4.1)
+      rails (~> 4.2)
+      sprockets-rails (~> 2.3)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     crass (1.0.3)
@@ -187,6 +154,21 @@ GEM
       sprockets (>= 2.0.3)
       tilt
     hashdiff (0.3.0)
+    health-data-standards (4.0.6)
+      activesupport (~> 4.2.0)
+      builder (~> 3.1)
+      erubis (~> 2.7.0)
+      highline (~> 1.7.0)
+      log4r (~> 1.1.10)
+      memoist (~> 0.9.1)
+      mongoid (~> 5.0.0)
+      mongoid-tree (~> 2.0.0)
+      nokogiri (~> 1.8.2)
+      protected_attributes (~> 1.0.5)
+      rest-client (~> 1.8.0)
+      rubyzip (~> 1.2.1)
+      uuid (~> 2.3.7)
+      zip-zip (~> 0.3)
     highline (1.7.10)
     hike (1.2.3)
     hqmf2js (1.4.0)
@@ -417,18 +399,18 @@ PLATFORMS
 
 DEPENDENCIES
   axlsx!
-  bonnie_bundler!
+  bonnie_bundler (~> 2.1.2)
   brakeman
   browser
   bundler-audit
   capistrano-rails
   coffee-rails
-  cql_qdm_patientapi!
+  cql_qdm_patientapi (~> 1.1.4)
   devise
   exception_notification!
   foreman
   handlebars_assets (= 0.16)
-  health-data-standards!
+  health-data-standards (~> 4.0.6)
   hqmf2js (~> 1.4)
   hquery-patient-api (~> 1.1)
   jquery-rails


### PR DESCRIPTION
Update gemfile and gemfile.lock for latest version of cql_qdm_patientapi, health-data-standards, and bonnie_bundler.

Pull requests into Bonnie require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] JIRA ticket for this PR: N/A
- [x] JIRA ticket links to this PR N/A
- [x] Code diff has been done and been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] If UI changes have been made, google WAVE plug-in has been executed to ensure no 508 issues were introduced. N/A
- [x] Tests are included and test edge cases N/A
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable) 
- [x] Test fixtures updated and documented as necessary ( see [internal wiki](https://gitlab.mitre.org/bonnie/internal-documentation/wikis/testing#test-fixtures) ) N/A
- [x] Code coverage has not gone down and all code touched or added is covered.  N/A
     * In rare situations, this may not be possible or applicable to a PR. In those situations:
         1. Note why this could not be done or is not applicable here: 
         2. Add TODOs in the code noting that it requires a test
         3. Add a JIRA task to add the test and link it here: 

Branch | Back End Coverage | Front End Coverage
-- | -- | --
master | 1738 / 1950 LOC (89.13%) covered | Statements : 58.45% 7037/12040 )<br>Branches: 42.22% ( 1889/4474 )<br>Functions: 48.85% ( 1167/2389 )<br>Lines : 56.27% ( 6311/11215 )
gemfile_lock_update | 1738 / 1950 LOC (89.13%) covered | Statements   : 58.45% ( 7037/12040 )<br>Branches     : 42.22% ( 1889/4474 )<br>Functions    : 48.85% ( 1167/2389 )<br>Lines        : 56.27% ( 6311/11215 )

- [x] Automated regression test(s) pass

If JIRA tests were used to supplement or replace automated tests:
- [x] JIRA test links: N/A
- [x] Justification for using JIRA tests: N/A
- [x] JIRA tests have been added to sprint N/A


**Reviewer 1:**

Name: @jbradl11 
- [x] Gemfile/gemfile.lock sanity check

**Reviewer 2:**

Name: @mayerm94 
- [x] Gemfile/gemfile.lock sanity check