### PR TITLE
reverting qrda enablement. bonnie-1525 #1024

### DIFF
--- a/app/assets/javascripts/templates/measure.hbs
+++ b/app/assets/javascripts/templates/measure.hbs
@@ -57,7 +57,7 @@
       <h2 class="h1-style"><i class="fa fa-user fa-fw" aria-hidden="true"></i> Test Patients</h2>
       <span class="settings-container">
         <div class="patients-settings">
-          {{#button "exportQrdaPatients" class="btn btn-default export-patients"}}<i class="fa fa-download" aria-hidden="true"></i> QRDA <span class="sr-only">Patient Export</span>{{/button}}
+          <a data-title="Not yet implemented for QDM 5.3" data-toggle="tooltip" data-placement="bottom">{{#button "exportQrdaPatients" class="btn btn-default export-patients" disabled="true"}}<i class="fa fa-download" aria-hidden="true"></i> QRDA<span class="sr-only">Patient Export</span>{{/button}}</a>
           {{#if cql}}
             {{#button "exportExcelPatients" class="btn btn-default export-patients"}}<i class="fa fa-download" aria-hidden="true"></i> Excel <span class="sr-only">Patient Export</span>{{/button}}
           {{/if}}

--- a/app/assets/javascripts/views/measure_view.js.coffee
+++ b/app/assets/javascripts/views/measure_view.js.coffee
@@ -43,6 +43,7 @@ class Thorax.Views.Measure extends Thorax.Views.BonnieView
       @exportPatientsView = new Thorax.Views.ExportPatientsView() # Modal dialogs for exporting
       @exportPatientsView.appendTo(@$el)
       @$('.d3-measure-viz, .btn-viz-text').hide()
+      @$('a[data-toggle="tooltip"]').tooltip()
 
   context: ->
     _(super).extend

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -163,8 +163,8 @@ private
   def qrda_patient_export(patient, measure)
     start_time = Time.new(Time.zone.at(APP_CONFIG['measure_period_start']).year, 1, 1)
     end_time = Time.new(Time.zone.at(APP_CONFIG['measure_period_start']).year, 12, 31)
-    qrda_exporter = HealthDataStandards::Export::Cat1.new 'r5'
-    qrda_exporter.export(patient, measure, start_time, end_time, nil, 'r5')
+    qrda_exporter = HealthDataStandards::Export::Cat1.new 'r3_1'
+    qrda_exporter.export(patient, measure, start_time, end_time, nil, 'r3_1')
   end
 
   def html_patient_export(patient, measure)

--- a/spec/javascripts/views/measure_view_spec.js.coffee
+++ b/spec/javascripts/views/measure_view_spec.js.coffee
@@ -86,10 +86,10 @@ describe 'MeasureView', ->
       bonnie.valueSetsByOid = @universalValueSetsByOid
       @cqlMeasureValueSetsView.remove()
 
-    it 'has QRDA export button to be enabled', ->
+    it 'has QRDA export button disabled', ->
       @measureView = new Thorax.Views.Measure(model: @cqlMeasure, patients: @cqlPatients, populations: @cqlMeasure.get('populations'), population: @cqlMeasure.get('displayedPopulation'))
       @measureView.appendTo 'body'
-      expect(@measureView.$("button[data-call-method=exportQrdaPatients]")).not.toBeDisabled()
+      expect(@measureView.$("button[data-call-method=exportQrdaPatients]")).toBeDisabled()
       @measureView.remove()
 
     it 'does not show SDEs for older measure', ->


### PR DESCRIPTION
Reverts the QRDA enablement change to no longer be enabled. This reverses PR #1024 from BONNIE-1525.

Pull requests into Bonnie require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] JIRA ticket for this PR: N/A
- [x] JIRA ticket links to this PR N/A
- [x] Code diff has been done and been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)

**Reviewer 1:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

If JIRA tests were used to supplement or replace automated tests:
- [x] You agree with the justification for use of JIRA tests or have provided input on why you disagree: N/A
