### PR TITLE
added days supplied criteria to medication

### DIFF
--- a/app/assets/javascripts/models/measure.js.coffee
+++ b/app/assets/javascripts/models/measure.js.coffee
@@ -104,7 +104,7 @@ class Thorax.Models.Measure extends Thorax.Model
       immunizations: ['route', 'dose', 'reaction', 'supply', 'active_datetime', 'reason']
       interventions: ['qdm_status', 'reason']
       laboratory_tests: ['reference_range_low', 'reference_range_high', 'qdm_status', 'result_date_time', 'components', 'method', 'reason']
-      medications: ['route', 'dispenser_identifier', 'dose', 'supply', 'administration_timing', 'prescriber_identifier', 'refills', 'setting', 'reason']
+      medications: ['route', 'dispenser_identifier', 'dose', 'supply', 'administration_timing', 'prescriber_identifier', 'refills', 'setting', 'reason','days_supplied']
       participations: []
       physical_exams: ['anatomical_location', 'components', 'method', 'reason']
       procedures: ['incision_time', 'anatomical_location', 'ordinality', 'qdm_status', 'components', 'method', 'reason']


### PR DESCRIPTION
This PR adds a "Days Supplied" attribute to: Medication. The field is a number indicating the number of days a supply of medication should last.

Pull requests into Bonnie require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] JIRA ticket for this PR: https://jira.mitre.org/browse/BONNIE-1690
- [x] JIRA ticket links to this PR
- [x] Code diff has been done and been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] If UI changes have been made, google WAVE plug-in has been executed to ensure no 508 issues were introduced. N/A
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Test fixtures updated and documented as necessary ( see [internal wiki](https://gitlab.mitre.org/bonnie/internal-documentation/wikis/testing#test-fixtures) )
- [x] Code coverage has not gone down and all code touched or added is covered. 
     * In rare situations, this may not be possible or applicable to a PR. In those situations:
         1. Note why this could not be done or is not applicable here: 
         2. Add TODOs in the code noting that it requires a test
         3. Add a JIRA task to add the test and link it here: 

Branch | Back End Coverage | Front End Coverage
-- | -- | --
bonnie-v3.0 | 2161 / 2412 LOC (89.59%) covered| Statements   : 59.45% ( 7283/12251 )<br/>Branches     : 43.42% ( 1979/4558 )<br/>Functions    : 49.81% ( 1207/2423 )<br/>Lines        : 57.32% ( 6539/11408 )
BONNIE_1690_days_supplied | 2161 / 2412 LOC (89.59%) covered | Statements   : 59.45% ( 7283/12251 )<br/>Branches     : 43.42% ( 1979/4558 )<br/>Functions    : 49.81% ( 1207/2423 )<br/>Lines        : 57.32% ( 6539/11408 )

- [x] Automated regression test(s) pass N/A

If JIRA tests were used to supplement or replace automated tests:
- [x] JIRA test links: N/A
- [x] Justification for using JIRA tests: N/A
- [x] JIRA tests have been added to sprint N/A


**Reviewer 1:**

Name: @hossenlopp
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

If JIRA tests were used to supplement or replace automated tests:
- [x] JIRA tests have been run and pass
- [x] You agree with the justification for use of JIRA tests or have provided input on why you disagree


**Reviewer 2:**

Name: @mayerm94
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

If JIRA tests were used to supplement or replace automated tests:
- [x] JIRA tests have been run and pass
- [x] You agree with the justification for use of JIRA tests or have provided input on why you disagree
