### PR TITLE
fixed bug where expected values only trimmed if block is provided to …

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -277,7 +277,7 @@ GEM
     net-ssh (2.9.2)
     netrc (0.11.0)
     newrelic_rpm (3.14.3.313)
-    nokogiri (1.8.4)
+    nokogiri (1.8.5)
       mini_portile2 (~> 2.3.0)
     non-stupid-digest-assets (1.0.4)
     oj (2.12.11)

--- a/lib/ext/record.rb
+++ b/lib/ext/record.rb
@@ -179,7 +179,7 @@ class Record
 
       # delete populations that no longer exist (populations in the expected values that don't exist in the measure)
       removed_populations = expected_value_population_set - measure_population_set
-      if removed_populations.count > 0 && block_given?
+      if removed_populations.count > 0
         # create the structure to yield about these changes
         removed_changes = {"measure_id" => measure.hqmf_set_id, "population_index" => expected_value_set[:population_index]}
         removed_populations.each { |population| removed_changes[population] = expected_value_set[population] }

--- a/test/unit/models/record_test.rb
+++ b/test/unit/models/record_test.rb
@@ -11,7 +11,8 @@ class RecordTest < ActiveSupport::TestCase
   end
 
   # Runs the update_expected_value_structure! method on the patient and collects the changes it yields.
-  def collect_expected_changes(patient, measure)
+  def collect_expected_changes_and_verify_block_no_block(patient, measure)
+    patient_clone = Marshal.load(Marshal.dump(patient))
     changes = []
     patient.update_expected_value_structure!(measure) do |change_type, change_reason, expected_value_set|
       changes << {
@@ -20,19 +21,22 @@ class RecordTest < ActiveSupport::TestCase
         expected_value_set: expected_value_set
       }
     end
+    patient_clone.update_expected_value_structure!(measure)
+    # always make sure function works the same way whether passed blocks for yielding or not
+    assert_equal patient.expected_values, patient_clone.expected_values
     changes
   end
 
   test "Good Expecteds" do
     patient = Record.where(last: 'Expecteds', first: 'Good').first
-    changes = collect_expected_changes(patient, @measure)
+    changes = collect_expected_changes_and_verify_block_no_block(patient, @measure)
     assert_equal 0, changes.count
     assert_equal 1, patient.expected_values.count
   end
 
   test "Duplicate Expecteds" do
     patient = Record.where(last: 'Expecteds', first: 'Duplicate').first
-    changes = collect_expected_changes(patient, @measure)
+    changes = collect_expected_changes_and_verify_block_no_block(patient, @measure)
     assert_equal 1, changes.count
 
     # check duplicate population set removal
@@ -51,7 +55,7 @@ class RecordTest < ActiveSupport::TestCase
 
   test "Extra Population Set Expecteds" do
     patient = Record.where(last: 'Expecteds', first: 'Extra Population Set').first
-    changes = collect_expected_changes(patient, @measure)
+    changes = collect_expected_changes_and_verify_block_no_block(patient, @measure)
     assert_equal 1, changes.count
 
     # check extra population set removal
@@ -70,7 +74,7 @@ class RecordTest < ActiveSupport::TestCase
 
   test "Extra Population Set Multiple Measure Expecteds" do
     patient = Record.where(last: 'Expecteds', first: 'Extra Population Set Multiple Measure').first
-    changes = collect_expected_changes(patient, @measure)
+    changes = collect_expected_changes_and_verify_block_no_block(patient, @measure)
     assert_equal 1, changes.count
 
     # check extra population set removal
@@ -91,7 +95,7 @@ class RecordTest < ActiveSupport::TestCase
 
   test "Garbage and Duplicate Expecteds" do
     patient = Record.where(last: 'Expecteds', first: 'Garbage and Duplicate').first
-    changes = collect_expected_changes(patient, @measure)
+    changes = collect_expected_changes_and_verify_block_no_block(patient, @measure)
     assert_equal 2, changes.count
 
     # check garbage data removal
@@ -116,7 +120,7 @@ class RecordTest < ActiveSupport::TestCase
 
   test "Garbage Expecteds" do
     patient = Record.where(last: 'Expecteds', first: 'Garbage').first
-    changes = collect_expected_changes(patient, @measure)
+    changes = collect_expected_changes_and_verify_block_no_block(patient, @measure)
     assert_equal 1, changes.count
 
     # check garbage data removal
@@ -134,7 +138,7 @@ class RecordTest < ActiveSupport::TestCase
 
   test "Garbage Empty Expecteds" do
     patient = Record.where(last: 'Expecteds', first: 'Garbage Empty').first
-    changes = collect_expected_changes(patient, @measure)
+    changes = collect_expected_changes_and_verify_block_no_block(patient, @measure)
     assert_equal 1, changes.count
 
     # check garbage data removal of a blank set
@@ -152,7 +156,7 @@ class RecordTest < ActiveSupport::TestCase
 
   test "Missing Population Set Expecteds" do
     patient = Record.where(last: 'Expecteds', first: 'Missing Population Set').first
-    changes = collect_expected_changes(patient, @measure)
+    changes = collect_expected_changes_and_verify_block_no_block(patient, @measure)
     assert_equal 2, changes.count
 
     # check missing population set addition
@@ -177,7 +181,7 @@ class RecordTest < ActiveSupport::TestCase
 
   test "Missing Population Set With Garbage Expecteds" do
     patient = Record.where(last: 'Expecteds', first: 'Missing Population Set With Garbage').first
-    changes = collect_expected_changes(patient, @measure)
+    changes = collect_expected_changes_and_verify_block_no_block(patient, @measure)
     assert_equal 3, changes.count
 
     # check garbage data removal
@@ -208,7 +212,7 @@ class RecordTest < ActiveSupport::TestCase
 
   test "Missing Population Expecteds" do
     patient = Record.where(last: 'Expecteds', first: 'Missing Population').first
-    changes = collect_expected_changes(patient, @measure)
+    changes = collect_expected_changes_and_verify_block_no_block(patient, @measure)
     assert_equal 1, changes.count
 
     # check missing population addition
@@ -227,7 +231,7 @@ class RecordTest < ActiveSupport::TestCase
   
   test "Extra Population Expecteds" do
     patient = Record.where(last: 'Expecteds', first: 'Extra Population').first
-    changes = collect_expected_changes(patient, @measure)
+    changes = collect_expected_changes_and_verify_block_no_block(patient, @measure)
     assert_equal 1, changes.count
     
     # check missing population set addition


### PR DESCRIPTION
This PR fixes a bug in the update_expected_value_structure function where expected values were only trimmed if a yield block was passed into the function (which does not happen when the function is used by the measure controller endpoints). The result of this bug meant that if measures were updated with versions that had different amount of population sets, expected values could have incorrect fields (e.g. STRAT on the population set).

See the JIRA ticket for measures packages and test instructions.

Pull requests into Bonnie require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] JIRA ticket for this PR: https://jira.mitre.org/browse/BONNIE-1767
- [x] JIRA ticket links to this PR
- [x] Code diff has been done and been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] NA If UI changes have been made, google WAVE plug-in has been executed to ensure no 508 issues were introduced.
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] NA Test fixtures updated and documented as necessary ( see [internal wiki](https://gitlab.mitre.org/bonnie/internal-documentation/wikis/testing#test-fixtures) )
- [x] Code coverage has not gone down and all code touched or added is covered. 
     * In rare situations, this may not be possible or applicable to a PR. In those situations:
         1. Note why this could not be done or is not applicable here: 
         2. Add TODOs in the code noting that it requires a test
         3. Add a JIRA task to add the test and link it here: 

Branch | Back End Coverage | Front End Coverage
--- | --- | ---
bonnie-v3.0 | 2166 / 2420 LOC (89.5%) covered | NA
bonnie-v3.0_fix_update_expected_value_structure_bug | 2166 / 2420 LOC (89.5%) covered. | NA

- [x] NA Automated regression test(s) pass

If JIRA tests were used to supplement or replace automated tests:
- [x] NA JIRA test links:
- [x] NA Justification for using JIRA tests:
- [x] NA JIRA tests have been added to sprint


**Reviewer 1:**

Name: @jbradl11 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

If JIRA tests were used to supplement or replace automated tests:
- [x] JIRA tests have been run and pass
- [x] You agree with the justification for use of JIRA tests or have provided input on why you disagree


**Reviewer 2:**

Name: @mayerm94 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

If JIRA tests were used to supplement or replace automated tests:
- [x] JIRA tests have been run and pass
- [x] You agree with the justification for use of JIRA tests or have provided input on why you disagree
