### PR TITLE
Catch failed patient conversions and return in separate array

### DIFF
--- a/app/helpers/patient_helper.rb
+++ b/app/helpers/patient_helper.rb
@@ -2,7 +2,21 @@ module PatientHelper
   
   # HDS Patient to QDM Patient model translation
   def self.convert_patient_models(hds_records)
+    qdm_records = []
+    failed_records = []
+
     # Convert all of the HDS Records into QDM Records
-    hds_records.map { |hds_record| CQMConverter.to_qdm(hds_record) }
+    hds_records.each do |hds_record|
+      begin
+        qdm_records << CQMConverter.to_qdm(hds_record)
+      rescue => e
+        # if there was a conversion failure we should record the resulting failure message with the hds model in a
+        # separate collection to return
+        failed_records << { hds_record: hds_record, error_message: e.message }
+      end
+    end
+
+    # Return both sucessful and failed records
+    [qdm_records, failed_records]
   end
 end

--- a/app/helpers/patient_helper.rb
+++ b/app/helpers/patient_helper.rb
@@ -9,7 +9,7 @@ module PatientHelper
     hds_records.each do |hds_record|
       begin
         qdm_records << CQMConverter.to_qdm(hds_record)
-      rescue => e
+      rescue ExecJS::ProgramError => e
         # if there was a conversion failure we should record the resulting failure message with the hds model in a
         # separate collection to return
         failed_records << { hds_record: hds_record, error_message: e.message }

--- a/test/unit/helpers/patient_helper_test.rb
+++ b/test/unit/helpers/patient_helper_test.rb
@@ -46,6 +46,9 @@ class PatientHelperTest < ActionView::TestCase
 
     # expect all 7 to convert without issue
     assert_equal 7, qdm_records.count
+
+    # expect there to be no failed records
+    assert_empty failed_records
   end
 
   test 'Calculations Are Unaffected By HDS to QDM Conversion' do

--- a/test/unit/helpers/patient_helper_test.rb
+++ b/test/unit/helpers/patient_helper_test.rb
@@ -5,14 +5,47 @@ class PatientHelperTest < ActionView::TestCase
 
   test 'No Patients Sent To convert_patient_models' do
     qdm_records = PatientHelper.convert_patient_models([])
-    assert_equal [], qdm_records
+    assert_equal [[], []], qdm_records
   end
 
-  test 'Correct Number Of Patients Recieved From convert_patient_models' do
-    records_set = File.join("records","base_set")
+  test 'Using core_measures set, Correct Number Of Patients Recieved From convert_patient_models with one failed patient' do
+    # load all of the core_measures fixture patients
+    dump_database
+    cms32_records_set = File.join("records","core_measures","CMS32v7")
+    cms134_records_set = File.join("records","core_measures","CMS134v6")
+    cms158_records_set = File.join("records","core_measures","CMS158v6")
+    cms160_records_set = File.join("records","core_measures","CMS160v6")
+    cms177_records_set = File.join("records","core_measures","CMS177v6")
+    collection_fixtures(cms32_records_set, cms134_records_set, cms158_records_set, cms160_records_set, cms177_records_set)
+
     hds_records = Record.all
-    qdm_records = PatientHelper.convert_patient_models(hds_records)
-    assert_equal hds_records.count, qdm_records.count
+    # make sure we have a total of 12 records and run conversion
+    assert_equal 12, hds_records.count
+    qdm_records, failed_records = PatientHelper.convert_patient_models(hds_records)
+
+    # 11 of the 12 patient are expected to convert without error
+    assert_equal 11, qdm_records.count
+
+    # Pass Numer from CMS134v6 has a component with a unit "cc". This is not valid UCUM so it will show up in the list of failed records.
+    assert_equal 1, failed_records.count
+    assert_equal "Pass", failed_records[0][:hds_record].first
+    assert_equal "Numer", failed_records[0][:hds_record].last
+    assert_equal "Error: 'cc' is not a valid UCUM unit.", failed_records[0][:error_message]
+  end
+
+  test 'Using special_measures set, Correct Number Of Patients Recieved From convert_patient_models' do
+    # load all of the special_measures fixture patients
+    dump_database
+    cms347_records_set = File.join("records","special_records","CMS347v1")
+    collection_fixtures(cms347_records_set)
+
+    hds_records = Record.all
+    # make sure we have a total of 7 records and run converson
+    assert_equal 7, hds_records.count
+    qdm_records, failed_records = PatientHelper.convert_patient_models(hds_records)
+
+    # expect all 7 to convert without issue
+    assert_equal 7, qdm_records.count
   end
 
   test 'Calculations Are Unaffected By HDS to QDM Conversion' do


### PR DESCRIPTION
Catch failed patient conversions and return in separate array. Also tests that the conversion with fixture patients.

Pull requests into Bonnie require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] JIRA ticket for this PR: https://jira.mitre.org/browse/BONNIE-1553
- [x] JIRA ticket links to this PR
- [x] Code diff has been done and been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] If UI changes have been made, google WAVE plug-in has been executed to ensure no 508 issues were introduced. N/A
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Test fixtures updated and documented as necessary ( see [internal wiki](https://gitlab.mitre.org/bonnie/internal-documentation/wikis/testing#test-fixtures) )
- [x] Code coverage has not gone down and all code touched or added is covered. 

Branch | Back End Coverage | Front End Coverage
-- | -- | --
bonnie-v2.3-backend_calculation | 1897 / 2128 LOC (89.14%) | Statements   : 59.44% ( 7280/12247 )<br>Branches     : 43.43% ( 1979/4557 )<br>Functions    : 49.81% ( 1207/2423 )<br>Lines        : 57.31% ( 6536/11404 )
[New Branch] | 1903 / 2134 LOC (89.18%) | Statements   : 59.44% ( 7280/12247 )<br>Branches     : 43.43% ( 1979/4557 )<br>Functions    : 49.81% ( 1207/2423 )<br>Lines        : 57.31% ( 6536/11404 )

- [x] Automated regression test(s) pass N/A doesn't touch calculation code

If JIRA tests were used to supplement or replace automated tests: N/A
- [x] JIRA test links: N/A
- [x] Justification for using JIRA tests: N/A
- [x] JIRA tests have been added to sprint N/A


**Reviewer 1:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

If JIRA tests were used to supplement or replace automated tests: N/A
- [x] JIRA tests have been run and pass N/A
- [x] You agree with the justification for use of JIRA tests or have provided input on why you disagree N/A


**Reviewer 2:**

Name: Cole
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

If JIRA tests were used to supplement or replace automated tests: N/A
- [x] JIRA tests have been run and pass N/A
- [x] You agree with the justification for use of JIRA tests or have provided input on why you disagree N/A
