### PR TITLE
align logicFieldsFor to QDM 5.4 spec

### DIFF
--- a/app/assets/javascripts/models/measure.js.coffee
+++ b/app/assets/javascripts/models/measure.js.coffee
@@ -82,43 +82,36 @@ class Thorax.Models.Measure extends Thorax.Model
     # Defines what is included in the drop down menu in the Bonnie Patient Builder for all
     # criteria. The name should correspond with what is the `coded_entry_method` in the `FIELDS`
     # hash in health-data-standards:lib/health-model/data_criteria.rb.
-    globalInclusions = ['reason', 'source', 'health_record_field']
+    # TODO: The QDM spec also lists 'recorder' here as a globally included item.
+    globalInclusions = ['source', 'health_record_field']
 
     # Defines what is included in the drop down menu in the Bonnie Patient Builder for a particular
     # criteria. The name should correspond with what is the `coded_entry_method` in the `FIELDS`
-    # hash in health-data-standards:lib/health-model/data_criteria.rb.
+    # hash in health-data-standards:lib/hqmf-model/data_criteria.rb.
     typeInclusions =
-      adverse_events: ['facility', 'severity', 'type'] # TODO: (LDY 9/29/2016) we care about "facility location". this appears to be the same as "facility"
+      adverse_events: ['facility', 'severity', 'type']
       allergies_intolerances: ['severity', 'type']
-      assessments: ['method', 'components']
+      assessments: ['reason', 'method', 'components']
       care_experiences: []
       care_goals: ['target_outcome']
       characteristics: []
       communications: ['category', 'sender', 'recipient', 'medium']
-      conditions: ['anatomical_structure', 'anatomical_location', 'ordinality', 'severity', 'laterality']
-      devices: ['removal_time', 'anatomical_structure']
-      diagnostic_studies: ['facility', 'method', 'qdm_status', 'result_date_time', 'components']
-      encounters: ['admission_source', 'admit_time', 'discharge_time', 'discharge_disposition', 'facility',
-        'transfer_to', 'transfer_to_time', 
-        'transfer_from', 'transfer_from_time', 'principal_diagnosis', 'diagnosis']
+      conditions: ['anatomical_location', 'ordinality', 'severity']
+      devices: ['anatomical_location', 'reason']
+      diagnostic_studies: ['facility', 'method', 'qdm_status', 'result_date_time', 'components', 'reason']
+      encounters: ['admission_source', 'discharge_disposition', 'facility', 'principal_diagnosis', 'diagnosis', 'reason']
       family_history: ['relationship_to_patient']
-      functional_statuses: []
-      immunizations: ['route', 'dose', 'reaction', 'supply', 'active_datetime']
-      interventions: ['anatomical_structure', 'qdm_status']
-      laboratory_tests: ['reference_range_low', 'reference_range_high', 'qdm_status', 'result_date_time', 'components', 'method']
-      medications: ['route', 'dispenser_identifier', 'dose', 'reaction', 'supply', 'administration_timing', 'prescriber_identifier', 'refills', 'setting']
+      immunizations: ['route', 'dose', 'reaction', 'supply', 'active_datetime', 'reason']
+      interventions: ['qdm_status', 'reason']
+      laboratory_tests: ['reference_range_low', 'reference_range_high', 'qdm_status', 'result_date_time', 'components', 'method', 'reason']
+      medications: ['route', 'dispenser_identifier', 'dose', 'supply', 'administration_timing', 'prescriber_identifier', 'refills', 'setting', 'reason']
       participations: []
-      patient_care_experiences: []
-      physical_exams: ['anatomical_structure', 'components', 'method']
-      preferences: []
-      procedures: ['incision_time', 'anatomical_structure', 'anatomical_location', 'ordinality', 'qdm_status', 'components', 'method']
+      physical_exams: ['anatomical_location', 'components', 'method', 'reason']
+      procedures: ['incision_time', 'anatomical_location', 'ordinality', 'qdm_status', 'components', 'method', 'reason']
       provider_care_experiences: []
       provider_characteristics: []
-      risk_category_assessments: ['severity']
-      substances: ['dose', 'route', 'administration_timing', 'reaction', 'supply', 'refills']
-      symptoms: ['ordinality', 'severity']
-      system_characteristics: []
-      transfers: []
+      substances: ['dose', 'route', 'administration_timing', 'supply', 'refills', 'reason']
+      symptoms: ['severity']
 
     # start with all field values
     fields = Thorax.Models.Measure.logicFields


### PR DESCRIPTION
This PR aligns the field value dropdown to include the right items for data criteria as of the QDM 5.4 spec.

'Reason' was removed from the globably included attributes because it is actually 'recorder' that is listed in the QDM spec and not reason.  A TODO was added for investigating adding 'recorder', which currently is not implemented.

There is a corresponding hds PR that just adds comments (so no need to point to that branch for testing purposes): 

Pull requests into Bonnie require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] JIRA ticket for this PR: https://jira.mitre.org/browse/BONNIE-1609 https://jira.mitre.org/browse/BONNIE-1735
- [x] JIRA ticket links to this PR
- [x] Code diff has been done and been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] ~If UI changes have been made, google WAVE plug-in has been executed to ensure no 508 issues were introduced.~
- [x] ~Tests are included and test edge cases~ 
The process of using this list to populate the drop downs is tested.  It does not make sense to test that every drop down contains only these elements, as that is just duplicated information. If the spec changes, the tests and the lists would have to be updated, and the tests would not automatically update if the spec changes.
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] ~Test fixtures updated and documented as necessary ( see [internal wiki](https://gitlab.mitre.org/bonnie/internal-documentation/wikis/testing#test-fixtures) )~
- [x] Code coverage has not gone down and all code touched or added is covered. 

Branch | Back End Coverage | Front End Coverage
-- | -- | --
bonnie-v3.0 | 2161 / 2412 LOC (89.59%) | ![image](https://user-images.githubusercontent.com/14879344/44803445-86caaa00-ab8c-11e8-9f4f-b7263d018a37.png)
drop_down_alignment | 2161 / 2412 LOC (89.59%) | ![image](https://user-images.githubusercontent.com/14879344/44803522-b4afee80-ab8c-11e8-918c-d7cef3966260.png)


- [x] Automated regression test(s) pass

If JIRA tests were used to supplement or replace automated tests:
- ~[x] JIRA test links:~
- ~[x] Justification for using JIRA tests:~
- ~[x] JIRA tests have been added to sprint~


**Reviewer 1:**

Name: @daco101 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

If JIRA tests were used to supplement or replace automated tests:
- ~[x] JIRA tests have been run and pass~
- ~[x] You agree with the justification for use of JIRA tests or have provided input on why you disagree~


**Reviewer 2:**

Name: @mayerm94 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

If JIRA tests were used to supplement or replace automated tests:
- ~[x] JIRA tests have been run and pass~
- ~[x] You agree with the justification for use of JIRA tests or have provided input on why you disagree~
