### PR TITLE
don't count components in composite coverage calculation

### DIFF
--- a/app/assets/javascripts/models/coverage.js.coffee
+++ b/app/assets/javascripts/models/coverage.js.coffee
@@ -21,27 +21,28 @@ class Thorax.Model.Coverage extends Thorax.Model
         @rationaleCriteria = {}
         totalClauses = 0
         passedClauses = 0
+        elmAnnotationLibraryNames = Object.keys(@population.collection.parent.get('elm_annotations'))
         for patientResults in @clauseResults
-          for libraryName, library of patientResults 
-            for localId, clauseResult of library
-              if !@ignoreClause(clauseResult)
-                key = libraryName.concat('_',localId)
-                # Initialize allClauses list to all false and count number of clauses
-                if !allClauses[key]?
-                  totalClauses += 1
-                  allClauses[key] = false
-                allClauses[key] = allClauses[key] || @determineCovered(clauseResult)
-                # Build rationaleCriteria structure for coverage highlighting
-                if allClauses[key]
-                  if !@rationaleCriteria[libraryName]?
-                    @rationaleCriteria[libraryName] = []
-                  @rationaleCriteria[libraryName][localId] = clauseResult
-                
+          for libraryName, library of patientResults
+            if elmAnnotationLibraryNames.some((el) -> libraryName is el)
+              for localId, clauseResult of library
+                if !@ignoreClause(clauseResult)
+                  key = libraryName.concat('_',localId)
+                  # Initialize allClauses list to all false and count number of clauses
+                  if !allClauses[key]?
+                    totalClauses += 1
+                    allClauses[key] = false
+                  allClauses[key] = allClauses[key] || @determineCovered(clauseResult)
+                  # Build rationaleCriteria structure for coverage highlighting
+                  if allClauses[key]
+                    if !@rationaleCriteria[libraryName]?
+                      @rationaleCriteria[libraryName] = []
+                    @rationaleCriteria[libraryName][localId] = clauseResult
         # Count total number of clauses that evalueated to true
         for localId of allClauses
           if allClauses[localId]
             passedClauses += 1
-        # Set coverage to the percentage of evaluated clauses to total clauses   
+        # Set coverage to the percentage of evaluated clauses to total clauses
         @set coverage: Math.floor( passedClauses * 100 / totalClauses )
     else
       # Find all unique criteria that evaluated true in the rationale that are also in the measure
@@ -64,8 +65,8 @@ class Thorax.Model.Coverage extends Thorax.Model
   ignoreClause: (clause) ->
     # Ignore value set clauses
     if clause.raw? && clause.raw.name? && clause.raw.name == "ValueSet"
-      return true    
+      return true
     # Ignore clauses that were not used in logic, for example unused defines from an included library
     if clause.final == "NA"
-      return true      
+      return true
     return false

--- a/spec/javascripts/models/coverage_spec.js.coffee
+++ b/spec/javascripts/models/coverage_spec.js.coffee
@@ -16,7 +16,7 @@ describe 'Coverage', ->
     measure.set('patients',@cqlPatients)
     bonnie.measures.add measure      
 
-    expect(measure.get('populations').at(0).coverage().get('coverage')).toEqual 44 #should change with composite coverage calculation PR
+    expect(measure.get('populations').at(0).coverage().get('coverage')).toEqual 72
 
   it 'calculates coverage correctly for a component measure', ->
     measure = new Thorax.Models.Measure @components[0], parse: true


### PR DESCRIPTION
Pull requests into Bonnie require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

This PR modifies coverage calculation to only be performed on the elm libraries that are included in the elm_annotations. This will solve the issue with coverage calculations of composite measure logic.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] JIRA ticket for this PR:  https://jira.mitre.org/browse/BONNIE-1823
- [x] JIRA ticket links to this PR
- [x] Code diff has been done and been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] If UI changes have been made, google WAVE plug-in has been executed to ensure no 508 issues were introduced.
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Test fixtures updated and documented as necessary ( see [internal wiki](https://gitlab.mitre.org/bonnie/internal-documentation/wikis/testing#test-fixtures) )
- [x] Code coverage has not gone down and all code touched or added is covered. 
     * In rare situations, this may not be possible or applicable to a PR. In those situations:
         1. Note why this could not be done or is not applicable here: 
         2. Add TODOs in the code noting that it requires a test
         3. Add a JIRA task to add the test and link it here: 

Branch | Back End Coverage | Front End Coverage
-- | -- | --
bonnie-v3.1 | 2226 / 2487 LOC (89.51%) covered | Statements   : 60.43% ( 7472/12364 )<br>Branches     : 45.75% ( 2116/4625 )<br>Functions    : 50.72% ( 1237/2439 )<br>Lines        : 58.38% ( 6719/11509 )
composite_coverage | 2226 / 2487 LOC (89.51%) covered. | Statements   : 60.44% ( 7475/12367 ) <br>Branches     : 45.77% ( 2118/4627 )<br>Functions    : 50.74% ( 1238/2440 )<br>Lines        : 58.39% ( 6722/11512 )  
- [x] Automated regression test(s) pass

If JIRA tests were used to supplement or replace automated tests:
- ~[ ] JIRA test links:~
- ~[ ] Justification for using JIRA tests:~
- ~[ ] JIRA tests have been added to sprint~


**Reviewer 1:**

Name: @daco101 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

If JIRA tests were used to supplement or replace automated tests:
- [x] NA JIRA tests have been run and pass
- [x] NA You agree with the justification for use of JIRA tests or have provided input on why you disagree


**Reviewer 2:**

Name: @losborne 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

If JIRA tests were used to supplement or replace automated tests:
- [x] JIRA tests have been run and pass
- [x] You agree with the justification for use of JIRA tests or have provided input on why you disagree
