### PR TITLE
Adjust conditional so scalar values appear in results

### DIFF
--- a/app/assets/javascripts/templates/patient_builder/edit_criteria.hbs
+++ b/app/assets/javascripts/templates/patient_builder/edit_criteria.hbs
@@ -108,10 +108,10 @@
                 {{#if denominator_scalar}}
                   {{numerator_scalar}}{{numerator_units}}:{{denominator_scalar}}{{denominator_units}}
                   {{title}}
-                {{else}}
+                {{/if}}
+              {{else}}
                   {{value}} {{unit}}
                   {{title}}
-                {{/if}}
               {{/if}}
             {{/if}}
               {{#button "removeValue" class="btn btn-link close delete"}}&times; <span class="sr-only">Delete</span>{{/button}}

--- a/app/assets/javascripts/templates/patient_builder/edit_criteria.hbs
+++ b/app/assets/javascripts/templates/patient_builder/edit_criteria.hbs
@@ -110,8 +110,8 @@
                   {{title}}
                 {{/if}}
               {{else}}
-                  {{value}} {{unit}}
-                  {{title}}
+                {{value}} {{unit}}
+                {{title}}
               {{/if}}
             {{/if}}
               {{#button "removeValue" class="btn btn-link close delete"}}&times; <span class="sr-only">Delete</span>{{/button}}

--- a/app/assets/javascripts/views/patient_builder/data_criteria.js.coffee
+++ b/app/assets/javascripts/views/patient_builder/data_criteria.js.coffee
@@ -476,6 +476,10 @@ class Thorax.Views.EditCriteriaValueView extends Thorax.Views.BuilderChildView
         @$('select[name="code_list_id"]').focus()
       when 'TS'
         @$('input[name="start_date"]').focus()
+      when 'RT'
+        @$('input[name="numerator_scalar"]').focus()
+      when 'ID'
+        @$('input[name="root"]').focus()
       when 'CMP'
         switch @model.get('type_cmp')
           when 'PQ'
@@ -491,6 +495,8 @@ class Thorax.Views.EditCriteriaValueView extends Thorax.Views.BuilderChildView
     isDisabled = ((attributes.type == 'PQ' || attributes.type_cmp == 'PQ') && !attributes.value) ||
                  ((attributes.type == 'CD' || attributes.type_cmp == 'CD') && !attributes.code_list_id) ||
                  ((attributes.type == 'TS' || attributes.type_cmp == 'TS') && !attributes.value) ||
+                 ((attributes.type == 'RT' || attributes.type_cmp == 'RT') && !attributes.denominator_scalar) ||
+                 ((attributes.type == 'ID' || attributes.type_cmp == 'ID') && (!attributes.root || !attributes.extension)) ||
                  (attributes.key == 'COMPONENT' && (!attributes.code_list_id_cmp)) ||
                  (attributes.key == 'FACILITY_LOCATION' && !attributes.code_list_id) ||
                  (@fieldValue && !attributes.key)

--- a/app/assets/javascripts/views/patient_builder/data_criteria.js.coffee
+++ b/app/assets/javascripts/views/patient_builder/data_criteria.js.coffee
@@ -495,7 +495,7 @@ class Thorax.Views.EditCriteriaValueView extends Thorax.Views.BuilderChildView
     isDisabled = ((attributes.type == 'PQ' || attributes.type_cmp == 'PQ') && !attributes.value) ||
                  ((attributes.type == 'CD' || attributes.type_cmp == 'CD') && !attributes.code_list_id) ||
                  ((attributes.type == 'TS' || attributes.type_cmp == 'TS') && !attributes.value) ||
-                 ((attributes.type == 'RT' || attributes.type_cmp == 'RT') && !attributes.denominator_scalar) ||
+                 ((attributes.type == 'RT' || attributes.type_cmp == 'RT') && (!attributes.denominator_scalar || !attributes.numerator_scalar)) ||
                  ((attributes.type == 'ID' || attributes.type_cmp == 'ID') && (!attributes.root || !attributes.extension)) ||
                  (attributes.key == 'COMPONENT' && (!attributes.code_list_id_cmp)) ||
                  (attributes.key == 'FACILITY_LOCATION' && !attributes.code_list_id) ||

--- a/spec/javascripts/views/patient_builder_spec.js.coffee
+++ b/spec/javascripts/views/patient_builder_spec.js.coffee
@@ -230,7 +230,7 @@ describe 'PatientBuilderView', ->
         expect(@firstCriteria.get('value').first().get('type')).toEqual 'PQ'
         expect(@firstCriteria.get('value').first().get('value')).toEqual '1'
         expect(@firstCriteria.get('value').first().get('unit')).toEqual 'mg'
-        expect(this.patientBuilder.$('.existing-values span').first().text().indexOf("1 mg")).not.toEqual -1
+        expect(@patientBuilder.$('.existing-values span').first().text().indexOf("1 mg")).not.toEqual -1
 
       it "adds a coded value", ->
         expect(@firstCriteria.get('value').length).toEqual 0

--- a/spec/javascripts/views/patient_builder_spec.js.coffee
+++ b/spec/javascripts/views/patient_builder_spec.js.coffee
@@ -295,7 +295,7 @@ describe 'PatientBuilderView', ->
             @patientBuilder.$('select[name=key]').val(fieldType).change()
             @patientBuilder.$('select[name=type]:eq(1)').val('ID').change()
             @patientBuilder.$('input[name=root]').val(id).keyup()
-            @patientBuilder.$('input[name=extension]').val(system)
+            @patientBuilder.$('input[name=extension]').val(system).keyup()
             @patientBuilder.$('.field-value-formset .btn-primary:first').click() if submit
 
         it "adds a scalar field value", ->

--- a/spec/javascripts/views/patient_builder_spec.js.coffee
+++ b/spec/javascripts/views/patient_builder_spec.js.coffee
@@ -230,6 +230,7 @@ describe 'PatientBuilderView', ->
         expect(@firstCriteria.get('value').first().get('type')).toEqual 'PQ'
         expect(@firstCriteria.get('value').first().get('value')).toEqual '1'
         expect(@firstCriteria.get('value').first().get('unit')).toEqual 'mg'
+        expect(this.patientBuilder.$('.existing-values span').first().text().indexOf("1 mg")).not.toEqual -1
 
       it "adds a coded value", ->
         expect(@firstCriteria.get('value').length).toEqual 0


### PR DESCRIPTION
Conditional in results display was not falling back to Scalar.
Pull requests into Bonnie require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] JIRA ticket for this PR: https://jira.mitre.org/browse/BONNIE-1793
- [x] JIRA ticket links to this PR
- [x] Code diff has been done and been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] If UI changes have been made, google WAVE plug-in has been executed to ensure no 508 issues were introduced.
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Test fixtures updated and documented as necessary ( see [internal wiki] (https://gitlab.mitre.org/bonnie/internal-documentation/wikis/testing#test-fixtures) ) NA
- [x] Code coverage has not gone down and all code touched or added is covered. 
     * In rare situations, this may not be possible or applicable to a PR. In those situations:
         1. Note why this could not be done or is not applicable here: 
         2. Add TODOs in the code noting that it requires a test
         3. Add a JIRA task to add the test and link it here: 

Branch | Back End Coverage | Front End Coverage
-- | -- | --
master | 89.54% | ![image](https://user-images.githubusercontent.com/3967953/47508686-912eba80-d842-11e8-92b0-379969bdce23.png)
[New Branch] | 89.54% | ![image](https://user-images.githubusercontent.com/3967953/47507978-39dc1a80-d841-11e8-9e7a-0675befd8590.png)

- [x] Automated regression test(s) pass

If JIRA tests were used to supplement or replace automated tests:
- [x] JIRA test links: NA
- [x] Justification for using JIRA tests: NA
- [x] JIRA tests have been added to sprint NA


**Reviewer 1:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

If JIRA tests were used to supplement or replace automated tests:
- ~[ ] JIRA tests have been run and pass~
- ~[ ] You agree with the justification for use of JIRA tests or have provided input on why you disagree~


**Reviewer 2:**

Name: @losborne 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

If JIRA tests were used to supplement or replace automated tests:
- ~[x] JIRA tests have been run and pass~
- ~[x] You agree with the justification for use of JIRA tests or have provided input on why you disagree~
