### PR TITLE
Sort keys in objects for prettyResult and update gemfile with id changes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,13 +8,13 @@ GIT
 
 GIT
   remote: https://github.com/projecttacoma/cqm-converter
-  revision: dda86d312dfee775197c2128341d3d6d93073301
+  revision: 01da63e0a4c12eb4ec75250babf37d165a2b2885
   branch: master
   specs:
-    cqm-converter (0.3.5)
+    cqm-converter (0.3.6)
       activesupport
       coffee-script
-      cqm-models (>= 0.8.3)
+      cqm-models (>= 0.8.4)
       execjs
       health-data-standards (>= 4.1.0)
       momentjs-rails
@@ -131,7 +131,7 @@ GEM
     coffee-script (2.4.1)
       coffee-script-source
       execjs
-    coffee-script-source (1.9.1.1)
+    coffee-script-source (1.12.2)
     colorize (0.7.7)
     columnize (0.9.0)
     commonjs (0.2.7)
@@ -140,10 +140,10 @@ GEM
       coffee-rails (~> 4.1)
       rails (~> 4.2)
       sprockets-rails (~> 2.3)
-    cqm-models (0.8.3)
+    cqm-models (0.8.4)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
-    crass (1.0.3)
+    crass (1.0.4)
     daemons (1.2.3)
     delayed_job (4.1.3)
       activesupport (>= 3.0, < 5.2)
@@ -170,7 +170,7 @@ GEM
     equalizer (0.0.11)
     erubis (2.7.0)
     eventmachine (1.0.7)
-    execjs (2.5.2)
+    execjs (2.7.0)
     ffi (1.9.18)
     foreman (0.78.0)
       thor (~> 0.19.1)
@@ -259,7 +259,7 @@ GEM
       mongoid (>= 2.0)
     mongoid-tree (2.0.1)
       mongoid (>= 4.0, < 6.0)
-    multi_json (1.12.1)
+    multi_json (1.13.1)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
     net-ssh (2.9.2)
@@ -293,7 +293,7 @@ GEM
       mongoid (~> 5.0)
       rubyzip (~> 1.0)
       zip-zip (~> 0.3)
-    rack (1.6.8)
+    rack (1.6.10)
     rack-test (0.6.3)
       rack (>= 1.0)
     rails (4.2.9)
@@ -309,8 +309,8 @@ GEM
       sprockets-rails
     rails-deprecated_sanitizer (1.0.3)
       activesupport (>= 4.2.0.alpha)
-    rails-dom-testing (1.0.8)
-      activesupport (>= 4.2.0.beta, < 5.0)
+    rails-dom-testing (1.0.9)
+      activesupport (>= 4.2.0, < 5.0)
       nokogiri (~> 1.6)
       rails-deprecated_sanitizer (>= 1.0.1)
     rails-html-sanitizer (1.0.4)
@@ -330,7 +330,7 @@ GEM
       thor (>= 0.18.1, < 2.0)
     rainbow (2.2.2)
       rake
-    rake (12.0.0)
+    rake (12.3.1)
     reek (4.7.3)
       codeclimate-engine-rb (~> 0.4.0)
       parser (>= 2.4.0.0, < 2.5)

--- a/app/assets/javascripts/helpers/cql_results_helpers.js.coffee
+++ b/app/assets/javascripts/helpers/cql_results_helpers.js.coffee
@@ -249,7 +249,9 @@ class CQLResultsHelpers
     else if result instanceof Object
       prettyResult = '{\n'
       baseIndentation = Array(3).join ' '
-      for key, value of result
+      sortedKeys = Object.keys(result).sort()
+      for key in sortedKeys
+        value = result[key]
         # add 2 spaces per indent
         nextIndentLevel = indentLevel + 2
         # key length + ': '
@@ -257,7 +259,7 @@ class CQLResultsHelpers
         prettyResult = prettyResult.concat("#{baseIndentation}#{currentIndentation}#{key}: #{@prettyResult(value, nextIndentLevel, keyIndent)}")
 
         # append commas if it isn't the last key
-        if key == Object.keys(result)[Object.keys(result).length - 1]
+        if key == sortedKeys[sortedKeys.length - 1]
           prettyResult += '\n'
         else
           prettyResult += ',\n'

--- a/spec/javascripts/helper_specs/cql_results_helpers_spec.js.coffee
+++ b/spec/javascripts/helper_specs/cql_results_helpers_spec.js.coffee
@@ -15,7 +15,7 @@ describe 'CQLResultsHelpers', ->
         expect(item).toEqual(beforeClone[index])
 
     it 'should properly indent nested objects', ->
-      nestedObject = {'one': 'single item', 'two': {'nested': 'item', 'nested2': 'item'}, 'three': {'doubleNested': {'a' : '1', 'b': '2', 'c': '3'}, 'nested': 'item'}}
+      nestedObject = {'one': 'single item', 'three': {'doubleNested': {'a' : '1', 'b': '2', 'c': '3'}, 'nested': 'item'}, 'two': {'nested': 'item', 'nested2': 'item'} }
       prettyNestedObject = """
 {
   one: "single item",
@@ -30,6 +30,27 @@ describe 'CQLResultsHelpers', ->
   two: {
     nested: "item",
     nested2: "item"
+  }
+}
+"""
+      expect(CQLResultsHelpers.prettyResult(nestedObject)).toEqual(prettyNestedObject)
+
+    it 'should properly indent nested objects and sort out of order elements', ->
+      nestedObject = {'three': {'doubleNested': {'b' : '2', 'c': '3', 'a': '1'}, 'aSingleNested': 'item'}, 'two': {'cnested': 'item', 'bnested2': 'item'}, 'one': 'single item' }
+      prettyNestedObject = """
+{
+  one: "single item",
+  three: {
+    aSingleNested: "item",
+    doubleNested: {
+      a: "1",
+      b: "2",
+      c: "3"
+    }
+  },
+  two: {
+    bnested2: "item",
+    cnested: "item"
   }
 }
 """

--- a/spec/javascripts/helper_specs/cql_results_helpers_spec.js.coffee
+++ b/spec/javascripts/helper_specs/cql_results_helpers_spec.js.coffee
@@ -19,10 +19,6 @@ describe 'CQLResultsHelpers', ->
       prettyNestedObject = """
 {
   one: "single item",
-  two: {
-    nested: "item",
-    nested2: "item"
-  },
   three: {
     doubleNested: {
       a: "1",
@@ -30,6 +26,10 @@ describe 'CQLResultsHelpers', ->
       c: "3"
     },
     nested: "item"
+  },
+  two: {
+    nested: "item",
+    nested2: "item"
   }
 }
 """


### PR DESCRIPTION
Pull requests into Bonnie require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] JIRA ticket for this PR: https://jira.mitre.org/browse/BONNIE-1634  https://jira.mitre.org/browse/BONNIE-1704
- [x] JIRA ticket links to this PR
- [x] Code diff has been done and been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] If UI changes have been made, google WAVE plug-in has been executed to ensure no 508 issues were introduced. N/A
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Test fixtures updated and documented as necessary ( see [internal wiki](https://gitlab.mitre.org/bonnie/internal-documentation/wikis/testing#test-fixtures) )
- [x] Code coverage has not gone down and all code touched or added is covered. 
     * In rare situations, this may not be possible or applicable to a PR. In those situations:
         1. Note why this could not be done or is not applicable here: 
         2. Add TODOs in the code noting that it requires a test
         3. Add a JIRA task to add the test and link it here: 

Branch | Back End Coverage | Front End Coverage
-- | -- | --
master | 2161 / 2412 LOC (89.59%) covered. | Statements   : 59.44% ( 7282/12250 )<br/>Branches     : 43.46% ( 1982/4561 )<br/>Functions    : 49.81% ( 1207/2423 )<br/>Lines        : 57.32% ( 6538/11407 )
[New Branch] | 2161 / 2412 LOC (89.59%) covered. | Statements   : 59.45% ( 7288/12259 )<br/>Branches     : 43.46% ( 1982/4561 )<br/>Functions    : 49.81% ( 1207/2423 )<br/>Lines        : 57.32% ( 6544/11416 )

- [x] Automated regression test(s) pass N/A

If JIRA tests were used to supplement or replace automated tests: N/A
- [x] JIRA test links: N/A
- [x] Justification for using JIRA tests: N/A
- [x] JIRA tests have been added to sprint


**Reviewer 1:**

Name: @losborne
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

If JIRA tests were used to supplement or replace automated tests: N/A
- [x] JIRA tests have been run and pass
- [x] You agree with the justification for use of JIRA tests or have provided input on why you disagree


**Reviewer 2:**

Name: @daco101
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

If JIRA tests were used to supplement or replace automated tests: N/A
- [x] JIRA tests have been run and pass
- [x] You agree with the justification for use of JIRA tests or have provided input on why you disagree
