### PR TITLE
Add setting attribute to medication

### DIFF
--- a/app/assets/javascripts/models/measure.js.coffee
+++ b/app/assets/javascripts/models/measure.js.coffee
@@ -106,7 +106,7 @@ class Thorax.Models.Measure extends Thorax.Model
       immunizations: ['route', 'dose', 'reaction', 'supply', 'active_datetime']
       interventions: ['anatomical_structure', 'qdm_status']
       laboratory_tests: ['reference_range_low', 'reference_range_high', 'qdm_status', 'result_date_time', 'components', 'method']
-      medications: ['route', 'dose', 'reaction', 'supply', 'administration_timing', 'refills']
+      medications: ['route', 'dose', 'reaction', 'supply', 'administration_timing', 'refills', 'setting']
       participations: []
       patient_care_experiences: []
       physical_exams: ['anatomical_structure', 'components', 'method']


### PR DESCRIPTION
Setting code attribute was added to MedicationOrder in QDM5.4

Test with https://github.com/projectcypress/health-data-standards/tree/BONNIE_1600 and https://github.com/projecttacoma/cql_qdm_patientapi/tree/BONNIE_1600_2

Pull requests into Bonnie require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] JIRA ticket for this PR: https://jira.mitre.org/browse/BONNIE-1658
- [x] JIRA ticket links to this PR
- [x] Code diff has been done and been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] If UI changes have been made, google WAVE plug-in has been executed to ensure no 508 issues were introduced.
- [x] Tests are included and test edge cases NA, we do not yet have a measure that has this attribute. Tests are included in cql_qdm_patient_api and HDS
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Test fixtures updated and documented as necessary ( see [internal wiki](https://gitlab.mitre.org/bonnie/internal-documentation/wikis/testing#test-fixtures) )
- [] Code coverage has not gone down and all code touched or added is covered. 
     * In rare situations, this may not be possible or applicable to a PR. In those situations:
         1. Note why this could not be done or is not applicable here: 
         2. Add TODOs in the code noting that it requires a test
         3. Add a JIRA task to add the test and link it here: 

Branch | Back End Coverage | Front End Coverage
-- | -- | --
master | [Paste Output Here] | [Paste Screenshot Here]
[New Branch] | [Paste Output Here] | [Paste Screenshot Here]

- [x] Automated regression test(s) pass N/A not running regression into v3.0

If JIRA tests were used to supplement or replace automated tests:
- [x] JIRA test links: NA
- [x] Justification for using JIRA tests: NA
- [x] JIRA tests have been added to sprint NA


**Reviewer 1:**

Name: @edeyoung
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

If JIRA tests were used to supplement or replace automated tests:
- [x] JIRA tests have been run and pass N/A
- [x] You agree with the justification for use of JIRA tests or have provided input on why you disagree N/A


**Reviewer 2:**

Name: @losborne
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

If JIRA tests were used to supplement or replace automated tests:
- [x] JIRA tests have been run and pass
- [x] You agree with the justification for use of JIRA tests or have provided input on why you disagree
