### PR TITLE
Add new patient fixtures

### DIFF
--- a/lib/tasks/cql_testing.rake
+++ b/lib/tasks/cql_testing.rake
@@ -127,7 +127,7 @@ namespace :bonnie do
 
     desc %{Export patient fixtures for a given account. Uses vsac credentials from environmental vars.
       Exports into test/fixtures/patients/<CMS_ID> and spec/javascripts/fixtures/json/patients/<CMS_ID>
-      example: bundle exec rake bonnie:fixtures:export_fixtures_from_packages[bonnie-fixtures@mitre.org]}
+      example: bundle exec rake bonnie:fixtures:generate_cqm_patient_fixtures_from_cql_patients[bonnie-fixtures@mitre.org]}
     task :generate_cqm_patient_fixtures_from_cql_patients, [:email] => [:environment] do |task, args|
       email = args[:email]
       user = User.find_by email: args[:email]

--- a/lib/tasks/cql_testing.rake
+++ b/lib/tasks/cql_testing.rake
@@ -157,20 +157,6 @@ namespace :bonnie do
       end
     end
 
-    def get_cql_measure(user, cms_hqmf, measure_id)
-      if (cms_hqmf.downcase  != 'cms' && cms_hqmf.downcase != 'hqmf')
-        throw('Argument: "' + cms_hqmf + '" does not match expected: cms or hqmf')
-      end
-      CqlMeasure.by_user(user).each do |measure|
-        if (cms_hqmf.downcase  == 'cms' && measure.cms_id.downcase == measure_id.downcase)
-          return measure
-        elsif (cms_hqmf.downcase == 'hqmf' && measure.hqmf_set_id.downcase == measure_id.downcase)
-          return measure
-        end
-      end
-      throw('Argument: "' + cms_hqmf + ': ' + measure_id +'" does not match any measure id associated with user: "'+user.email+'"')
-    end
-
     def get_cqm_measure(user, cms_hqmf, measure_id)
       if (cms_hqmf.downcase  != 'cms' && cms_hqmf.downcase != 'hqmf')
         throw('Argument: "' + cms_hqmf + '" does not match expected: cms or hqmf')

--- a/lib/tasks/cql_testing.rake
+++ b/lib/tasks/cql_testing.rake
@@ -22,7 +22,7 @@ namespace :bonnie do
       record_file_path = File.join(fixtures_path, 'records', args[:path])
 
       user = User.find_by email: args[:user_email]
-      measure = get_cql_measure(user, args[:cms_hqmf], args[:measure_id])
+      measure = get_cqm_measure(user, args[:cms_hqmf], args[:measure_id])
       records = Record.by_user_and_hqmf_set_id(user, measure.hqmf_set_id)
       if (args[:patient_first_name].present? && args[:patient_last_name].present?)
         records = records.select { |r| r.first == args[:patient_first_name] && r.last == args[:patient_last_name] }
@@ -54,7 +54,7 @@ namespace :bonnie do
       value_sets_path = File.join(fixtures_path, 'health_data_standards_svs_value_sets', args[:path])
 
       user = User.find_by email: args[:user_email]
-      measure = get_cql_measure(user, args[:cms_hqmf], args[:measure_id])
+      measure = get_cqm_measure(user, args[:cms_hqmf], args[:measure_id])
       records = Record.by_user_and_hqmf_set_id(user, measure.hqmf_set_id)
 
       fixture_exporter = BackendFixtureExporter.new(user, measure: measure, records: records)
@@ -126,6 +126,20 @@ namespace :bonnie do
     end
 
     def get_cql_measure(user, cms_hqmf, measure_id)
+      if (cms_hqmf.downcase  != 'cms' && cms_hqmf.downcase != 'hqmf')
+        throw('Argument: "' + cms_hqmf + '" does not match expected: cms or hqmf')
+      end
+      CqlMeasure.by_user(user).each do |measure|
+        if (cms_hqmf.downcase  == 'cms' && measure.cms_id.downcase == measure_id.downcase)
+          return measure
+        elsif (cms_hqmf.downcase == 'hqmf' && measure.hqmf_set_id.downcase == measure_id.downcase)
+          return measure
+        end
+      end
+      throw('Argument: "' + cms_hqmf + ': ' + measure_id +'" does not match any measure id associated with user: "'+user.email+'"')
+    end
+
+    def get_cqm_measure(user, cms_hqmf, measure_id)
       if (cms_hqmf.downcase  != 'cms' && cms_hqmf.downcase != 'hqmf')
         throw('Argument: "' + cms_hqmf + '" does not match expected: cms or hqmf')
       end

--- a/lib/tasks/cql_testing.rake
+++ b/lib/tasks/cql_testing.rake
@@ -125,6 +125,38 @@ namespace :bonnie do
       fixture_exporter.try_export_measure_package(File.join(fixture_path,'cqm_measure_packages'))
     end
 
+    desc %{Export patient fixtures for a given account. Uses vsac credentials from environmental vars.
+      Exports into test/fixtures/patients/<CMS_ID>
+      example: bundle exec rake bonnie:fixtures:export_fixtures_from_packages[bonnie-fixtures@mitre.org]}
+    task :generate_cqm_patient_fixtures_from_cql_patients, [:email] => [:environment] do |task, args|
+      email = args[:email]
+      user = User.find_by email: args[:email]
+      cms_ids = {}
+      failed_exports = []
+      CqlMeasure.by_user(user).each do |measure|
+        Record.where(measure_ids: measure.hqmf_set_id, user_id: BSON::ObjectId.from_string(user.id)).each do |record|
+          begin
+            patient = CQMConverter.to_cqm(record)
+            patient._id = record._id if record._id
+
+            backend_fixture_exporter = BackendFixtureExporter.new(user, measure: measure, records: [patient])
+            backend_fixture_path = File.join('test', 'fixtures', 'patients', measure.cms_id)
+            backend_fixture_exporter.export_records_as_individual_files(backend_fixture_path)
+
+            frontend_fixture_exporter = FrontendFixtureExporter.new(user, measure: measure, records: [patient])
+            frontend_fixture_path = File.join('spec', 'javascripts', 'fixtures', 'json', 'patients', measure.cms_id)
+            frontend_fixture_exporter.export_records_as_individual_files(frontend_fixture_path)
+          rescue StandardError => e
+            failed_exports << "measure.hqmf_set_id: #{measure.hqmf_set_id}\n\trecord._id: #{record._id}\n\terror: #{e}"
+          end
+        end
+      end
+      unless failed_exports.empty?
+        puts "Failed to export the following patients:"
+        failed_exports.each {|failed_export| puts failed_export }
+      end
+    end
+
     def get_cql_measure(user, cms_hqmf, measure_id)
       if (cms_hqmf.downcase  != 'cms' && cms_hqmf.downcase != 'hqmf')
         throw('Argument: "' + cms_hqmf + '" does not match expected: cms or hqmf')

--- a/lib/tasks/cql_testing.rake
+++ b/lib/tasks/cql_testing.rake
@@ -126,7 +126,7 @@ namespace :bonnie do
     end
 
     desc %{Export patient fixtures for a given account. Uses vsac credentials from environmental vars.
-      Exports into test/fixtures/patients/<CMS_ID>
+      Exports into test/fixtures/patients/<CMS_ID> and spec/javascripts/fixtures/json/patients/<CMS_ID>
       example: bundle exec rake bonnie:fixtures:export_fixtures_from_packages[bonnie-fixtures@mitre.org]}
     task :generate_cqm_patient_fixtures_from_cql_patients, [:email] => [:environment] do |task, args|
       email = args[:email]

--- a/lib/util/fixture_exporter.rb
+++ b/lib/util/fixture_exporter.rb
@@ -29,7 +29,12 @@ class FixtureExporter
   def export_records_as_individual_files(path)
     @records.each do |r|
       record = as_transformed_hash(r)
-      record_file = File.join(path, "#{r.first}_#{r.last}.json")
+      record_file = if !record['givenNames'].nil?
+                      File.join(path, "#{r['givenNames'][0]}_#{r['familyName']}.json")
+                    else
+                      File.join(path, "#{r.first}_#{r.last}.json")
+                    end
+
       create_fixture_file(record_file, JSON.pretty_generate(record))
       puts 'exported a patient record to ' + record_file
     end

--- a/spec/javascripts/fixtures/json/patients/CMS108v7/108v7 Elements_108v7 Test.json
+++ b/spec/javascripts/fixtures/json/patients/CMS108v7/108v7 Elements_108v7 Test.json
@@ -1,0 +1,988 @@
+{
+  "_id": "5b6b2821b848461165a3e886",
+  "bundleId": "5a57e977942c6d1e61d32f14",
+  "expectedValues": [
+    {
+      "measure_id": "38B0B5EC-0F63-466F-8FE3-2CD20DDD1622",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    }
+  ],
+  "familyName": "108v7 Test",
+  "givenNames": [
+    "108v7 Elements"
+  ],
+  "notes": "",
+  "qdmPatient": {
+    "_id": "5c880144d7c8ac4c3e106797",
+    "birthDatetime": "1970-01-01T08:00:00.000+00:00",
+    "dataElements": [
+      {
+        "_id": "5c880144d7c8ac4c3e106798",
+        "authorDatetime": "2012-08-01T08:00:00.000+00:00",
+        "components": [
+          {
+            "result": {
+              "code": "0SP909Z",
+              "codeSystem": "ICD-10-PCS",
+              "version": null,
+              "descriptor": null
+            },
+            "code": {
+              "code": "112943005",
+              "codeSystem": "SNOMED-CT",
+              "version": null,
+              "descriptor": "Hip Replacement Surgery"
+            }
+          },
+          {
+            "result": {
+              "unit": "mg",
+              "value": 34
+            },
+            "code": {
+              "code": "1037045",
+              "codeSystem": "RxNorm",
+              "version": null,
+              "descriptor": null
+            }
+          },
+          {
+            "result": "44342-10-06T08:00:00+00:00",
+            "code": {
+              "code": "1736470",
+              "codeSystem": "RxNorm",
+              "version": null,
+              "descriptor": null
+            }
+          }
+        ],
+        "dataElementCodes": [
+          {
+            "codeSystem": "LOINC",
+            "code": "72136-5"
+          }
+        ],
+        "description": "Assessment, Performed: Risk for venous thromboembolism",
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.117",
+        "id": {
+          "_id": "5c880144d7c8ac4c3e106799",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5b6c247cb848464add0870f6"
+        },
+        "method": {
+          "code": "008Q0ZZ",
+          "codeSystem": "ICD-10-PCS",
+          "descriptor": "General Surgery",
+          "codeSystemOid": null,
+          "version": null
+        },
+        "negationRationale": null,
+        "qdmCategory": "assessment",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "reason": {
+          "code": "133918004",
+          "codeSystem": "SNOMED-CT",
+          "descriptor": "Comfort Measures",
+          "codeSystemOid": null,
+          "version": null
+        },
+        "relatedTo": [
+          {
+            "_id": "5c880144d7c8ac4c3e10679a",
+            "namingSystem": null,
+            "qdmVersion": "5.4",
+            "value": "5b6c247cb848464add0870ee"
+          }
+        ],
+        "result": "44422-02-28T08:00:00.000+00:00",
+        "_type": "QDM::AssessmentPerformed"
+      },
+      {
+        "_id": "5c880144d7c8ac4c3e10679b",
+        "anatomicalLocationSite": null,
+        "authorDatetime": "2012-08-01T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "442023007"
+          }
+        ],
+        "description": "Device, Applied: Venous foot pumps (VFP)",
+        "hqmfOid": "2.16.840.1.113883.3.560.1.10",
+        "id": {
+          "_id": "5c880144d7c8ac4c3e10679c",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5b6c247cb848464add0870ee"
+        },
+        "negationRationale": null,
+        "qdmCategory": "device",
+        "qdmStatus": "applied",
+        "qdmVersion": "5.4",
+        "reason": {
+          "code": "195155004",
+          "codeSystem": "SNOMED-CT",
+          "descriptor": "Hemorrhagic Stroke",
+          "codeSystemOid": null,
+          "version": null
+        },
+        "relevantPeriod": {
+          "low": "2012-08-01T08:00:00.000+00:00",
+          "high": "9999-12-31T23:59:59.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "_type": "QDM::DeviceApplied"
+      },
+      {
+        "_id": "5c880144d7c8ac4c3e10679d",
+        "anatomicalLocationSite": null,
+        "authorDatetime": "2012-08-01T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "428411000124104"
+          }
+        ],
+        "description": "Device, Applied: Intermittent pneumatic compression devices (IPC)",
+        "hqmfOid": "2.16.840.1.113883.3.560.1.110",
+        "id": {
+          "_id": "5c880144d7c8ac4c3e10679e",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5b6c247cb848464add0870ef"
+        },
+        "negationRationale": {
+          "code": "1037045",
+          "codeSystem": "RxNorm",
+          "descriptor": null,
+          "codeSystemOid": null,
+          "version": null
+        },
+        "qdmCategory": "device",
+        "qdmStatus": "applied",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "relevantPeriod": {
+          "low": "2012-08-01T08:00:00.000+00:00",
+          "high": "9999-12-31T23:59:59.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "_type": "QDM::DeviceApplied"
+      },
+      {
+        "_id": "5c880144d7c8ac4c3e10679f",
+        "authorDatetime": "2012-08-01T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "442023007"
+          }
+        ],
+        "description": "Device, Ordered: Venous foot pumps (VFP)",
+        "hqmfOid": "2.16.840.1.113883.3.560.1.37",
+        "id": {
+          "_id": "5c880144d7c8ac4c3e1067a0",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5b6c247cb848464add0870f0"
+        },
+        "negationRationale": null,
+        "qdmCategory": "device",
+        "qdmStatus": "order",
+        "qdmVersion": "5.4",
+        "reason": {
+          "code": "0SP909Z",
+          "codeSystem": "ICD-10-PCS",
+          "descriptor": "Hip Replacement Surgery",
+          "codeSystemOid": null,
+          "version": null
+        },
+        "_type": "QDM::DeviceOrder"
+      },
+      {
+        "_id": "5c880144d7c8ac4c3e1067a1",
+        "authorDatetime": "2012-08-01T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "348681001"
+          }
+        ],
+        "description": "Device, Ordered: Graduated compression stockings (GCS)",
+        "hqmfOid": "2.16.840.1.113883.3.560.1.137",
+        "id": {
+          "_id": "5c880144d7c8ac4c3e1067a2",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5b6c247cb848464add0870f1"
+        },
+        "negationRationale": {
+          "code": "195155004",
+          "codeSystem": "SNOMED-CT",
+          "descriptor": null,
+          "codeSystemOid": null,
+          "version": null
+        },
+        "qdmCategory": "device",
+        "qdmStatus": "order",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "_type": "QDM::DeviceOrder"
+      },
+      {
+        "_id": "5c880144d7c8ac4c3e1067a3",
+        "authorDatetime": "2012-08-01T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "RxNorm",
+            "code": "1037045"
+          }
+        ],
+        "description": "Medication, Administered: Direct Thrombin Inhibitor",
+        "dosage": {
+          "value": 5,
+          "unit": "mg"
+        },
+        "frequency": {
+          "code": null,
+          "codeSystem": null,
+          "descriptor": null,
+          "codeSystemOid": null,
+          "version": null
+        },
+        "hqmfOid": "2.16.840.1.113883.3.560.1.14",
+        "id": {
+          "_id": "5c880144d7c8ac4c3e1067a4",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5b6c247cb848464add0870f2"
+        },
+        "negationRationale": null,
+        "qdmCategory": "medication",
+        "qdmStatus": "administered",
+        "qdmVersion": "5.4",
+        "reason": {
+          "code": "4525004",
+          "codeSystem": "SNOMED-CT",
+          "descriptor": "Emergency Department Visit",
+          "codeSystemOid": null,
+          "version": null
+        },
+        "relevantPeriod": {
+          "low": "2012-08-01T08:00:00.000+00:00",
+          "high": "9999-12-31T23:59:59.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "route": {
+          "code": "418114005",
+          "codeSystem": "SNOMED-CT",
+          "descriptor": "Intravenous route",
+          "codeSystemOid": null,
+          "version": null
+        },
+        "_type": "QDM::MedicationAdministered"
+      },
+      {
+        "_id": "5c880144d7c8ac4c3e1067a5",
+        "authorDatetime": "2012-08-01T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "RxNorm",
+            "code": "1361226"
+          }
+        ],
+        "description": "Medication, Administered: Low Dose Unfractionated Heparin for VTE Prophylaxis",
+        "dosage": null,
+        "frequency": null,
+        "hqmfOid": "2.16.840.1.113883.3.560.1.114",
+        "id": {
+          "_id": "5c880144d7c8ac4c3e1067a6",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5b6c247cb848464add0870f3"
+        },
+        "negationRationale": {
+          "code": "861356",
+          "codeSystem": "RxNorm",
+          "descriptor": null,
+          "codeSystemOid": null,
+          "version": null
+        },
+        "qdmCategory": "medication",
+        "qdmStatus": "administered",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "relevantPeriod": {
+          "low": "2012-08-01T08:00:00.000+00:00",
+          "high": "9999-12-31T23:59:59.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "route": null,
+        "_type": "QDM::MedicationAdministered"
+      },
+      {
+        "_id": "5c880144d7c8ac4c3e1067a7",
+        "authorDatetime": "2012-08-01T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "RxNorm",
+            "code": "1361226"
+          }
+        ],
+        "daysSupplied": null,
+        "description": "Medication, Ordered: Low Dose Unfractionated Heparin for VTE Prophylaxis",
+        "dosage": null,
+        "frequency": null,
+        "hqmfOid": "2.16.840.1.113883.3.560.1.78",
+        "id": {
+          "_id": "5c880144d7c8ac4c3e1067a8",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5b6c247cb848464add0870f4"
+        },
+        "negationRationale": {
+          "code": "101421000119107",
+          "codeSystem": "SNOMED-CT",
+          "descriptor": null,
+          "codeSystemOid": null,
+          "version": null
+        },
+        "prescriberId": null,
+        "qdmCategory": "medication",
+        "qdmStatus": "order",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "refills": null,
+        "relevantPeriod": {
+          "low": "2012-08-01T08:00:00.000+00:00",
+          "high": "9999-12-31T23:59:59.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "route": null,
+        "setting": null,
+        "supply": null,
+        "_type": "QDM::MedicationOrder"
+      },
+      {
+        "_id": "5c880144d7c8ac4c3e1067a9",
+        "authorDatetime": "2012-08-01T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "RxNorm",
+            "code": "855288"
+          }
+        ],
+        "daysSupplied": null,
+        "description": "Medication, Ordered: Warfarin",
+        "dosage": {
+          "value": 5,
+          "unit": "mg"
+        },
+        "frequency": {
+          "code": null,
+          "codeSystem": null,
+          "descriptor": null,
+          "codeSystemOid": null,
+          "version": null
+        },
+        "hqmfOid": "2.16.840.1.113883.3.560.1.17",
+        "id": {
+          "_id": "5c880144d7c8ac4c3e1067aa",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5b6c247cb848464add0870f5"
+        },
+        "negationRationale": null,
+        "prescriberId": null,
+        "qdmCategory": "medication",
+        "qdmStatus": "order",
+        "qdmVersion": "5.4",
+        "reason": {
+          "code": "195080001",
+          "codeSystem": "SNOMED-CT",
+          "descriptor": "Atrial Fibrillation/Flutter",
+          "codeSystemOid": null,
+          "version": null
+        },
+        "refills": 9,
+        "relevantPeriod": {
+          "low": "2012-08-01T08:00:00.000+00:00",
+          "high": "9999-12-31T23:59:59.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "route": {
+          "code": "34206005",
+          "codeSystem": "SNOMED-CT",
+          "descriptor": "Subcutaneous route",
+          "codeSystemOid": null,
+          "version": null
+        },
+        "setting": null,
+        "supply": {
+          "value": 100,
+          "unit": "mg"
+        },
+        "_type": "QDM::MedicationOrder"
+      },
+      {
+        "_id": "5c880144d7c8ac4c3e106792",
+        "birthDatetime": "1970-01-01T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "code": "21112-8",
+            "codeSystem": "LOINC",
+            "descriptor": null,
+            "codeSystemOid": null,
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.54",
+        "id": {
+          "_id": "5c880144d7c8ac4c3e1067ab",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880144d7c8ac4c3e106792"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "birthdate",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicBirthdate"
+      },
+      {
+        "_id": "5c880144d7c8ac4c3e106793",
+        "dataElementCodes": [
+          {
+            "code": "2186-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "Not Hispanic or Latino",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.56",
+        "id": {
+          "_id": "5c880144d7c8ac4c3e1067ac",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880144d7c8ac4c3e106793"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "ethnicity",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicEthnicity"
+      },
+      {
+        "_id": "5c880144d7c8ac4c3e106794",
+        "dataElementCodes": [
+          {
+            "code": "1002-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "American Indian or Alaska Native",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.59",
+        "id": {
+          "_id": "5c880144d7c8ac4c3e1067ad",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880144d7c8ac4c3e106794"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "race",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicRace"
+      },
+      {
+        "_id": "5c880144d7c8ac4c3e106795",
+        "dataElementCodes": [
+          {
+            "code": "M",
+            "codeSystem": "AdministrativeGender",
+            "descriptor": "M",
+            "codeSystemOid": "2.16.840.1.113883.5.1",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.55",
+        "id": {
+          "_id": "5c880144d7c8ac4c3e1067ae",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880144d7c8ac4c3e106795"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "gender",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicSex"
+      }
+    ],
+    "extendedData": {
+      "type": null,
+      "measure_ids": [
+        "38B0B5EC-0F63-466F-8FE3-2CD20DDD1622",
+        null
+      ],
+      "source_data_criteria": [
+        {
+          "negation": false,
+          "definition": "assessment",
+          "status": "performed",
+          "title": "Assessment, Performed: Assessment, Performed",
+          "description": "Assessment, Performed: Risk for venous thromboembolism",
+          "code_list_id": "drc-522a38859e8337cb6214742610b449c149172dccc97f176b0b580b4d3f975004",
+          "type": "assessments",
+          "id": "prefix_72136_5_AssessmentPerformed_B7EF188A_B153_422B_8D67_C74436EAB826_source",
+          "start_date": 1343808000000,
+          "value": [
+            {
+              "type": "TS",
+              "type_cmp": "CD",
+              "start_date": "06/14/2012",
+              "start_time": "8:00 AM",
+              "value": 1339660800000
+            }
+          ],
+          "references": [
+            {
+              "reference_type": "Related To",
+              "reference_id": "1651a9359d3RB",
+              "type": "CD",
+              "description": "Device, Applied: Venous foot pumps (VFP)",
+              "start_date": "08/01/2012"
+            }
+          ],
+          "field_values": {
+            "REASON": {
+              "type": "CD",
+              "code_list_id": "1.3.6.1.4.1.33895.1.3.0.45",
+              "field_title": "Reason",
+              "title": "Comfort Measures"
+            },
+            "METHOD": {
+              "type": "CD",
+              "code_list_id": "2.16.840.1.113883.3.117.1.7.1.255",
+              "field_title": "Method",
+              "title": "General Surgery"
+            },
+            "COMPONENT": {
+              "type": "COL",
+              "values": [
+                {
+                  "type": "CMP",
+                  "key": "COMPONENT",
+                  "code_list_id": "2.16.840.1.113883.3.666.5.1743",
+                  "title_cmp": "Hip Replacement Surgery",
+                  "field_title": "Component",
+                  "type_cmp": "CD",
+                  "code_list_id_cmp": "2.16.840.1.113883.3.117.1.7.1.259",
+                  "title": "General or Neuraxial Anesthesia"
+                },
+                {
+                  "type": "CMP",
+                  "key": "COMPONENT",
+                  "code_list_id": "2.16.840.1.113883.3.117.1.7.1.205",
+                  "field_title": "Component",
+                  "type_cmp": "PQ",
+                  "code_list_id_cmp": "",
+                  "title": "Direct Thrombin Inhibitor",
+                  "value": "34",
+                  "unit": "mg"
+                },
+                {
+                  "type": "CMP",
+                  "key": "COMPONENT",
+                  "code_list_id": "2.16.840.1.113762.1.4.1045.41",
+                  "field_title": "Component",
+                  "type_cmp": "TS",
+                  "code_list_id_cmp": "",
+                  "title": "Glycoprotein IIb/IIIa Inhibitors",
+                  "start_date": "05/16/2012",
+                  "start_time": "8:00 AM",
+                  "value": 1337155200000
+                }
+              ],
+              "field_title": "Component"
+            }
+          },
+          "hqmf_set_id": "38B0B5EC-0F63-466F-8FE3-2CD20DDD1622",
+          "cms_id": "CMS108v7",
+          "criteria_id": "1651a91e4800A",
+          "codes": {
+            "LOINC": [
+              "72136-5"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5b6c247cb848464add0870f6"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "device",
+          "status": "applied",
+          "title": "Venousfootpumps(VFP)",
+          "description": "Device, Applied: Venous foot pumps (VFP)",
+          "code_list_id": "2.16.840.1.113883.3.117.1.7.1.230",
+          "type": "devices",
+          "id": "Venousfootpumps_VFP__DeviceApplied_40280381_3d27_5493_013d_4be146945c82_source",
+          "start_date": 1343808000000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+            "REASON": {
+              "type": "CD",
+              "code_list_id": "2.16.840.1.113883.3.117.1.7.1.212",
+              "field_title": "Reason",
+              "title": "Hemorrhagic Stroke"
+            }
+          },
+          "hqmf_set_id": "38B0B5EC-0F63-466F-8FE3-2CD20DDD1622",
+          "cms_id": "CMS108v7",
+          "criteria_id": "1651a9359d3RB",
+          "codes": {
+            "SNOMED-CT": [
+              "442023007"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5b6c247cb848464add0870ee"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": true,
+          "definition": "device",
+          "status": "applied",
+          "title": "Intermittentpneumaticcompressiondevices(IPC)",
+          "description": "Device, Applied: Intermittent pneumatic compression devices (IPC)",
+          "code_list_id": "2.16.840.1.113883.3.117.1.7.1.214",
+          "type": "devices",
+          "id": "Intermittentpneumaticcompressiondevices_IPC__DeviceApplied_40280381_3d27_5493_013d_4be146945c83_source",
+          "start_date": 1343808000000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "38B0B5EC-0F63-466F-8FE3-2CD20DDD1622",
+          "cms_id": "CMS108v7",
+          "criteria_id": "1651a948034mw",
+          "codes": {
+            "SNOMED-CT": [
+              "428411000124104"
+            ]
+          },
+          "negation_code_list_id": "2.16.840.1.113883.3.117.1.7.1.205",
+          "coded_entry_id": {
+            "$oid": "5b6c247cb848464add0870ef"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "medication",
+          "status": "administered",
+          "title": "DirectThrombinInhibitor",
+          "description": "Medication, Administered: Direct Thrombin Inhibitor",
+          "code_list_id": "2.16.840.1.113883.3.117.1.7.1.205",
+          "type": "medications",
+          "id": "DirectThrombinInhibitor_MedicationAdministered_40280381_3d27_5493_013d_4be146955c93_source",
+          "start_date": 1343808000000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+            "DOSE": {
+              "type": "PQ",
+              "code_list_id": "",
+              "field_title": "Dosage",
+              "value": "5",
+              "unit": "mg"
+            },
+            "FREQUENCY": {
+              "type": "PQ",
+              "code_list_id": "",
+              "field_title": "Frequency",
+              "value": "3",
+              "unit": "days"
+            },
+            "SUPPLY": {
+              "type": "PQ",
+              "code_list_id": "",
+              "field_title": "Supply",
+              "value": "100",
+              "unit": "mg"
+            },
+            "REASON": {
+              "type": "CD",
+              "code_list_id": "2.16.840.1.113883.3.117.1.7.1.292",
+              "field_title": "Reason",
+              "title": "Emergency Department Visit"
+            },
+            "ROUTE": {
+              "type": "CD",
+              "code_list_id": "2.16.840.1.113883.3.117.1.7.1.222",
+              "field_title": "Route",
+              "title": "Intravenous route"
+            }
+          },
+          "hqmf_set_id": "38B0B5EC-0F63-466F-8FE3-2CD20DDD1622",
+          "cms_id": "CMS108v7",
+          "criteria_id": "1651a97e18a0J",
+          "codes": {
+            "RxNorm": [
+              "1037045"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5b6c247cb848464add0870f2"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": true,
+          "definition": "medication",
+          "status": "administered",
+          "title": "LowDoseUnfractionatedHeparinforVTEProphylaxis",
+          "description": "Medication, Administered: Low Dose Unfractionated Heparin for VTE Prophylaxis",
+          "code_list_id": "2.16.840.1.113762.1.4.1045.39",
+          "type": "medications",
+          "id": "LowDoseUnfractionatedHeparinforVTEProphylaxis_MedicationAdministered_389f98c4_53d0_4562_bfae_02b74a2f8c26_source",
+          "start_date": 1343808000000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "38B0B5EC-0F63-466F-8FE3-2CD20DDD1622",
+          "cms_id": "CMS108v7",
+          "criteria_id": "1651a98e395QR",
+          "codes": {
+            "RxNorm": [
+              "1361226"
+            ]
+          },
+          "negation_code_list_id": "2.16.840.1.113883.3.117.1.7.1.211",
+          "coded_entry_id": {
+            "$oid": "5b6c247cb848464add0870f3"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": true,
+          "definition": "medication",
+          "status": "ordered",
+          "title": "LowDoseUnfractionatedHeparinforVTEProphylaxis",
+          "description": "Medication, Ordered: Low Dose Unfractionated Heparin for VTE Prophylaxis",
+          "code_list_id": "2.16.840.1.113762.1.4.1045.39",
+          "type": "medications",
+          "id": "Derived from LowDoseUnfractionatedHeparinforVTEProphylaxis_MedicationNotOrdered_389f98c4_53d0_4562_bfae_02b74a2f8c26_source",
+          "start_date": 1343808000000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "38B0B5EC-0F63-466F-8FE3-2CD20DDD1622",
+          "cms_id": "CMS108v7",
+          "criteria_id": "1651e6b65b5hH",
+          "codes": {
+            "RxNorm": [
+              "1361226"
+            ]
+          },
+          "negation_code_list_id": "2.16.840.1.113883.3.464.1003.105.12.1004",
+          "coded_entry_id": {
+            "$oid": "5b6c247cb848464add0870f4"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "device",
+          "status": "ordered",
+          "title": "Venousfootpumps(VFP)",
+          "description": "Device, Ordered: Venous foot pumps (VFP)",
+          "code_list_id": "2.16.840.1.113883.3.117.1.7.1.230",
+          "type": "devices",
+          "id": "Derived from Venousfootpumps_VFP__DeviceNotOrdered_40280381_3d27_5493_013d_4be146945c82_source",
+          "start_date": 1343808000000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+            "REASON": {
+              "type": "CD",
+              "code_list_id": "2.16.840.1.113883.3.117.1.7.1.259",
+              "field_title": "Reason",
+              "title": "Hip Replacement Surgery"
+            }
+          },
+          "hqmf_set_id": "38B0B5EC-0F63-466F-8FE3-2CD20DDD1622",
+          "cms_id": "CMS108v7",
+          "criteria_id": "1651e6bf4ddcQ",
+          "codes": {
+            "SNOMED-CT": [
+              "442023007"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5b6c247cb848464add0870f0"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": true,
+          "definition": "device",
+          "status": "ordered",
+          "title": "Graduatedcompressionstockings(GCS)",
+          "description": "Device, Ordered: Graduated compression stockings (GCS)",
+          "code_list_id": "2.16.840.1.113883.3.117.1.7.1.256",
+          "type": "devices",
+          "id": "Derived from Graduatedcompressionstockings_GCS__DeviceNotOrdered_40280381_3d27_5493_013d_4be146945c81_source",
+          "start_date": 1343808000000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "38B0B5EC-0F63-466F-8FE3-2CD20DDD1622",
+          "cms_id": "CMS108v7",
+          "criteria_id": "1651e6c69caJj",
+          "codes": {
+            "SNOMED-CT": [
+              "348681001"
+            ]
+          },
+          "negation_code_list_id": "2.16.840.1.113883.3.117.1.7.1.212",
+          "coded_entry_id": {
+            "$oid": "5b6c247cb848464add0870f1"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "medication",
+          "status": "ordered",
+          "title": "Warfarin",
+          "description": "Medication, Ordered: Warfarin",
+          "code_list_id": "2.16.840.1.113883.3.117.1.7.1.232",
+          "type": "medications",
+          "id": "Derived from Warfarin_MedicationNotOrdered_40280381_3d27_5493_013d_4be146955c95_source",
+          "start_date": 1343808000000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+            "DOSE": {
+              "type": "PQ",
+              "code_list_id": "",
+              "field_title": "Dosage",
+              "value": "5",
+              "unit": "mg"
+            },
+            "SUPPLY": {
+              "type": "PQ",
+              "code_list_id": "",
+              "field_title": "Supply",
+              "value": "100",
+              "unit": "mg"
+            },
+            "FREQUENCY": {
+              "type": "PQ",
+              "code_list_id": "",
+              "field_title": "Frequency",
+              "value": "1",
+              "unit": "day"
+            },
+            "REASON": {
+              "type": "CD",
+              "code_list_id": "2.16.840.1.113883.3.117.1.7.1.202",
+              "field_title": "Reason",
+              "title": "Atrial Fibrillation/Flutter"
+            },
+            "REFILLS": {
+              "type": "PQ",
+              "code_list_id": "",
+              "field_title": "Refills",
+              "value": "9",
+              "unit": ""
+            },
+            "ROUTE": {
+              "type": "CD",
+              "code_list_id": "2.16.840.1.113883.3.117.1.7.1.223",
+              "field_title": "Route",
+              "title": "Subcutaneous route"
+            }
+          },
+          "hqmf_set_id": "38B0B5EC-0F63-466F-8FE3-2CD20DDD1622",
+          "cms_id": "CMS108v7",
+          "criteria_id": "1651e6cc909wk",
+          "codes": {
+            "RxNorm": [
+              "855288"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5b6c247cb848464add0870f5"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "id": "MeasurePeriod",
+          "start_date": 0,
+          "end_date": 0,
+          "references": null
+        }
+      ],
+      "is_shared": null,
+      "origin_data": [
+
+      ],
+      "test_id": null,
+      "medical_record_number": "6f951a8be6a7afd11c1ef6d6b44a59eac8a9d0a0ab98c519c6edf957334df8a7",
+      "medical_record_assigner": "Bonnie",
+      "description": null,
+      "description_category": null,
+      "insurance_providers": "[{\"codes\":{\"SOP\":[\"349\"]},\"description\":null,\"end_time\":null,\"financial_responsibility_type\":{\"code\":\"SELF\",\"codeSystem\":\"HL7 Relationship Code\"},\"health_record_field\":null,\"member_id\":\"1234567890\",\"mood_code\":\"EVN\",\"name\":\"Other\",\"negationInd\":null,\"negationReason\":null,\"oid\":null,\"payer\":{\"name\":\"Other\"},\"reason\":null,\"relationship\":null,\"specifics\":null,\"start_time\":1199145600,\"status_code\":null,\"time\":null,\"type\":\"OT\"}]"
+    },
+    "qdmVersion": "5.4"
+  }
+}

--- a/spec/javascripts/fixtures/json/patients/CMS10v0/Test_DenexcepPass.json
+++ b/spec/javascripts/fixtures/json/patients/CMS10v0/Test_DenexcepPass.json
@@ -1,0 +1,314 @@
+{
+  "_id": "5bfef1a9b848462b5596bd7b",
+  "bundleId": "5a57e977942c6d1e61d32f14",
+  "expectedValues": [
+    {
+      "measure_id": "442F4F7E-3C22-4641-9BEE-0E968CC38EF2",
+      "population_index": 0,
+      "IPP": 1,
+      "DENOM": 1,
+      "NUMER": 0,
+      "DENEXCEP": 1
+    }
+  ],
+  "familyName": "DenexcepPass",
+  "givenNames": [
+    "Test"
+  ],
+  "notes": "",
+  "qdmPatient": {
+    "_id": "5c880146d7c8ac4c3e1067d3",
+    "birthDatetime": "1990-02-01T08:00:00.000+00:00",
+    "dataElements": [
+      {
+        "_id": "5c880146d7c8ac4c3e1067d4",
+        "admissionSource": null,
+        "authorDatetime": "2012-07-18T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "10197000"
+          },
+          {
+            "codeSystem": "CPT",
+            "code": "59400"
+          },
+          {
+            "codeSystem": "HCPCS",
+            "code": "G0101"
+          }
+        ],
+        "description": "Encounter, Performed: Medications Encounter Code Set",
+        "diagnoses": [
+
+        ],
+        "dischargeDisposition": null,
+        "facilityLocations": [
+
+        ],
+        "hqmfOid": "2.16.840.1.113883.3.560.1.79",
+        "id": {
+          "_id": "5c880146d7c8ac4c3e1067d5",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5bfef1a9b848462b5596bd7d"
+        },
+        "lengthOfStay": {
+          "value": 0,
+          "unit": "days"
+        },
+        "negationRationale": null,
+        "principalDiagnosis": null,
+        "qdmCategory": "encounter",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "relevantPeriod": {
+          "low": "2012-07-18T08:00:00.000+00:00",
+          "high": "2012-07-18T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "_type": "QDM::EncounterPerformed"
+      },
+      {
+        "_id": "5c880146d7c8ac4c3e1067d6",
+        "anatomicalLocationSite": null,
+        "authorDatetime": "2012-07-18T08:00:00.000+00:00",
+        "components": [
+
+        ],
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "428191000124101"
+          }
+        ],
+        "description": "Procedure, Performed: Current Medications Documented SNMD",
+        "hqmfOid": "2.16.840.1.113883.3.560.1.106",
+        "id": {
+          "_id": "5c880146d7c8ac4c3e1067d7",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5bfef1a9b848462b5596bd7c"
+        },
+        "incisionDatetime": null,
+        "method": null,
+        "negationRationale": {
+          "code": "183932001",
+          "codeSystem": "SNOMED-CT",
+          "descriptor": null,
+          "codeSystemOid": null,
+          "version": null
+        },
+        "ordinality": null,
+        "qdmCategory": "procedure",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "relevantPeriod": {
+          "low": "2012-07-18T08:00:00.000+00:00",
+          "high": "9999-12-31T23:59:59.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "result": null,
+        "status": null,
+        "_type": "QDM::ProcedurePerformed"
+      },
+      {
+        "_id": "5c880146d7c8ac4c3e1067ce",
+        "birthDatetime": "1990-02-01T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "code": "21112-8",
+            "codeSystem": "LOINC",
+            "descriptor": null,
+            "codeSystemOid": null,
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.54",
+        "id": {
+          "_id": "5c880146d7c8ac4c3e1067d8",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880146d7c8ac4c3e1067ce"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "birthdate",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicBirthdate"
+      },
+      {
+        "_id": "5c880146d7c8ac4c3e1067cf",
+        "dataElementCodes": [
+          {
+            "code": "2186-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "Not Hispanic or Latino",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.56",
+        "id": {
+          "_id": "5c880146d7c8ac4c3e1067d9",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880146d7c8ac4c3e1067cf"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "ethnicity",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicEthnicity"
+      },
+      {
+        "_id": "5c880146d7c8ac4c3e1067d0",
+        "dataElementCodes": [
+          {
+            "code": "1002-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "American Indian or Alaska Native",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.59",
+        "id": {
+          "_id": "5c880146d7c8ac4c3e1067da",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880146d7c8ac4c3e1067d0"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "race",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicRace"
+      },
+      {
+        "_id": "5c880146d7c8ac4c3e1067d1",
+        "dataElementCodes": [
+          {
+            "code": "M",
+            "codeSystem": "AdministrativeGender",
+            "descriptor": "M",
+            "codeSystemOid": "2.16.840.1.113883.5.1",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.55",
+        "id": {
+          "_id": "5c880146d7c8ac4c3e1067db",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880146d7c8ac4c3e1067d1"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "gender",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicSex"
+      }
+    ],
+    "extendedData": {
+      "type": null,
+      "measure_ids": [
+        "442F4F7E-3C22-4641-9BEE-0E968CC38EF2",
+        null
+      ],
+      "source_data_criteria": [
+        {
+          "negation": true,
+          "definition": "procedure",
+          "status": "performed",
+          "title": "Current Medications Documented SNMD",
+          "description": "Procedure, Performed: Current Medications Documented SNMD",
+          "code_list_id": "2.16.840.1.113883.3.600.1.462",
+          "type": "procedures",
+          "id": "CurrentMedicationsDocumentedSNMD_ProcedurePerformed_4851d807_b8b9_4e52_a1ce_a7c97a762502_source",
+          "start_date": 1342598400000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "442F4F7E-3C22-4641-9BEE-0E968CC38EF2",
+          "cms_id": "CMS10v0",
+          "criteria_id": "1675bde99deSL",
+          "codes": {
+            "SNOMED-CT": [
+              "428191000124101"
+            ]
+          },
+          "negation_code_list_id": "2.16.840.1.113883.3.600.1.1502",
+          "coded_entry_id": {
+            "$oid": "5bfef1a9b848462b5596bd7c"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "encounter",
+          "status": "performed",
+          "title": "Medications Encounter Code Set",
+          "description": "Encounter, Performed: Medications Encounter Code Set",
+          "code_list_id": "2.16.840.1.113883.3.600.1.1834",
+          "type": "encounters",
+          "id": "MedicationsEncounterCodeSet_EncounterPerformed_0a3e8996_7fcb_4ff8_be65_0739cba27409_source",
+          "start_date": 1342598400000,
+          "end_date": 1342599300000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "442F4F7E-3C22-4641-9BEE-0E968CC38EF2",
+          "cms_id": "CMS10v0",
+          "criteria_id": "1675bdf6c56Ib",
+          "codes": {
+            "SNOMED-CT": [
+              "10197000"
+            ],
+            "CPT": [
+              "59400"
+            ],
+            "HCPCS": [
+              "G0101"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5bfef1a9b848462b5596bd7d"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "id": "MeasurePeriod",
+          "start_date": 0,
+          "end_date": 0,
+          "references": null
+        }
+      ],
+      "is_shared": null,
+      "origin_data": [
+
+      ],
+      "test_id": null,
+      "medical_record_number": "3993742715f1bee6c424d5ac453467cf51c872781d2c86da04189ac08d03414f",
+      "medical_record_assigner": "Bonnie",
+      "description": null,
+      "description_category": null,
+      "insurance_providers": "[{\"codes\":{\"SOP\":[\"349\"]},\"description\":null,\"end_time\":null,\"financial_responsibility_type\":{\"code\":\"SELF\",\"codeSystem\":\"HL7 Relationship Code\"},\"health_record_field\":null,\"member_id\":\"1234567890\",\"mood_code\":\"EVN\",\"name\":\"Other\",\"negationInd\":null,\"negationReason\":null,\"oid\":null,\"payer\":{\"name\":\"Other\"},\"reason\":null,\"relationship\":null,\"specifics\":null,\"start_time\":1199145600,\"status_code\":null,\"time\":null,\"type\":\"OT\"}]"
+    },
+    "qdmVersion": "5.4"
+  }
+}

--- a/spec/javascripts/fixtures/json/patients/CMS10v0/Test_IppPass.json
+++ b/spec/javascripts/fixtures/json/patients/CMS10v0/Test_IppPass.json
@@ -1,0 +1,239 @@
+{
+  "_id": "5bfef119b84846254735f78e",
+  "bundleId": "5a57e977942c6d1e61d32f14",
+  "expectedValues": [
+    {
+      "measure_id": "442F4F7E-3C22-4641-9BEE-0E968CC38EF2",
+      "population_index": 0,
+      "IPP": 1,
+      "DENOM": 1,
+      "NUMER": 0,
+      "DENEXCEP": 0
+    }
+  ],
+  "familyName": "IppPass",
+  "givenNames": [
+    "Test"
+  ],
+  "notes": "",
+  "qdmPatient": {
+    "_id": "5c880145d7c8ac4c3e1067c7",
+    "birthDatetime": "1990-03-02T08:00:00.000+00:00",
+    "dataElements": [
+      {
+        "_id": "5c880145d7c8ac4c3e1067c8",
+        "admissionSource": null,
+        "authorDatetime": "2012-07-12T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "10197000"
+          },
+          {
+            "codeSystem": "CPT",
+            "code": "59400"
+          },
+          {
+            "codeSystem": "HCPCS",
+            "code": "G0101"
+          }
+        ],
+        "description": "Encounter, Performed: Medications Encounter Code Set",
+        "diagnoses": [
+
+        ],
+        "dischargeDisposition": null,
+        "facilityLocations": [
+
+        ],
+        "hqmfOid": "2.16.840.1.113883.3.560.1.79",
+        "id": {
+          "_id": "5c880145d7c8ac4c3e1067c9",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5bfef119b84846254735f78f"
+        },
+        "lengthOfStay": {
+          "value": 0,
+          "unit": "days"
+        },
+        "negationRationale": null,
+        "principalDiagnosis": null,
+        "qdmCategory": "encounter",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "relevantPeriod": {
+          "low": "2012-07-12T08:00:00.000+00:00",
+          "high": "2012-07-12T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "_type": "QDM::EncounterPerformed"
+      },
+      {
+        "_id": "5c880145d7c8ac4c3e1067c2",
+        "birthDatetime": "1990-03-02T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "code": "21112-8",
+            "codeSystem": "LOINC",
+            "descriptor": null,
+            "codeSystemOid": null,
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.54",
+        "id": {
+          "_id": "5c880145d7c8ac4c3e1067ca",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880145d7c8ac4c3e1067c2"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "birthdate",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicBirthdate"
+      },
+      {
+        "_id": "5c880145d7c8ac4c3e1067c3",
+        "dataElementCodes": [
+          {
+            "code": "2186-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "Not Hispanic or Latino",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.56",
+        "id": {
+          "_id": "5c880145d7c8ac4c3e1067cb",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880145d7c8ac4c3e1067c3"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "ethnicity",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicEthnicity"
+      },
+      {
+        "_id": "5c880145d7c8ac4c3e1067c4",
+        "dataElementCodes": [
+          {
+            "code": "1002-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "American Indian or Alaska Native",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.59",
+        "id": {
+          "_id": "5c880145d7c8ac4c3e1067cc",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880145d7c8ac4c3e1067c4"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "race",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicRace"
+      },
+      {
+        "_id": "5c880145d7c8ac4c3e1067c5",
+        "dataElementCodes": [
+          {
+            "code": "M",
+            "codeSystem": "AdministrativeGender",
+            "descriptor": "M",
+            "codeSystemOid": "2.16.840.1.113883.5.1",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.55",
+        "id": {
+          "_id": "5c880145d7c8ac4c3e1067cd",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880145d7c8ac4c3e1067c5"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "gender",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicSex"
+      }
+    ],
+    "extendedData": {
+      "type": null,
+      "measure_ids": [
+        "442F4F7E-3C22-4641-9BEE-0E968CC38EF2",
+        null
+      ],
+      "source_data_criteria": [
+        {
+          "negation": false,
+          "definition": "encounter",
+          "status": "performed",
+          "title": "Medications Encounter Code Set",
+          "description": "Encounter, Performed: Medications Encounter Code Set",
+          "code_list_id": "2.16.840.1.113883.3.600.1.1834",
+          "type": "encounters",
+          "id": "MedicationsEncounterCodeSet_EncounterPerformed_0a3e8996_7fcb_4ff8_be65_0739cba27409_source",
+          "start_date": 1342080000000,
+          "end_date": 1342080900000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "442F4F7E-3C22-4641-9BEE-0E968CC38EF2",
+          "cms_id": "CMS10v0",
+          "criteria_id": "1675bdd0864DE",
+          "codes": {
+            "SNOMED-CT": [
+              "10197000"
+            ],
+            "CPT": [
+              "59400"
+            ],
+            "HCPCS": [
+              "G0101"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5bfef119b84846254735f78f"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "id": "MeasurePeriod",
+          "start_date": 0,
+          "end_date": 0,
+          "references": null
+        }
+      ],
+      "is_shared": null,
+      "origin_data": [
+
+      ],
+      "test_id": null,
+      "medical_record_number": "2e3ea4d102b19bfcf87b8874283c0958613ad23896bb7ccec1f24daedd53a3d6",
+      "medical_record_assigner": "Bonnie",
+      "description": null,
+      "description_category": null,
+      "insurance_providers": "[{\"codes\":{\"SOP\":[\"349\"]},\"description\":null,\"end_time\":null,\"financial_responsibility_type\":{\"code\":\"SELF\",\"codeSystem\":\"HL7 Relationship Code\"},\"health_record_field\":null,\"member_id\":\"1234567890\",\"mood_code\":\"EVN\",\"name\":\"Other\",\"negationInd\":null,\"negationReason\":null,\"oid\":null,\"payer\":{\"name\":\"Other\"},\"reason\":null,\"relationship\":null,\"specifics\":null,\"start_time\":1199145600,\"status_code\":null,\"time\":null,\"type\":\"OT\"}]"
+    },
+    "qdmVersion": "5.4"
+  }
+}

--- a/spec/javascripts/fixtures/json/patients/CMS123v7/Test_PatientCharacteristic.json
+++ b/spec/javascripts/fixtures/json/patients/CMS123v7/Test_PatientCharacteristic.json
@@ -1,0 +1,208 @@
+{
+  "_id": "5b588789b84846559a53f763",
+  "bundleId": "5a57e977942c6d1e61d32f14",
+  "expectedValues": [
+    {
+      "measure_id": "C0D72444-7C26-4863-9B51-8080F8928A85",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    }
+  ],
+  "familyName": "PatientCharacteristic",
+  "givenNames": [
+    "Test"
+  ],
+  "notes": "",
+  "qdmPatient": {
+    "_id": "5c880143d7c8ac4c3e106753",
+    "birthDatetime": "1970-01-01T08:00:00.000+00:00",
+    "dataElements": [
+      {
+        "_id": "5c880143d7c8ac4c3e106754",
+        "dataElementCodes": [
+          {
+            "codeSystem": "Source of Payment Typology",
+            "code": "1"
+          }
+        ],
+        "description": "Patient Characteristic Payer: Payer",
+        "hqmfOid": "2.16.840.1.113883.3.560.1.405",
+        "id": {
+          "_id": "5c880143d7c8ac4c3e106755",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5b588789b84846559a53f764"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "payer",
+        "qdmVersion": "5.4",
+        "relevantPeriod": {
+          "low": "2012-07-25T08:00:00.000+00:00",
+          "high": "2012-07-25T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "_type": "QDM::PatientCharacteristicPayer"
+      },
+      {
+        "_id": "5c880143d7c8ac4c3e10674e",
+        "birthDatetime": "1970-01-01T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "code": "21112-8",
+            "codeSystem": "LOINC",
+            "descriptor": null,
+            "codeSystemOid": null,
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.54",
+        "id": {
+          "_id": "5c880143d7c8ac4c3e106756",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880143d7c8ac4c3e10674e"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "birthdate",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicBirthdate"
+      },
+      {
+        "_id": "5c880143d7c8ac4c3e10674f",
+        "dataElementCodes": [
+          {
+            "code": "2186-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "Not Hispanic or Latino",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.56",
+        "id": {
+          "_id": "5c880143d7c8ac4c3e106757",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880143d7c8ac4c3e10674f"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "ethnicity",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicEthnicity"
+      },
+      {
+        "_id": "5c880143d7c8ac4c3e106750",
+        "dataElementCodes": [
+          {
+            "code": "1002-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "American Indian or Alaska Native",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.59",
+        "id": {
+          "_id": "5c880143d7c8ac4c3e106758",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880143d7c8ac4c3e106750"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "race",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicRace"
+      },
+      {
+        "_id": "5c880143d7c8ac4c3e106751",
+        "dataElementCodes": [
+          {
+            "code": "M",
+            "codeSystem": "AdministrativeGender",
+            "descriptor": "M",
+            "codeSystemOid": "2.16.840.1.113883.5.1",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.55",
+        "id": {
+          "_id": "5c880143d7c8ac4c3e106759",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880143d7c8ac4c3e106751"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "gender",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicSex"
+      }
+    ],
+    "extendedData": {
+      "type": null,
+      "measure_ids": [
+        "C0D72444-7C26-4863-9B51-8080F8928A85",
+        null
+      ],
+      "source_data_criteria": [
+        {
+          "negation": false,
+          "definition": "patient_characteristic_payer",
+          "title": "Payer",
+          "description": "Patient Characteristic Payer: Payer",
+          "code_list_id": "2.16.840.1.114222.4.11.3591",
+          "type": "characteristic",
+          "id": "Payer_PatientCharacteristicPayer_028e6363_f1a0_4340_ade5_e8b4d2a93072_source",
+          "start_date": 1343203200000,
+          "end_date": 1343204100000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "C0D72444-7C26-4863-9B51-8080F8928A85",
+          "cms_id": "CMS123v7",
+          "criteria_id": "164d1d173704L",
+          "codes": {
+            "Source of Payment Typology": [
+              "1"
+            ]
+          },
+          "coded_entry_id": {
+            "$oid": "5b588789b84846559a53f764"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "id": "MeasurePeriod",
+          "start_date": 0,
+          "end_date": 0,
+          "references": null
+        }
+      ],
+      "is_shared": null,
+      "origin_data": [
+
+      ],
+      "test_id": null,
+      "medical_record_number": "99ddf802dea6b779a29e71cc5b14688667f72baf9d6816860d1447bbed646713",
+      "medical_record_assigner": "Bonnie",
+      "description": null,
+      "description_category": null,
+      "insurance_providers": "[{\"codes\":{\"SOP\":[\"349\"]},\"description\":null,\"end_time\":null,\"financial_responsibility_type\":{\"code\":\"SELF\",\"codeSystem\":\"HL7 Relationship Code\"},\"health_record_field\":null,\"member_id\":\"1234567890\",\"mood_code\":\"EVN\",\"name\":\"Other\",\"negationInd\":null,\"negationReason\":null,\"oid\":null,\"payer\":{\"name\":\"Other\"},\"reason\":null,\"relationship\":null,\"specifics\":null,\"start_time\":1199145600,\"status_code\":null,\"time\":null,\"type\":\"OT\"}]"
+    },
+    "qdmVersion": "5.4"
+  }
+}

--- a/spec/javascripts/fixtures/json/patients/CMS12v0/MedAllergyEndIP_DENEXCEPPass.json
+++ b/spec/javascripts/fixtures/json/patients/CMS12v0/MedAllergyEndIP_DENEXCEPPass.json
@@ -1,0 +1,301 @@
+{
+  "_id": "5c12f47cb848466c63f9afca",
+  "bundleId": "5a57e977942c6d1e61d32f14",
+  "expectedValues": [
+    {
+      "measure_id": "DEAB0F79-D6C0-4E5C-9866-3DCFFAD0181B",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0,
+      "DENEXCEP": 0
+    }
+  ],
+  "familyName": "DENEXCEPPass",
+  "givenNames": [
+    "MedAllergyEndIP"
+  ],
+  "notes": "",
+  "qdmPatient": {
+    "_id": "5c880149d7c8ac4c3e1068e1",
+    "birthDatetime": "1989-07-12T08:00:00.000+00:00",
+    "dataElements": [
+      {
+        "_id": "5c880149d7c8ac4c3e1068e2",
+        "authorDatetime": "2010-02-01T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "RxNorm",
+            "code": "301542"
+          }
+        ],
+        "description": "Allergy/Intolerance: Statin Allergen",
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.119",
+        "id": {
+          "_id": "5c880149d7c8ac4c3e1068e3",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c12f47cb848466c63f9afcb"
+        },
+        "prevalencePeriod": {
+          "low": "2010-02-01T08:00:00.000+00:00",
+          "high": "9999-12-31T23:59:59.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "qdmCategory": "allergy",
+        "qdmStatus": "intolerance",
+        "qdmVersion": "5.4",
+        "severity": null,
+        "type": null,
+        "_type": "QDM::AllergyIntolerance"
+      },
+      {
+        "_id": "5c880149d7c8ac4c3e1068e4",
+        "admissionSource": null,
+        "authorDatetime": "2012-12-14T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "183452005"
+          }
+        ],
+        "description": "Encounter, Performed: Non-Elective Inpatient Encounter",
+        "diagnoses": [
+          {
+            "code": "111297002",
+            "codeSystem": "SNOMED-CT",
+            "version": null,
+            "descriptor": "Ischemic Stroke"
+          }
+        ],
+        "dischargeDisposition": null,
+        "facilityLocations": [
+
+        ],
+        "hqmfOid": "2.16.840.1.113883.3.560.1.79",
+        "id": {
+          "_id": "5c880149d7c8ac4c3e1068e5",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c12f47cb848466c63f9afcc"
+        },
+        "lengthOfStay": {
+          "value": 0,
+          "unit": "days"
+        },
+        "negationRationale": null,
+        "principalDiagnosis": {
+          "code": "111297002",
+          "codeSystem": "SNOMED-CT",
+          "descriptor": "Ischemic Stroke",
+          "codeSystemOid": null,
+          "version": null
+        },
+        "qdmCategory": "encounter",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "relevantPeriod": {
+          "low": "2012-12-14T08:00:00.000+00:00",
+          "high": "2012-12-14T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "_type": "QDM::EncounterPerformed"
+      },
+      {
+        "_id": "5c880149d7c8ac4c3e1068dc",
+        "birthDatetime": "1989-07-12T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "code": "21112-8",
+            "codeSystem": "LOINC",
+            "descriptor": null,
+            "codeSystemOid": null,
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.54",
+        "id": {
+          "_id": "5c880149d7c8ac4c3e1068e6",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880149d7c8ac4c3e1068dc"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "birthdate",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicBirthdate"
+      },
+      {
+        "_id": "5c880149d7c8ac4c3e1068dd",
+        "dataElementCodes": [
+          {
+            "code": "2186-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "Not Hispanic or Latino",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.56",
+        "id": {
+          "_id": "5c880149d7c8ac4c3e1068e7",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880149d7c8ac4c3e1068dd"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "ethnicity",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicEthnicity"
+      },
+      {
+        "_id": "5c880149d7c8ac4c3e1068de",
+        "dataElementCodes": [
+          {
+            "code": "1002-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "American Indian or Alaska Native",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.59",
+        "id": {
+          "_id": "5c880149d7c8ac4c3e1068e8",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880149d7c8ac4c3e1068de"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "race",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicRace"
+      },
+      {
+        "_id": "5c880149d7c8ac4c3e1068df",
+        "dataElementCodes": [
+          {
+            "code": "M",
+            "codeSystem": "AdministrativeGender",
+            "descriptor": "M",
+            "codeSystemOid": "2.16.840.1.113883.5.1",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.55",
+        "id": {
+          "_id": "5c880149d7c8ac4c3e1068e9",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880149d7c8ac4c3e1068df"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "gender",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicSex"
+      }
+    ],
+    "extendedData": {
+      "type": null,
+      "measure_ids": [
+        "DEAB0F79-D6C0-4E5C-9866-3DCFFAD0181B",
+        null
+      ],
+      "source_data_criteria": [
+        {
+          "negation": false,
+          "definition": "allergy_intolerance",
+          "title": "Statin Allergen",
+          "description": "Allergy/Intolerance: Statin Allergen",
+          "code_list_id": "2.16.840.1.113883.3.117.1.7.1.423",
+          "type": "allergies_intolerances",
+          "id": "StatinAllergen_Allergy_Intolerance_0465ff33_0f70_4a43_bfa4_e0d58eaf529a_source",
+          "start_date": 1265011200000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "DEAB0F79-D6C0-4E5C-9866-3DCFFAD0181B",
+          "cms_id": "CMS12v0",
+          "criteria_id": "167aa0443c5LU",
+          "codes": {
+            "RxNorm": [
+              "301542"
+            ]
+          },
+          "coded_entry_id": {
+            "$oid": "5c12f47cb848466c63f9afcb"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "encounter",
+          "status": "performed",
+          "title": "Non-Elective Inpatient Encounter",
+          "description": "Encounter, Performed: Non-Elective Inpatient Encounter",
+          "code_list_id": "2.16.840.1.113883.3.117.1.7.1.424",
+          "type": "encounters",
+          "id": "Non_ElectiveInpatientEncounter_EncounterPerformed_2abc795f_73fb_4273_a9da_ae9a84cdca7a_source",
+          "start_date": 1355472000000,
+          "end_date": 1355472900000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+            "PRINCIPAL_DIAGNOSIS": {
+              "type": "CD",
+              "code_list_id": "2.16.840.1.113883.3.117.1.7.1.247",
+              "field_title": "Principal Diagnosis",
+              "title": "Ischemic Stroke"
+            }
+          },
+          "hqmf_set_id": "DEAB0F79-D6C0-4E5C-9866-3DCFFAD0181B",
+          "cms_id": "CMS12v0",
+          "criteria_id": "167aa0abc42Bv",
+          "codes": {
+            "SNOMED-CT": [
+              "183452005"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5c12f47cb848466c63f9afcc"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "id": "MeasurePeriod",
+          "start_date": 0,
+          "end_date": 0,
+          "references": null
+        }
+      ],
+      "is_shared": null,
+      "origin_data": [
+
+      ],
+      "test_id": null,
+      "medical_record_number": "5739baa6fa0456c1b69041eeb6fa7d3f9dbfa0b778ac82a0f14641f6e84f326d",
+      "medical_record_assigner": "Bonnie",
+      "description": null,
+      "description_category": null,
+      "insurance_providers": "[{\"codes\":{\"SOP\":[\"349\"]},\"description\":null,\"end_time\":null,\"financial_responsibility_type\":{\"code\":\"SELF\",\"codeSystem\":\"HL7 Relationship Code\"},\"health_record_field\":null,\"member_id\":\"1234567890\",\"mood_code\":\"EVN\",\"name\":\"Other\",\"negationInd\":null,\"negationReason\":null,\"oid\":null,\"payer\":{\"name\":\"Other\"},\"reason\":null,\"relationship\":null,\"specifics\":null,\"start_time\":1199145600,\"status_code\":null,\"time\":null,\"type\":\"OT\"}]"
+    },
+    "qdmVersion": "5.4"
+  }
+}

--- a/spec/javascripts/fixtures/json/patients/CMS134v6/Elements_Test.json
+++ b/spec/javascripts/fixtures/json/patients/CMS134v6/Elements_Test.json
@@ -1,0 +1,1281 @@
+{
+  "_id": "5b6b2161b848461165a3b783",
+  "bundleId": "5a57e977942c6d1e61d32f14",
+  "expectedValues": [
+    {
+      "measure_id": "7B2A9277-43DA-4D99-9BEE-6AC271A07747",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    }
+  ],
+  "familyName": "Test",
+  "givenNames": [
+    "Elements"
+  ],
+  "notes": "",
+  "qdmPatient": {
+    "_id": "5c88013ad7c8ac4c3e1065f5",
+    "birthDatetime": "1970-01-01T08:00:00.000+00:00",
+    "dataElements": [
+      {
+        "_id": "5c88013ad7c8ac4c3e1065f6",
+        "anatomicalLocationSite": {
+          "code": "129151000119102",
+          "codeSystem": "SNOMED-CT",
+          "descriptor": "Kidney Failure",
+          "codeSystemOid": null,
+          "version": null
+        },
+        "authorDatetime": "2012-07-23T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "129151000119102"
+          }
+        ],
+        "description": "Diagnosis: Kidney Failure",
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.110",
+        "id": {
+          "_id": "5c88013ad7c8ac4c3e1065f7",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5b6c2f6cb848464add087399"
+        },
+        "prevalencePeriod": {
+          "low": "2012-07-23T08:00:00.000+00:00",
+          "high": "2012-07-23T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "qdmCategory": "condition",
+        "qdmVersion": "5.4",
+        "qrdaOid": "2.16.840.1.113883.10.20.24.3.135",
+        "severity": {
+          "code": "12178007",
+          "codeSystem": "SNOMED-CT",
+          "descriptor": "Proteinuria",
+          "codeSystemOid": null,
+          "version": null
+        },
+        "_type": "QDM::Diagnosis"
+      },
+      {
+        "_id": "5c88013ad7c8ac4c3e1065f8",
+        "admissionSource": {
+          "code": "185460008",
+          "codeSystem": "SNOMED-CT",
+          "descriptor": "Home Healthcare Services",
+          "codeSystemOid": null,
+          "version": null
+        },
+        "authorDatetime": "2012-07-23T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "12843005"
+          }
+        ],
+        "description": "Encounter, Performed: Face-to-Face Interaction",
+        "diagnoses": [
+          {
+            "code": "129151000119102",
+            "codeSystem": "SNOMED-CT",
+            "version": null,
+            "descriptor": "Kidney Failure"
+          },
+          {
+            "code": "12178007",
+            "codeSystem": "SNOMED-CT",
+            "version": null,
+            "descriptor": "Proteinuria"
+          },
+          {
+            "code": "105401000119101",
+            "codeSystem": "SNOMED-CT",
+            "version": null,
+            "descriptor": "Diabetes"
+          }
+        ],
+        "dischargeDisposition": {
+          "code": "428361000124107",
+          "codeSystem": "SNOMED-CT",
+          "descriptor": "Discharged to Home for Hospice Care",
+          "codeSystemOid": null,
+          "version": null
+        },
+        "facilityLocations": [
+          {
+            "_id": {
+              "$oid": "5c88013ad7c8ac4c3e1065ee"
+            },
+            "dataElementCodes": [
+
+            ],
+            "description": null,
+            "_type": "QDM::FacilityLocation",
+            "code": {
+              "code": "4525004",
+              "codeSystem": "SNOMED-CT",
+              "descriptor": "Emergency Department Visit",
+              "codeSystemOid": null,
+              "version": null,
+              "_type": "QDM::Code"
+            },
+            "locationPeriod": {
+              "low": "2012-07-23T08:00:00.000+00:00",
+              "high": "2012-07-23T09:00:00.000+00:00",
+              "lowClosed": true,
+              "highClosed": true,
+              "_type": "QDM::Interval"
+            },
+            "qdmVersion": "5.4"
+          },
+          {
+            "_id": {
+              "$oid": "5c88013ad7c8ac4c3e1065ef"
+            },
+            "dataElementCodes": [
+
+            ],
+            "description": null,
+            "_type": "QDM::FacilityLocation",
+            "code": {
+              "code": "185463005",
+              "codeSystem": "SNOMED-CT",
+              "descriptor": "Office Visit",
+              "codeSystemOid": null,
+              "version": null,
+              "_type": "QDM::Code"
+            },
+            "locationPeriod": {
+              "low": "2012-07-23T09:00:00.000+00:00",
+              "high": "2012-07-23T10:00:00.000+00:00",
+              "lowClosed": true,
+              "highClosed": true,
+              "_type": "QDM::Interval"
+            },
+            "qdmVersion": "5.4"
+          }
+        ],
+        "hqmfOid": "2.16.840.1.113883.3.560.1.79",
+        "id": {
+          "_id": "5c88013ad7c8ac4c3e1065f9",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5b6c2f6cb848464add08739a"
+        },
+        "lengthOfStay": {
+          "value": 0,
+          "unit": "days"
+        },
+        "negationRationale": null,
+        "principalDiagnosis": {
+          "code": "105401000119101",
+          "codeSystem": "SNOMED-CT",
+          "descriptor": "Diabetes",
+          "codeSystemOid": null,
+          "version": null
+        },
+        "qdmCategory": "encounter",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "relevantPeriod": {
+          "low": "2012-07-23T08:00:00.000+00:00",
+          "high": "2012-07-23T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "_type": "QDM::EncounterPerformed"
+      },
+      {
+        "_id": "5c88013ad7c8ac4c3e1065fa",
+        "dataElementCodes": [
+          {
+            "codeSystem": "RxNorm",
+            "code": "1000001"
+          }
+        ],
+        "description": "Medication, Active: ACE Inhibitor or ARB",
+        "dosage": {
+          "value": 60,
+          "unit": "mg"
+        },
+        "frequency": {
+          "code": null,
+          "codeSystem": null,
+          "descriptor": null,
+          "codeSystemOid": null,
+          "version": null
+        },
+        "hqmfOid": "2.16.840.1.113883.3.560.1.13",
+        "id": {
+          "_id": "5c88013ad7c8ac4c3e1065fb",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5b6c2f6cb848464add08739d"
+        },
+        "qdmCategory": "medication",
+        "qdmStatus": "active",
+        "qdmVersion": "5.4",
+        "relevantPeriod": {
+          "low": "2012-07-23T08:00:00.000+00:00",
+          "high": "2012-07-23T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "route": {
+          "code": "180272001",
+          "codeSystem": "SNOMED-CT",
+          "descriptor": "Vascular Access for Dialysis",
+          "codeSystemOid": null,
+          "version": null
+        },
+        "_type": "QDM::MedicationActive"
+      },
+      {
+        "_id": "5c88013ad7c8ac4c3e1065fc",
+        "authorDatetime": "2012-07-23T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "385763009"
+          }
+        ],
+        "description": "Intervention, Order: Hospice care ambulatory",
+        "hqmfOid": "2.16.840.1.113883.3.560.1.45",
+        "id": {
+          "_id": "5c88013ad7c8ac4c3e1065fd",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5b6c2f6cb848464add08739e"
+        },
+        "negationRationale": null,
+        "qdmCategory": "intervention",
+        "qdmStatus": "order",
+        "qdmVersion": "5.4",
+        "reason": {
+          "code": "G0438",
+          "codeSystem": "HCPCS",
+          "descriptor": "Annual Wellness Visit",
+          "codeSystemOid": null,
+          "version": null
+        },
+        "_type": "QDM::InterventionOrder"
+      },
+      {
+        "_id": "5c88013ad7c8ac4c3e1065fe",
+        "authorDatetime": "2012-07-23T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "385763009"
+          }
+        ],
+        "description": "Intervention, Performed: Hospice care ambulatory",
+        "hqmfOid": "2.16.840.1.113883.3.560.1.46",
+        "id": {
+          "_id": "5c88013ad7c8ac4c3e1065ff",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5b6c2f6cb848464add08739f"
+        },
+        "negationRationale": null,
+        "qdmCategory": "intervention",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "reason": {
+          "code": "129151000119102",
+          "codeSystem": "SNOMED-CT",
+          "descriptor": "Kidney Failure",
+          "codeSystemOid": null,
+          "version": null
+        },
+        "relevantPeriod": {
+          "low": "2012-07-23T08:00:00.000+00:00",
+          "high": "2012-07-23T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "result": {
+          "code": "419099009",
+          "codeSystem": "SNOMED-CT",
+          "version": null,
+          "descriptor": "Dead"
+        },
+        "status": {
+          "code": "105401000119101",
+          "codeSystem": "SNOMED-CT",
+          "descriptor": "Diabetes",
+          "codeSystemOid": null,
+          "version": null
+        },
+        "_type": "QDM::InterventionPerformed"
+      },
+      {
+        "_id": "5c88013ad7c8ac4c3e106600",
+        "anatomicalLocationSite": {
+          "code": "12843005",
+          "codeSystem": "SNOMED-CT",
+          "descriptor": "Face-to-Face Interaction",
+          "codeSystemOid": null,
+          "version": null
+        },
+        "authorDatetime": "2012-07-23T08:00:00.000+00:00",
+        "components": [
+
+        ],
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "108241001"
+          }
+        ],
+        "description": "Procedure, Performed: Dialysis Services",
+        "hqmfOid": "2.16.840.1.113883.3.560.1.6",
+        "id": {
+          "_id": "5c88013ad7c8ac4c3e106601",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5b6c2f6cb848464add0873a1"
+        },
+        "incisionDatetime": "2012-07-12T08:00:00.000+00:00",
+        "method": {
+          "code": "11218-5",
+          "codeSystem": "LOINC",
+          "descriptor": "Urine Protein Tests",
+          "codeSystemOid": null,
+          "version": null
+        },
+        "negationRationale": null,
+        "ordinality": {
+          "code": "127013003",
+          "codeSystem": "SNOMED-CT",
+          "descriptor": "Diabetic Nephropathy",
+          "codeSystemOid": null,
+          "version": null
+        },
+        "qdmCategory": "procedure",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "reason": {
+          "code": "12178007",
+          "codeSystem": "SNOMED-CT",
+          "descriptor": "Proteinuria",
+          "codeSystemOid": null,
+          "version": null
+        },
+        "relevantPeriod": {
+          "low": "2012-07-23T08:00:00.000+00:00",
+          "high": "2012-07-23T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "result": {
+          "code": "419099009",
+          "codeSystem": "SNOMED-CT",
+          "version": null,
+          "descriptor": "Dead"
+        },
+        "status": {
+          "code": "419099009",
+          "codeSystem": "SNOMED-CT",
+          "descriptor": "Dead",
+          "codeSystemOid": null,
+          "version": null
+        },
+        "_type": "QDM::ProcedurePerformed"
+      },
+      {
+        "_id": "5c88013ad7c8ac4c3e106602",
+        "anatomicalLocationSite": null,
+        "authorDatetime": "2012-07-23T08:00:00.000+00:00",
+        "components": [
+          {
+            "result": 56,
+            "code": {
+              "code": "127013003",
+              "codeSystem": "SNOMED-CT",
+              "version": null,
+              "descriptor": null
+            }
+          },
+          {
+            "result": {
+              "code": "12178007",
+              "codeSystem": "SNOMED-CT",
+              "version": null,
+              "descriptor": null
+            },
+            "code": {
+              "code": "11218-5",
+              "codeSystem": "LOINC",
+              "version": null,
+              "descriptor": "Proteinuria"
+            }
+          }
+        ],
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "175899003"
+          }
+        ],
+        "description": "Procedure, Performed: Kidney Transplant",
+        "hqmfOid": "2.16.840.1.113883.3.560.1.6",
+        "id": {
+          "_id": "5c88013ad7c8ac4c3e106603",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5b6c2f6cb848464add0873a3"
+        },
+        "incisionDatetime": null,
+        "method": null,
+        "negationRationale": null,
+        "ordinality": null,
+        "qdmCategory": "procedure",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "relevantPeriod": {
+          "low": "2012-07-23T08:00:00.000+00:00",
+          "high": "2012-07-23T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "result": null,
+        "status": null,
+        "_type": "QDM::ProcedurePerformed"
+      },
+      {
+        "_id": "5c88013ad7c8ac4c3e106604",
+        "authorDatetime": "2012-07-23T08:00:00.000+00:00",
+        "components": [
+
+        ],
+        "dataElementCodes": [
+          {
+            "codeSystem": "LOINC",
+            "code": "11218-5"
+          }
+        ],
+        "description": "Laboratory Test, Performed: Urine Protein Tests",
+        "hqmfOid": "2.16.840.1.113883.3.560.1.5",
+        "id": {
+          "_id": "5c88013ad7c8ac4c3e106605",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5b6c2f6cb848464add0873a4"
+        },
+        "method": {
+          "code": "180272001",
+          "codeSystem": "SNOMED-CT",
+          "descriptor": "Vascular Access for Dialysis",
+          "codeSystemOid": null,
+          "version": null
+        },
+        "negationRationale": null,
+        "qdmCategory": "laboratory_test",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "reason": {
+          "code": "129151000119102",
+          "codeSystem": "SNOMED-CT",
+          "descriptor": "Kidney Failure",
+          "codeSystemOid": null,
+          "version": null
+        },
+        "referenceRange": {
+          "low": {
+            "unit": "mg",
+            "value": 20
+          },
+          "high": {
+            "unit": "mg",
+            "value": 60
+          },
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "relevantPeriod": {
+          "low": "2012-07-23T08:00:00.000+00:00",
+          "high": "2012-07-23T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "result": {
+          "unit": "mg",
+          "value": 35
+        },
+        "resultDatetime": "2012-07-28T08:00:00.000+00:00",
+        "status": {
+          "code": "428371000124100",
+          "codeSystem": "SNOMED-CT",
+          "descriptor": "Discharged to Health Care Facility for Hospice Care",
+          "codeSystemOid": null,
+          "version": null
+        },
+        "_type": "QDM::LaboratoryTestPerformed"
+      },
+      {
+        "_id": "5c88013ad7c8ac4c3e106606",
+        "authorDatetime": "2012-07-23T08:00:00.000+00:00",
+        "components": [
+          {
+            "result": {
+              "unit": "mg",
+              "value": 45
+            },
+            "code": {
+              "code": "12178007",
+              "codeSystem": "SNOMED-CT",
+              "version": null,
+              "descriptor": null
+            },
+            "referenceRange": {
+              "low": "20",
+              "high": "60",
+              "lowClosed": true,
+              "highClosed": true
+            }
+          },
+          {
+            "result": {
+              "code": "105401000119101",
+              "codeSystem": "SNOMED-CT",
+              "version": null,
+              "descriptor": null
+            },
+            "code": {
+              "code": "180272001",
+              "codeSystem": "SNOMED-CT",
+              "version": null,
+              "descriptor": "Diabetes"
+            }
+          }
+        ],
+        "dataElementCodes": [
+          {
+            "codeSystem": "LOINC",
+            "code": "12842-1"
+          }
+        ],
+        "description": "Laboratory Test, Performed: Urine Protein Tests",
+        "hqmfOid": "2.16.840.1.113883.3.560.1.5",
+        "id": {
+          "_id": "5c88013ad7c8ac4c3e106607",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5b6c2f6cb848464add0873a6"
+        },
+        "method": null,
+        "negationRationale": null,
+        "qdmCategory": "laboratory_test",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "referenceRange": null,
+        "relevantPeriod": {
+          "low": "2012-07-23T08:00:00.000+00:00",
+          "high": "2012-07-23T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "result": null,
+        "resultDatetime": null,
+        "status": null,
+        "_type": "QDM::LaboratoryTestPerformed"
+      },
+      {
+        "_id": "5c88013ad7c8ac4c3e1065f0",
+        "birthDatetime": "1970-01-01T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "code": "21112-8",
+            "codeSystem": "LOINC",
+            "descriptor": null,
+            "codeSystemOid": null,
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.54",
+        "id": {
+          "_id": "5c88013ad7c8ac4c3e106608",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013ad7c8ac4c3e1065f0"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "birthdate",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicBirthdate"
+      },
+      {
+        "_id": "5c88013ad7c8ac4c3e1065f1",
+        "dataElementCodes": [
+          {
+            "code": "2186-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "Not Hispanic or Latino",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.56",
+        "id": {
+          "_id": "5c88013ad7c8ac4c3e106609",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013ad7c8ac4c3e1065f1"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "ethnicity",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicEthnicity"
+      },
+      {
+        "_id": "5c88013ad7c8ac4c3e1065f2",
+        "dataElementCodes": [
+          {
+            "code": "1002-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "American Indian or Alaska Native",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.59",
+        "id": {
+          "_id": "5c88013ad7c8ac4c3e10660a",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013ad7c8ac4c3e1065f2"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "race",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicRace"
+      },
+      {
+        "_id": "5c88013ad7c8ac4c3e1065f3",
+        "dataElementCodes": [
+          {
+            "code": "M",
+            "codeSystem": "AdministrativeGender",
+            "descriptor": "M",
+            "codeSystemOid": "2.16.840.1.113883.5.1",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.55",
+        "id": {
+          "_id": "5c88013ad7c8ac4c3e10660b",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013ad7c8ac4c3e1065f3"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "gender",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicSex"
+      }
+    ],
+    "extendedData": {
+      "type": null,
+      "measure_ids": [
+        "7B2A9277-43DA-4D99-9BEE-6AC271A07747",
+        null
+      ],
+      "source_data_criteria": [
+        {
+          "negation": false,
+          "definition": "intervention",
+          "status": "ordered",
+          "title": "Hospicecareambulatory",
+          "description": "Intervention, Order: Hospice care ambulatory",
+          "code_list_id": "2.16.840.1.113762.1.4.1108.15",
+          "type": "interventions",
+          "id": "Hospicecareambulatory_InterventionOrder_95cca057_9695_4ee4_a5bd_eff4b54c6098_source",
+          "start_date": 1343030400000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+            "REASON": {
+              "type": "CD",
+              "code_list_id": "2.16.840.1.113883.3.526.3.1240",
+              "field_title": "Reason",
+              "title": "Annual Wellness Visit"
+            }
+          },
+          "hqmf_set_id": "7B2A9277-43DA-4D99-9BEE-6AC271A07747",
+          "cms_id": "CMS134v6",
+          "criteria_id": "1651a76c4eezO",
+          "codes": {
+            "SNOMED-CT": [
+              "385763009"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5b6c2f6cb848464add08739e"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "diagnosis",
+          "title": "KidneyFailure",
+          "description": "Diagnosis: Kidney Failure",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.109.12.1028",
+          "type": "conditions",
+          "id": "KidneyFailure_Diagnosis_96400e6f_2f81_4eb4_ab44_62586d331790_source",
+          "start_date": 1343030400000,
+          "end_date": 1343031300000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+            "ANATOMICAL_LOCATION_SITE": {
+              "type": "CD",
+              "code_list_id": "2.16.840.1.113883.3.464.1003.109.12.1028",
+              "field_title": "Anatomical Location Site",
+              "title": "Kidney Failure"
+            },
+            "SEVERITY": {
+              "type": "CD",
+              "code_list_id": "2.16.840.1.113883.3.526.3.1003",
+              "field_title": "Severity",
+              "title": "Proteinuria"
+            }
+          },
+          "hqmf_set_id": "7B2A9277-43DA-4D99-9BEE-6AC271A07747",
+          "cms_id": "CMS134v6",
+          "criteria_id": "1651a7738384e",
+          "codes": {
+            "SNOMED-CT": [
+              "129151000119102"
+            ]
+          },
+          "coded_entry_id": {
+            "$oid": "5b6c2f6cb848464add087399"
+          },
+          "code_source": "USER_DEFINED"
+        },
+        {
+          "negation": false,
+          "definition": "encounter",
+          "status": "performed",
+          "title": "Face-to-FaceInteraction",
+          "description": "Encounter, Performed: Face-to-Face Interaction",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.101.12.1048",
+          "type": "encounters",
+          "id": "Face_to_FaceInteraction_EncounterPerformed_40280381_3d61_56a7_013e_62abf57e301a_source",
+          "start_date": 1343030400000,
+          "end_date": 1343031300000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+            "ADMISSION_SOURCE": {
+              "type": "CD",
+              "code_list_id": "2.16.840.1.113883.3.464.1003.101.12.1016",
+              "field_title": "Admission Source",
+              "title": "Home Healthcare Services"
+            },
+            "DIAGNOSIS": {
+              "type": "COL",
+              "values": [
+                {
+                  "type": "CD",
+                  "key": "DIAGNOSIS",
+                  "code_list_id": "2.16.840.1.113883.3.464.1003.109.12.1028",
+                  "field_title": "Diagnosis",
+                  "title": "Kidney Failure"
+                },
+                {
+                  "type": "CD",
+                  "key": "DIAGNOSIS",
+                  "code_list_id": "2.16.840.1.113883.3.526.3.1003",
+                  "field_title": "Diagnosis",
+                  "title": "Proteinuria"
+                }
+              ],
+              "field_title": "Diagnosis"
+            },
+            "DISCHARGE_STATUS": {
+              "type": "CD",
+              "code_list_id": "2.16.840.1.113883.3.117.1.7.1.209",
+              "field_title": "Discharge Disposition",
+              "title": "Discharged to Home for Hospice Care"
+            },
+            "PRINCIPAL_DIAGNOSIS": {
+              "type": "CD",
+              "code_list_id": "2.16.840.1.113883.3.464.1003.103.12.1001",
+              "field_title": "Principal Diagnosis",
+              "title": "Diabetes"
+            },
+            "FACILITY_LOCATION": {
+              "type": "COL",
+              "values": [
+                {
+                  "type": "FAC",
+                  "key": "FACILITY_LOCATION",
+                  "code_list_id": "2.16.840.1.113883.3.117.1.7.1.292",
+                  "field_title": "Facility Location",
+                  "start_date": "07/23/2012",
+                  "start_time": "8:00 AM",
+                  "end_date": "07/23/2012",
+                  "end_time": "9:00 AM",
+                  "value": 1343030400000,
+                  "locationPeriodLow": "07/23/2012 8:00 AM",
+                  "locationPeriodHigh": "07/23/2012 9:00 AM",
+                  "end_value": 1343034000000,
+                  "title": "Emergency Department Visit"
+                },
+                {
+                  "type": "FAC",
+                  "key": "FACILITY_LOCATION",
+                  "code_list_id": "2.16.840.1.113883.3.464.1003.101.12.1001",
+                  "field_title": "Facility Location",
+                  "start_date": "07/23/2012",
+                  "start_time": "9:00 AM",
+                  "end_date": "07/23/2012",
+                  "end_time": "10:00 AM",
+                  "value": 1343034000000,
+                  "locationPeriodLow": "07/23/2012 9:00 AM",
+                  "locationPeriodHigh": "07/23/2012 10:00 AM",
+                  "end_value": 1343037600000,
+                  "title": "Office Visit"
+                }
+              ],
+              "field_title": "Facility Location"
+            }
+          },
+          "hqmf_set_id": "7B2A9277-43DA-4D99-9BEE-6AC271A07747",
+          "cms_id": "CMS134v6",
+          "criteria_id": "1651a78658aJ5",
+          "codes": {
+            "SNOMED-CT": [
+              "12843005"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5b6c2f6cb848464add08739a"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "intervention",
+          "status": "performed",
+          "title": "Hospicecareambulatory",
+          "description": "Intervention, Performed: Hospice care ambulatory",
+          "code_list_id": "2.16.840.1.113762.1.4.1108.15",
+          "type": "interventions",
+          "id": "Hospicecareambulatory_InterventionPerformed_95cca057_9695_4ee4_a5bd_eff4b54c6098_source",
+          "start_date": 1343030400000,
+          "end_date": 1343031300000,
+          "value": [
+            {
+              "type": "CD",
+              "type_cmp": "CD",
+              "code_list_id": "drc-288b28533ea3e20c8bed70cf4e0a8d78afa536cf3be01339e67e189ef32d0b58",
+              "title": "Dead"
+            }
+          ],
+          "references": null,
+          "field_values": {
+            "REASON": {
+              "type": "CD",
+              "code_list_id": "2.16.840.1.113883.3.464.1003.109.12.1028",
+              "field_title": "Reason",
+              "title": "Kidney Failure"
+            },
+            "STATUS": {
+              "type": "CD",
+              "code_list_id": "2.16.840.1.113883.3.464.1003.103.12.1001",
+              "field_title": "Status",
+              "title": "Diabetes"
+            }
+          },
+          "hqmf_set_id": "7B2A9277-43DA-4D99-9BEE-6AC271A07747",
+          "cms_id": "CMS134v6",
+          "criteria_id": "1651a7af0ce5A",
+          "codes": {
+            "SNOMED-CT": [
+              "385763009"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5b6c2f6cb848464add08739f"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "laboratory_test",
+          "status": "performed",
+          "title": "UrineProteinTests",
+          "description": "Laboratory Test, Performed: Urine Protein Tests",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.109.12.1024",
+          "type": "laboratory_tests",
+          "id": "UrineProteinTests_LaboratoryTestPerformed_28120d98_866d_488a_b3c6_4cd573a59048_source",
+          "start_date": 1343030400000,
+          "end_date": 1343031300000,
+          "value": [
+            {
+              "type": "PQ",
+              "type_cmp": "CD",
+              "value": "35",
+              "unit": "mg"
+            }
+          ],
+          "references": null,
+          "field_values": {
+            "REFERENCE_RANGE_HIGH": {
+              "type": "PQ",
+              "code_list_id": "",
+              "field_title": "Reference Range - High",
+              "value": "60",
+              "unit": "mg"
+            },
+            "REFERENCE_RANGE_LOW": {
+              "type": "PQ",
+              "code_list_id": "",
+              "field_title": "Reference Range - Low",
+              "value": "20",
+              "unit": "mg"
+            },
+            "METHOD": {
+              "type": "CD",
+              "code_list_id": "2.16.840.1.113883.3.464.1003.109.12.1011",
+              "field_title": "Method",
+              "title": "Vascular Access for Dialysis"
+            },
+            "REASON": {
+              "type": "CD",
+              "code_list_id": "2.16.840.1.113883.3.464.1003.109.12.1028",
+              "field_title": "Reason",
+              "title": "Kidney Failure"
+            },
+            "RESULT_DATETIME": {
+              "type": "TS",
+              "code_list_id": "",
+              "field_title": "Result Date/Time",
+              "start_date": "07/28/2012",
+              "start_time": "8:00 AM",
+              "value": 1343462400000
+            },
+            "STATUS": {
+              "type": "CD",
+              "code_list_id": "2.16.840.1.113883.3.117.1.7.1.207",
+              "field_title": "Status",
+              "title": "Discharged to Health Care Facility for Hospice Care"
+            }
+          },
+          "hqmf_set_id": "7B2A9277-43DA-4D99-9BEE-6AC271A07747",
+          "cms_id": "CMS134v6",
+          "criteria_id": "1651a7b95aeYP",
+          "codes": {
+            "LOINC": [
+              "11218-5"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5b6c2f6cb848464add0873a4"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "laboratory_test",
+          "status": "performed",
+          "title": "UrineProteinTests",
+          "description": "Laboratory Test, Performed: Urine Protein Tests",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.109.12.1024",
+          "type": "laboratory_tests",
+          "id": "UrineProteinTests_LaboratoryTestPerformed_28120d98_866d_488a_b3c6_4cd573a59048_source",
+          "start_date": 1343030400000,
+          "end_date": 1343031300000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+            "COMPONENT": {
+              "type": "COL",
+              "values": [
+                {
+                  "type": "CMP",
+                  "type_cmp": "PQ",
+                  "key": "COMPONENT",
+                  "code_list_id": "2.16.840.1.113883.3.526.3.1003",
+                  "field_title": "Component",
+                  "code_list_id_cmp": "",
+                  "referenceRangeLow_value": "20",
+                  "referenceRangeLow_unit": "mg",
+                  "referenceRangeHigh_value": "60",
+                  "referenceRangeHigh_unit": "mg",
+                  "title": "Proteinuria",
+                  "value": "45",
+                  "unit": "mg"
+                },
+                {
+                  "type": "CMP",
+                  "key": "COMPONENT",
+                  "code_list_id": "2.16.840.1.113883.3.464.1003.109.12.1011",
+                  "title_cmp": "Diabetes",
+                  "field_title": "Component",
+                  "type_cmp": "CD",
+                  "code_list_id_cmp": "2.16.840.1.113883.3.464.1003.103.12.1001",
+                  "referenceRangeLow_value": "",
+                  "referenceRangeLow_unit": "",
+                  "referenceRangeHigh_value": "",
+                  "referenceRangeHigh_unit": "",
+                  "title": "Vascular Access for Dialysis"
+                }
+              ],
+              "field_title": "Component"
+            }
+          },
+          "hqmf_set_id": "7B2A9277-43DA-4D99-9BEE-6AC271A07747",
+          "cms_id": "CMS134v6",
+          "criteria_id": "1651a7d7903MW",
+          "codes": {
+            "LOINC": [
+              "12842-1"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5b6c2f6cb848464add0873a6"
+          },
+          "code_source": "USER_DEFINED"
+        },
+        {
+          "negation": false,
+          "definition": "medication",
+          "status": "active",
+          "title": "ACEInhibitororARB",
+          "description": "Medication, Active: ACE Inhibitor or ARB",
+          "code_list_id": "2.16.840.1.113883.3.526.3.1139",
+          "type": "medications",
+          "id": "ACEInhibitororARB_MedicationActive_40280381_3d61_56a7_013e_62abf57e301b_source",
+          "start_date": 1343030400000,
+          "end_date": 1343031300000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+            "SUPPLY": {
+              "type": "PQ",
+              "code_list_id": "",
+              "field_title": "Supply",
+              "value": "60",
+              "unit": "{pills}"
+            },
+            "DOSE": {
+              "type": "PQ",
+              "code_list_id": "",
+              "field_title": "Dosage",
+              "value": "60",
+              "unit": "mg"
+            },
+            "FREQUENCY": {
+              "type": "PQ",
+              "code_list_id": "",
+              "field_title": "Frequency",
+              "value": "1",
+              "unit": "mg/day"
+            },
+            "ROUTE": {
+              "type": "CD",
+              "code_list_id": "2.16.840.1.113883.3.464.1003.109.12.1011",
+              "field_title": "Route",
+              "title": "Vascular Access for Dialysis"
+            }
+          },
+          "hqmf_set_id": "7B2A9277-43DA-4D99-9BEE-6AC271A07747",
+          "cms_id": "CMS134v6",
+          "criteria_id": "1651a7ef215WS",
+          "codes": {
+            "RxNorm": [
+              "1000001"
+            ]
+          },
+          "coded_entry_id": {
+            "$oid": "5b6c2f6cb848464add08739d"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "procedure",
+          "status": "performed",
+          "title": "DialysisServices",
+          "description": "Procedure, Performed: Dialysis Services",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.109.12.1013",
+          "type": "procedures",
+          "id": "DialysisServices_ProcedurePerformed_40280381_3d61_56a7_013e_62abf57d300e_source",
+          "start_date": 1343030400000,
+          "end_date": 1343031300000,
+          "value": [
+            {
+              "type": "CD",
+              "type_cmp": "CD",
+              "code_list_id": "drc-288b28533ea3e20c8bed70cf4e0a8d78afa536cf3be01339e67e189ef32d0b58",
+              "title": "Dead"
+            }
+          ],
+          "references": null,
+          "field_values": {
+            "ANATOMICAL_LOCATION_SITE": {
+              "type": "CD",
+              "code_list_id": "2.16.840.1.113883.3.464.1003.101.12.1048",
+              "field_title": "Anatomical Location Site",
+              "title": "Face-to-Face Interaction"
+            },
+            "INCISION_DATETIME": {
+              "type": "TS",
+              "code_list_id": "",
+              "field_title": "Incision Date/Time",
+              "start_date": "07/12/2012",
+              "start_time": "8:00 AM",
+              "value": 1342080000000
+            },
+            "METHOD": {
+              "type": "CD",
+              "code_list_id": "2.16.840.1.113883.3.464.1003.109.12.1024",
+              "field_title": "Method",
+              "title": "Urine Protein Tests"
+            },
+            "REASON": {
+              "type": "CD",
+              "code_list_id": "2.16.840.1.113883.3.526.3.1003",
+              "field_title": "Reason",
+              "title": "Proteinuria"
+            },
+            "STATUS": {
+              "type": "CD",
+              "code_list_id": "drc-288b28533ea3e20c8bed70cf4e0a8d78afa536cf3be01339e67e189ef32d0b58",
+              "field_title": "Status",
+              "title": "Dead"
+            },
+            "ORDINAL": {
+              "type": "CD",
+              "code_list_id": "2.16.840.1.113883.3.464.1003.109.12.1004",
+              "field_title": "Ordinality",
+              "title": "Diabetic Nephropathy"
+            }
+          },
+          "hqmf_set_id": "7B2A9277-43DA-4D99-9BEE-6AC271A07747",
+          "cms_id": "CMS134v6",
+          "criteria_id": "1651a801eecs0",
+          "codes": {
+            "SNOMED-CT": [
+              "108241001"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5b6c2f6cb848464add0873a1"
+          },
+          "code_source": "USER_DEFINED"
+        },
+        {
+          "negation": false,
+          "definition": "procedure",
+          "status": "performed",
+          "title": "KidneyTransplant",
+          "description": "Procedure, Performed: Kidney Transplant",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.109.12.1012",
+          "type": "procedures",
+          "id": "KidneyTransplant_ProcedurePerformed_40280381_3d61_56a7_013e_62abf57d300c_source",
+          "start_date": 1343030400000,
+          "end_date": 1343031300000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+            "COMPONENT": {
+              "type": "COL",
+              "values": [
+                {
+                  "type": "CMP",
+                  "type_cmp": "PQ",
+                  "key": "COMPONENT",
+                  "code_list_id": "2.16.840.1.113883.3.464.1003.109.12.1004",
+                  "field_title": "Component",
+                  "code_list_id_cmp": "",
+                  "title": "Diabetic Nephropathy",
+                  "value": "56",
+                  "unit": ""
+                },
+                {
+                  "type": "CMP",
+                  "key": "COMPONENT",
+                  "code_list_id": "2.16.840.1.113883.3.464.1003.109.12.1024",
+                  "title_cmp": "Proteinuria",
+                  "field_title": "Component",
+                  "type_cmp": "CD",
+                  "code_list_id_cmp": "2.16.840.1.113883.3.526.3.1003",
+                  "title": "Urine Protein Tests"
+                }
+              ],
+              "field_title": "Component"
+            }
+          },
+          "hqmf_set_id": "7B2A9277-43DA-4D99-9BEE-6AC271A07747",
+          "cms_id": "CMS134v6",
+          "criteria_id": "1651a8153dbOs",
+          "codes": {
+            "SNOMED-CT": [
+              "175899003"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5b6c2f6cb848464add0873a3"
+          },
+          "code_source": "USER_DEFINED"
+        },
+        {
+          "id": "MeasurePeriod",
+          "start_date": 0,
+          "end_date": 0,
+          "references": null
+        }
+      ],
+      "is_shared": null,
+      "origin_data": [
+
+      ],
+      "test_id": null,
+      "medical_record_number": "311fb11d919d608cffe0b352235bac8b505f9c29b9b0f7f1f58c26e94aa26844",
+      "medical_record_assigner": "Bonnie",
+      "description": null,
+      "description_category": null,
+      "insurance_providers": "[{\"codes\":{\"SOP\":[\"349\"]},\"description\":null,\"end_time\":null,\"financial_responsibility_type\":{\"code\":\"SELF\",\"codeSystem\":\"HL7 Relationship Code\"},\"health_record_field\":null,\"member_id\":\"1234567890\",\"mood_code\":\"EVN\",\"name\":\"Other\",\"negationInd\":null,\"negationReason\":null,\"oid\":null,\"payer\":{\"name\":\"Other\"},\"reason\":null,\"relationship\":null,\"specifics\":null,\"start_time\":1199145600,\"status_code\":null,\"time\":null,\"type\":\"OT\"}]"
+    },
+    "qdmVersion": "5.4"
+  }
+}

--- a/spec/javascripts/fixtures/json/patients/CMS134v6/Fail_Hospice_Not_Performed_Denex.json
+++ b/spec/javascripts/fixtures/json/patients/CMS134v6/Fail_Hospice_Not_Performed_Denex.json
@@ -1,0 +1,343 @@
+{
+  "_id": "5a73955cb848465f695c4ecb",
+  "bundleId": "5a57e977942c6d1e61d32f14",
+  "expectedValues": [
+    {
+      "measure_id": "7B2A9277-43DA-4D99-9BEE-6AC271A07747",
+      "population_index": 0,
+      "IPP": 1,
+      "DENOM": 1,
+      "DENEX": 0,
+      "NUMER": 0
+    }
+  ],
+  "familyName": "Denex",
+  "givenNames": [
+    "Fail_Hospice_Not_Performed"
+  ],
+  "notes": "",
+  "qdmPatient": {
+    "_id": "5c88013ad7c8ac4c3e1065e3",
+    "birthDatetime": "1937-07-01T08:00:00.000+00:00",
+    "dataElements": [
+      {
+        "_id": "5c88013ad7c8ac4c3e1065e4",
+        "anatomicalLocationSite": null,
+        "authorDatetime": "1949-02-17T09:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "190372001"
+          }
+        ],
+        "description": "Diagnosis: Diabetes",
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.110",
+        "id": {
+          "_id": "5c88013ad7c8ac4c3e1065e5",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5aeb7764b848463d625b3424"
+        },
+        "prevalencePeriod": {
+          "low": "1949-02-17T09:00:00.000+00:00",
+          "high": "9999-12-31T23:59:59.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "qdmCategory": "condition",
+        "qdmVersion": "5.4",
+        "qrdaOid": "2.16.840.1.113883.10.20.24.3.135",
+        "severity": null,
+        "_type": "QDM::Diagnosis"
+      },
+      {
+        "_id": "5c88013ad7c8ac4c3e1065e6",
+        "admissionSource": null,
+        "authorDatetime": "2012-02-02T08:45:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "HCPCS",
+            "code": "G0438"
+          }
+        ],
+        "description": "Encounter, Performed: Annual Wellness Visit",
+        "diagnoses": [
+
+        ],
+        "dischargeDisposition": null,
+        "facilityLocations": [
+
+        ],
+        "hqmfOid": "2.16.840.1.113883.3.560.1.79",
+        "id": {
+          "_id": "5c88013ad7c8ac4c3e1065e7",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5aeb7764b848463d625b3425"
+        },
+        "lengthOfStay": {
+          "value": 0,
+          "unit": "days"
+        },
+        "negationRationale": null,
+        "principalDiagnosis": null,
+        "qdmCategory": "encounter",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "relevantPeriod": {
+          "low": "2012-02-02T08:45:00.000+00:00",
+          "high": "2012-02-02T08:45:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "_type": "QDM::EncounterPerformed"
+      },
+      {
+        "_id": "5c88013ad7c8ac4c3e1065e8",
+        "authorDatetime": "2012-01-31T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "385763009"
+          }
+        ],
+        "description": "Intervention, Order: Hospice care ambulatory",
+        "hqmfOid": "2.16.840.1.113883.3.560.1.145",
+        "id": {
+          "_id": "5c88013ad7c8ac4c3e1065e9",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5aeb7764b848463d625b3426"
+        },
+        "negationRationale": {
+          "code": "4525004",
+          "codeSystem": "SNOMED-CT",
+          "descriptor": null,
+          "codeSystemOid": null,
+          "version": null
+        },
+        "qdmCategory": "intervention",
+        "qdmStatus": "order",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "_type": "QDM::InterventionOrder"
+      },
+      {
+        "_id": "5c88013ad7c8ac4c3e1065de",
+        "birthDatetime": "1937-07-01T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "code": "21112-8",
+            "codeSystem": "LOINC",
+            "descriptor": null,
+            "codeSystemOid": null,
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.54",
+        "id": {
+          "_id": "5c88013ad7c8ac4c3e1065ea",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013ad7c8ac4c3e1065de"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "birthdate",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicBirthdate"
+      },
+      {
+        "_id": "5c88013ad7c8ac4c3e1065df",
+        "dataElementCodes": [
+          {
+            "code": "2186-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "Not Hispanic or Latino",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.56",
+        "id": {
+          "_id": "5c88013ad7c8ac4c3e1065eb",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013ad7c8ac4c3e1065df"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "ethnicity",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicEthnicity"
+      },
+      {
+        "_id": "5c88013ad7c8ac4c3e1065e0",
+        "dataElementCodes": [
+          {
+            "code": "1002-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "American Indian or Alaska Native",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.59",
+        "id": {
+          "_id": "5c88013ad7c8ac4c3e1065ec",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013ad7c8ac4c3e1065e0"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "race",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicRace"
+      },
+      {
+        "_id": "5c88013ad7c8ac4c3e1065e1",
+        "dataElementCodes": [
+          {
+            "code": "F",
+            "codeSystem": "AdministrativeGender",
+            "descriptor": "F",
+            "codeSystemOid": "2.16.840.1.113883.5.1",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.55",
+        "id": {
+          "_id": "5c88013ad7c8ac4c3e1065ed",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013ad7c8ac4c3e1065e1"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "gender",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicSex"
+      }
+    ],
+    "extendedData": {
+      "type": null,
+      "measure_ids": [
+        "7B2A9277-43DA-4D99-9BEE-6AC271A07747",
+        null
+      ],
+      "source_data_criteria": [
+        {
+          "negation": false,
+          "definition": "diagnosis",
+          "title": "Diabetes",
+          "description": "Diagnosis: Diabetes",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.103.12.1001",
+          "type": "conditions",
+          "id": "Diabetes_Diagnosis_40280381_3d61_56a7_013e_62abf57d3006_source",
+          "start_date": -658594800000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "7B2A9277-43DA-4D99-9BEE-6AC271A07747",
+          "cms_id": "CMS134v6",
+          "criteria_id": "160eb64a4ffoq",
+          "codes": {
+            "SNOMED-CT": [
+              "190372001"
+            ]
+          },
+          "coded_entry_id": {
+            "$oid": "5aeb7764b848463d625b3424"
+          },
+          "code_source": "USER_DEFINED"
+        },
+        {
+          "negation": true,
+          "definition": "intervention",
+          "status": "ordered",
+          "title": "Hospicecareambulatory",
+          "description": "Intervention, Order: Hospice care ambulatory",
+          "code_list_id": "2.16.840.1.113762.1.4.1108.15",
+          "type": "interventions",
+          "id": "Hospicecareambulatory_InterventionOrder_95cca057_9695_4ee4_a5bd_eff4b54c6098_source",
+          "start_date": 1327996800000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "7B2A9277-43DA-4D99-9BEE-6AC271A07747",
+          "cms_id": "CMS134v6",
+          "criteria_id": "161537f0ab83k",
+          "codes": {
+            "SNOMED-CT": [
+              "385763009"
+            ]
+          },
+          "negation_code_list_id": "2.16.840.1.113883.3.117.1.7.1.292",
+          "coded_entry_id": {
+            "$oid": "5aeb7764b848463d625b3426"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "encounter",
+          "status": "performed",
+          "title": "AnnualWellnessVisit",
+          "description": "Encounter, Performed: Annual Wellness Visit",
+          "code_list_id": "2.16.840.1.113883.3.526.3.1240",
+          "type": "encounters",
+          "id": "AnnualWellnessVisit_EncounterPerformed_40280381_3d61_56a7_013e_62abf57e3022_source",
+          "start_date": 1328172300000,
+          "end_date": 1328172300000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "7B2A9277-43DA-4D99-9BEE-6AC271A07747",
+          "cms_id": "CMS134v6",
+          "criteria_id": "160eb65f2eaz2",
+          "codes": {
+            "HCPCS": [
+              "G0438"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5aeb7764b848463d625b3425"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "id": "MeasurePeriod",
+          "start_date": 0,
+          "end_date": 0,
+          "references": null
+        }
+      ],
+      "is_shared": null,
+      "origin_data": [
+
+      ],
+      "test_id": null,
+      "medical_record_number": "07490a6ba93a8d1d0252541c260e02e7f7efdaae5ef3613011dff6ce4c0dbd42",
+      "medical_record_assigner": "Bonnie",
+      "description": null,
+      "description_category": null,
+      "insurance_providers": "[]"
+    },
+    "qdmVersion": "5.4"
+  }
+}

--- a/spec/javascripts/fixtures/json/patients/CMS136v7/Pass_IPP1.json
+++ b/spec/javascripts/fixtures/json/patients/CMS136v7/Pass_IPP1.json
@@ -1,0 +1,313 @@
+{
+  "_id": "5a7dc63db8484620c5183d39",
+  "bundleId": "5a57e977942c6d1e61d32f14",
+  "expectedValues": [
+    {
+      "measure_id": "703CC49B-B653-4885-80E8-245A057F5AE9",
+      "population_index": 0,
+      "IPP": 1,
+      "DENOM": 1,
+      "DENEX": 0,
+      "NUMER": 1
+    },
+    {
+      "measure_id": "703CC49B-B653-4885-80E8-245A057F5AE9",
+      "population_index": 1,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    }
+  ],
+  "familyName": "IPP1",
+  "givenNames": [
+    "Pass"
+  ],
+  "notes": "",
+  "qdmPatient": {
+    "_id": "5c88013ed7c8ac4c3e10669b",
+    "birthDatetime": "2005-02-01T08:00:00.000+00:00",
+    "dataElements": [
+      {
+        "_id": "5c88013ed7c8ac4c3e10669c",
+        "admissionSource": null,
+        "authorDatetime": "2012-02-09T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "185463005"
+          },
+          {
+            "codeSystem": "CPT",
+            "code": "99201"
+          }
+        ],
+        "description": "Encounter, Performed: Office Visit",
+        "diagnoses": [
+
+        ],
+        "dischargeDisposition": null,
+        "facilityLocations": [
+
+        ],
+        "hqmfOid": "2.16.840.1.113883.3.560.1.79",
+        "id": {
+          "_id": "5c88013ed7c8ac4c3e10669d",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5aeb7734b848463d625b2038"
+        },
+        "lengthOfStay": {
+          "value": 0,
+          "unit": "days"
+        },
+        "negationRationale": null,
+        "principalDiagnosis": null,
+        "qdmCategory": "encounter",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "relevantPeriod": {
+          "low": "2012-02-09T08:00:00.000+00:00",
+          "high": "2012-02-09T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "_type": "QDM::EncounterPerformed"
+      },
+      {
+        "_id": "5c88013ed7c8ac4c3e10669e",
+        "authorDatetime": "2012-02-09T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "RxNorm",
+            "code": "1006608"
+          }
+        ],
+        "daysSupplied": null,
+        "description": "Medication, Dispensed: ADHD Medications",
+        "dispenserId": null,
+        "dosage": null,
+        "frequency": null,
+        "hqmfOid": "2.16.840.1.113883.3.560.1.8",
+        "id": {
+          "_id": "5c88013ed7c8ac4c3e10669f",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5aeb7734b848463d625b2039"
+        },
+        "negationRationale": null,
+        "prescriberId": null,
+        "qdmCategory": "medication",
+        "qdmStatus": "dispensed",
+        "qdmVersion": "5.4",
+        "refills": null,
+        "relevantPeriod": {
+          "low": "2012-02-09T08:00:00.000+00:00",
+          "high": "2012-02-09T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "route": null,
+        "supply": null,
+        "_type": "QDM::MedicationDispensed"
+      },
+      {
+        "_id": "5c88013ed7c8ac4c3e106696",
+        "birthDatetime": "2005-02-01T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "code": "21112-8",
+            "codeSystem": "LOINC",
+            "descriptor": null,
+            "codeSystemOid": null,
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.54",
+        "id": {
+          "_id": "5c88013ed7c8ac4c3e1066a0",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013ed7c8ac4c3e106696"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "birthdate",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicBirthdate"
+      },
+      {
+        "_id": "5c88013ed7c8ac4c3e106697",
+        "dataElementCodes": [
+          {
+            "code": "2186-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "Not Hispanic or Latino",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.56",
+        "id": {
+          "_id": "5c88013ed7c8ac4c3e1066a1",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013ed7c8ac4c3e106697"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "ethnicity",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicEthnicity"
+      },
+      {
+        "_id": "5c88013ed7c8ac4c3e106698",
+        "dataElementCodes": [
+          {
+            "code": "1002-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "American Indian or Alaska Native",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.59",
+        "id": {
+          "_id": "5c88013ed7c8ac4c3e1066a2",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013ed7c8ac4c3e106698"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "race",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicRace"
+      },
+      {
+        "_id": "5c88013ed7c8ac4c3e106699",
+        "dataElementCodes": [
+          {
+            "code": "M",
+            "codeSystem": "AdministrativeGender",
+            "descriptor": "M",
+            "codeSystemOid": "2.16.840.1.113883.5.1",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.55",
+        "id": {
+          "_id": "5c88013ed7c8ac4c3e1066a3",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013ed7c8ac4c3e106699"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "gender",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicSex"
+      }
+    ],
+    "extendedData": {
+      "type": null,
+      "measure_ids": [
+        "703CC49B-B653-4885-80E8-245A057F5AE9",
+        null
+      ],
+      "source_data_criteria": [
+        {
+          "negation": false,
+          "definition": "encounter",
+          "status": "performed",
+          "title": "OfficeVisit",
+          "description": "Encounter, Performed: Office Visit",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.101.12.1001",
+          "type": "encounters",
+          "id": "OfficeVisit_EncounterPerformed_40280381_3d61_56a7_013e_62e0524536ae_source",
+          "start_date": 1328774400000,
+          "end_date": 1328775300000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "703CC49B-B653-4885-80E8-245A057F5AE9",
+          "cms_id": "CMS136v7",
+          "criteria_id": "1617b4e4764Cu",
+          "codes": {
+            "SNOMED-CT": [
+              "185463005"
+            ],
+            "CPT": [
+              "99201"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5aeb7734b848463d625b2038"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "medication",
+          "status": "dispensed",
+          "title": "ADHDMedications",
+          "description": "Medication, Dispensed: ADHD Medications",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.196.12.1171",
+          "type": "medications",
+          "id": "ADHDMedications_MedicationDispensed_40280381_3d61_56a7_013e_62e0524536a7_source",
+          "start_date": 1328774400000,
+          "end_date": 1328775300000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "703CC49B-B653-4885-80E8-245A057F5AE9",
+          "cms_id": "CMS136v7",
+          "criteria_id": "1617b4e684fqB",
+          "codes": {
+            "RxNorm": [
+              "1006608"
+            ]
+          },
+          "fulfillments": null,
+          "dose_value": "",
+          "dose_unit": "{Capsule}",
+          "frequency_value": "",
+          "frequency_unit": "min",
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5aeb7734b848463d625b2039"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "id": "MeasurePeriod",
+          "start_date": 0,
+          "end_date": 0,
+          "references": null
+        }
+      ],
+      "is_shared": null,
+      "origin_data": [
+
+      ],
+      "test_id": null,
+      "medical_record_number": "b7ad2cc9e2a89ba7961791d541d1fd41970d60549e86ec25038e859fcab42ae0",
+      "medical_record_assigner": "Bonnie",
+      "description": null,
+      "description_category": null,
+      "insurance_providers": "[]"
+    },
+    "qdmVersion": "5.4"
+  }
+}

--- a/spec/javascripts/fixtures/json/patients/CMS136v7/Pass_IPP2.json
+++ b/spec/javascripts/fixtures/json/patients/CMS136v7/Pass_IPP2.json
@@ -1,0 +1,378 @@
+{
+  "_id": "5a7dc67fb8484620c5183d68",
+  "bundleId": "5a57e977942c6d1e61d32f14",
+  "expectedValues": [
+    {
+      "measure_id": "703CC49B-B653-4885-80E8-245A057F5AE9",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "703CC49B-B653-4885-80E8-245A057F5AE9",
+      "population_index": 1,
+      "IPP": 1,
+      "DENOM": 1,
+      "DENEX": 1,
+      "NUMER": 0
+    }
+  ],
+  "familyName": "IPP2",
+  "givenNames": [
+    "Pass"
+  ],
+  "notes": "",
+  "qdmPatient": {
+    "_id": "5c88013ed7c8ac4c3e1066a9",
+    "birthDatetime": "2005-02-02T08:00:00.000+00:00",
+    "dataElements": [
+      {
+        "_id": "5c88013ed7c8ac4c3e1066aa",
+        "admissionSource": null,
+        "authorDatetime": "2012-02-09T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "185463005"
+          },
+          {
+            "codeSystem": "CPT",
+            "code": "99201"
+          }
+        ],
+        "description": "Encounter, Performed: Office Visit",
+        "diagnoses": [
+
+        ],
+        "dischargeDisposition": null,
+        "facilityLocations": [
+
+        ],
+        "hqmfOid": "2.16.840.1.113883.3.560.1.79",
+        "id": {
+          "_id": "5c88013ed7c8ac4c3e1066ab",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5aeb7734b848463d625b203a"
+        },
+        "lengthOfStay": {
+          "value": 0,
+          "unit": "days"
+        },
+        "negationRationale": null,
+        "principalDiagnosis": null,
+        "qdmCategory": "encounter",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "relevantPeriod": {
+          "low": "2012-02-09T08:00:00.000+00:00",
+          "high": "2012-02-09T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "_type": "QDM::EncounterPerformed"
+      },
+      {
+        "_id": "5c88013ed7c8ac4c3e1066ac",
+        "authorDatetime": "2012-02-09T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "RxNorm",
+            "code": "1006608"
+          }
+        ],
+        "daysSupplied": null,
+        "description": "Medication, Dispensed: ADHD Medications",
+        "dispenserId": null,
+        "dosage": null,
+        "frequency": null,
+        "hqmfOid": "2.16.840.1.113883.3.560.1.8",
+        "id": {
+          "_id": "5c88013ed7c8ac4c3e1066ad",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5aeb7734b848463d625b203b"
+        },
+        "negationRationale": null,
+        "prescriberId": null,
+        "qdmCategory": "medication",
+        "qdmStatus": "dispensed",
+        "qdmVersion": "5.4",
+        "refills": null,
+        "relevantPeriod": {
+          "low": "2012-02-09T08:00:00.000+00:00",
+          "high": "2012-02-09T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "route": null,
+        "supply": null,
+        "_type": "QDM::MedicationDispensed"
+      },
+      {
+        "_id": "5c88013ed7c8ac4c3e1066ae",
+        "dataElementCodes": [
+          {
+            "codeSystem": "RxNorm",
+            "code": "1006608"
+          }
+        ],
+        "description": "Medication, Active: ADHD Medications",
+        "dosage": null,
+        "frequency": null,
+        "hqmfOid": "2.16.840.1.113883.3.560.1.13",
+        "id": {
+          "_id": "5c88013ed7c8ac4c3e1066af",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5aeb7734b848463d625b203c"
+        },
+        "qdmCategory": "medication",
+        "qdmStatus": "active",
+        "qdmVersion": "5.4",
+        "relevantPeriod": {
+          "low": "2012-02-09T08:00:00.000+00:00",
+          "high": "2012-12-09T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "route": null,
+        "_type": "QDM::MedicationActive"
+      },
+      {
+        "_id": "5c88013ed7c8ac4c3e1066a4",
+        "birthDatetime": "2005-02-02T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "code": "21112-8",
+            "codeSystem": "LOINC",
+            "descriptor": null,
+            "codeSystemOid": null,
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.54",
+        "id": {
+          "_id": "5c88013ed7c8ac4c3e1066b0",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013ed7c8ac4c3e1066a4"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "birthdate",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicBirthdate"
+      },
+      {
+        "_id": "5c88013ed7c8ac4c3e1066a5",
+        "dataElementCodes": [
+          {
+            "code": "2186-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "Not Hispanic or Latino",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.56",
+        "id": {
+          "_id": "5c88013ed7c8ac4c3e1066b1",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013ed7c8ac4c3e1066a5"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "ethnicity",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicEthnicity"
+      },
+      {
+        "_id": "5c88013ed7c8ac4c3e1066a6",
+        "dataElementCodes": [
+          {
+            "code": "1002-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "American Indian or Alaska Native",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.59",
+        "id": {
+          "_id": "5c88013ed7c8ac4c3e1066b2",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013ed7c8ac4c3e1066a6"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "race",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicRace"
+      },
+      {
+        "_id": "5c88013ed7c8ac4c3e1066a7",
+        "dataElementCodes": [
+          {
+            "code": "M",
+            "codeSystem": "AdministrativeGender",
+            "descriptor": "M",
+            "codeSystemOid": "2.16.840.1.113883.5.1",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.55",
+        "id": {
+          "_id": "5c88013ed7c8ac4c3e1066b3",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013ed7c8ac4c3e1066a7"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "gender",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicSex"
+      }
+    ],
+    "extendedData": {
+      "type": null,
+      "measure_ids": [
+        "703CC49B-B653-4885-80E8-245A057F5AE9",
+        null
+      ],
+      "source_data_criteria": [
+        {
+          "negation": false,
+          "definition": "encounter",
+          "status": "performed",
+          "title": "OfficeVisit",
+          "description": "Encounter, Performed: Office Visit",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.101.12.1001",
+          "type": "encounters",
+          "id": "OfficeVisit_EncounterPerformed_40280381_3d61_56a7_013e_62e0524536ae_source",
+          "start_date": 1328774400000,
+          "end_date": 1328775300000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "703CC49B-B653-4885-80E8-245A057F5AE9",
+          "cms_id": "CMS136v7",
+          "criteria_id": "1617b4f2f27a5",
+          "codes": {
+            "SNOMED-CT": [
+              "185463005"
+            ],
+            "CPT": [
+              "99201"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5aeb7734b848463d625b203a"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "medication",
+          "status": "dispensed",
+          "title": "ADHDMedications",
+          "description": "Medication, Dispensed: ADHD Medications",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.196.12.1171",
+          "type": "medications",
+          "id": "ADHDMedications_MedicationDispensed_40280381_3d61_56a7_013e_62e0524536a7_source",
+          "start_date": 1328774400000,
+          "end_date": 1328775300000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "703CC49B-B653-4885-80E8-245A057F5AE9",
+          "cms_id": "CMS136v7",
+          "criteria_id": "1617b4f4941uT",
+          "codes": {
+            "RxNorm": [
+              "1006608"
+            ]
+          },
+          "fulfillments": null,
+          "dose_value": "",
+          "dose_unit": "{Capsule}",
+          "frequency_value": "",
+          "frequency_unit": "min",
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5aeb7734b848463d625b203b"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "medication",
+          "status": "active",
+          "title": "ADHDMedications",
+          "description": "Medication, Active: ADHD Medications",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.196.12.1171",
+          "type": "medications",
+          "id": "ADHDMedications_MedicationActive_40280381_3d61_56a7_013e_62e0524536a7_source",
+          "start_date": 1328774400000,
+          "end_date": 1355040900000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "703CC49B-B653-4885-80E8-245A057F5AE9",
+          "cms_id": "CMS136v7",
+          "criteria_id": "1617b4f5d84zD",
+          "codes": {
+            "RxNorm": [
+              "1006608"
+            ]
+          },
+          "fulfillments": null,
+          "dose_value": "",
+          "dose_unit": "{Capsule}",
+          "frequency_value": "",
+          "frequency_unit": "min",
+          "coded_entry_id": {
+            "$oid": "5aeb7734b848463d625b203c"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "id": "MeasurePeriod",
+          "start_date": 0,
+          "end_date": 0,
+          "references": null
+        }
+      ],
+      "is_shared": null,
+      "origin_data": [
+
+      ],
+      "test_id": null,
+      "medical_record_number": "978377cb9abfa822ea7943ce0ac537f2638722c872dcb77b05b86b106367455a",
+      "medical_record_assigner": "Bonnie",
+      "description": null,
+      "description_category": null,
+      "insurance_providers": "[]"
+    },
+    "qdmVersion": "5.4"
+  }
+}

--- a/spec/javascripts/fixtures/json/patients/CMS146v6/Pass_IPP.json
+++ b/spec/javascripts/fixtures/json/patients/CMS146v6/Pass_IPP.json
@@ -1,0 +1,371 @@
+{
+  "_id": "5a7dc601b8484620c5183d15",
+  "bundleId": "5a57e977942c6d1e61d32f14",
+  "expectedValues": [
+    {
+      "measure_id": "BEB1C33C-2549-4E7F-9567-05ED38448464",
+      "population_index": 0,
+      "IPP": 1,
+      "DENOM": 1,
+      "DENEX": 0,
+      "NUMER": 0
+    }
+  ],
+  "familyName": "IPP",
+  "givenNames": [
+    "Pass"
+  ],
+  "notes": "",
+  "qdmPatient": {
+    "_id": "5c88013ed7c8ac4c3e10668b",
+    "birthDatetime": "2000-02-01T08:00:00.000+00:00",
+    "dataElements": [
+      {
+        "_id": "5c88013ed7c8ac4c3e10668c",
+        "anatomicalLocationSite": null,
+        "authorDatetime": "2012-02-07T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "1532007"
+          },
+          {
+            "codeSystem": "ICD-10-CM",
+            "code": "J02.0"
+          }
+        ],
+        "description": "Diagnosis: Acute Pharyngitis",
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.110",
+        "id": {
+          "_id": "5c88013ed7c8ac4c3e10668d",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5aeb77d7b848463d625b60da"
+        },
+        "prevalencePeriod": {
+          "low": "2012-02-07T08:00:00.000+00:00",
+          "high": "2012-02-09T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "qdmCategory": "condition",
+        "qdmVersion": "5.4",
+        "qrdaOid": "2.16.840.1.113883.10.20.24.3.135",
+        "severity": null,
+        "_type": "QDM::Diagnosis"
+      },
+      {
+        "_id": "5c88013ed7c8ac4c3e10668e",
+        "admissionSource": null,
+        "authorDatetime": "2012-02-07T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "12843005"
+          },
+          {
+            "codeSystem": "CPT",
+            "code": "99201"
+          }
+        ],
+        "description": "Encounter, Performed: Ambulatory/ED Visit",
+        "diagnoses": [
+
+        ],
+        "dischargeDisposition": null,
+        "facilityLocations": [
+
+        ],
+        "hqmfOid": "2.16.840.1.113883.3.560.1.79",
+        "id": {
+          "_id": "5c88013ed7c8ac4c3e10668f",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5aeb77d7b848463d625b60db"
+        },
+        "lengthOfStay": {
+          "value": 2,
+          "unit": "days"
+        },
+        "negationRationale": null,
+        "principalDiagnosis": null,
+        "qdmCategory": "encounter",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "relevantPeriod": {
+          "low": "2012-02-07T08:00:00.000+00:00",
+          "high": "2012-02-09T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "_type": "QDM::EncounterPerformed"
+      },
+      {
+        "_id": "5c88013ed7c8ac4c3e106690",
+        "authorDatetime": "2012-02-09T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "RxNorm",
+            "code": "1013659"
+          }
+        ],
+        "daysSupplied": null,
+        "description": "Medication, Order: Antibiotic Medications for Pharyngitis",
+        "dosage": null,
+        "frequency": null,
+        "hqmfOid": "2.16.840.1.113883.3.560.1.17",
+        "id": {
+          "_id": "5c88013ed7c8ac4c3e106691",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5aeb77d7b848463d625b60dc"
+        },
+        "negationRationale": null,
+        "prescriberId": null,
+        "qdmCategory": "medication",
+        "qdmStatus": "order",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "refills": null,
+        "relevantPeriod": {
+          "low": "2012-02-09T08:00:00.000+00:00",
+          "high": "2012-02-09T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "route": null,
+        "setting": null,
+        "supply": null,
+        "_type": "QDM::MedicationOrder"
+      },
+      {
+        "_id": "5c88013ed7c8ac4c3e106686",
+        "birthDatetime": "2000-02-01T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "code": "21112-8",
+            "codeSystem": "LOINC",
+            "descriptor": null,
+            "codeSystemOid": null,
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.54",
+        "id": {
+          "_id": "5c88013ed7c8ac4c3e106692",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013ed7c8ac4c3e106686"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "birthdate",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicBirthdate"
+      },
+      {
+        "_id": "5c88013ed7c8ac4c3e106687",
+        "dataElementCodes": [
+          {
+            "code": "2186-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "Not Hispanic or Latino",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.56",
+        "id": {
+          "_id": "5c88013ed7c8ac4c3e106693",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013ed7c8ac4c3e106687"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "ethnicity",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicEthnicity"
+      },
+      {
+        "_id": "5c88013ed7c8ac4c3e106688",
+        "dataElementCodes": [
+          {
+            "code": "1002-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "American Indian or Alaska Native",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.59",
+        "id": {
+          "_id": "5c88013ed7c8ac4c3e106694",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013ed7c8ac4c3e106688"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "race",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicRace"
+      },
+      {
+        "_id": "5c88013ed7c8ac4c3e106689",
+        "dataElementCodes": [
+          {
+            "code": "M",
+            "codeSystem": "AdministrativeGender",
+            "descriptor": "M",
+            "codeSystemOid": "2.16.840.1.113883.5.1",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.55",
+        "id": {
+          "_id": "5c88013ed7c8ac4c3e106695",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013ed7c8ac4c3e106689"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "gender",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicSex"
+      }
+    ],
+    "extendedData": {
+      "type": null,
+      "measure_ids": [
+        "BEB1C33C-2549-4E7F-9567-05ED38448464",
+        null
+      ],
+      "source_data_criteria": [
+        {
+          "negation": false,
+          "definition": "encounter",
+          "status": "performed",
+          "title": "Ambulatory/EDVisit",
+          "description": "Encounter, Performed: Ambulatory/ED Visit",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.101.12.1061",
+          "type": "encounters",
+          "id": "Ambulatory_EDVisit_EncounterPerformed_a6c00a1e_e319_498e_9b26_ff64eded029a_source",
+          "start_date": 1328601600000,
+          "end_date": 1328775300000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "BEB1C33C-2549-4E7F-9567-05ED38448464",
+          "cms_id": "CMS146v6",
+          "criteria_id": "1617b4cdc0bbk",
+          "codes": {
+            "SNOMED-CT": [
+              "12843005"
+            ],
+            "CPT": [
+              "99201"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5aeb77d7b848463d625b60db"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "diagnosis",
+          "title": "AcutePharyngitis",
+          "description": "Diagnosis: Acute Pharyngitis",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.102.12.1011",
+          "type": "conditions",
+          "id": "AcutePharyngitis_Diagnosis_178608ed_404c_4278_be24_3ad6b726d0f3_source",
+          "start_date": 1328601600000,
+          "end_date": 1328775300000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "BEB1C33C-2549-4E7F-9567-05ED38448464",
+          "cms_id": "CMS146v6",
+          "criteria_id": "1617b4d2c77l0",
+          "codes": {
+            "SNOMED-CT": [
+              "1532007"
+            ],
+            "ICD-10-CM": [
+              "J02.0"
+            ]
+          },
+          "coded_entry_id": {
+            "$oid": "5aeb77d7b848463d625b60da"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "medication",
+          "status": "ordered",
+          "title": "AntibioticMedicationsforPharyngitis",
+          "description": "Medication, Order: Antibiotic Medications for Pharyngitis",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.196.12.1001",
+          "type": "medications",
+          "id": "AntibioticMedicationsforPharyngitis_MedicationOrder_40280381_3d61_56a7_013e_5d1ef9ce6a5b_source",
+          "start_date": 1328774400000,
+          "end_date": 1328775300000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "BEB1C33C-2549-4E7F-9567-05ED38448464",
+          "cms_id": "CMS146v6",
+          "criteria_id": "1617b4d3523e7",
+          "codes": {
+            "RxNorm": [
+              "1013659"
+            ]
+          },
+          "fulfillments": null,
+          "administrations_value": "",
+          "frequency_value": "",
+          "frequency_unit": "min",
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5aeb77d7b848463d625b60dc"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "id": "MeasurePeriod",
+          "start_date": 0,
+          "end_date": 0,
+          "references": null
+        }
+      ],
+      "is_shared": null,
+      "origin_data": [
+
+      ],
+      "test_id": null,
+      "medical_record_number": "12580b7c221836aac3202ea2d5813c6172d6f05b972c94c0d234921f43523f98",
+      "medical_record_assigner": "Bonnie",
+      "description": null,
+      "description_category": null,
+      "insurance_providers": "[]"
+    },
+    "qdmVersion": "5.4"
+  }
+}

--- a/spec/javascripts/fixtures/json/patients/CMS158v6/Fail_IPP.json
+++ b/spec/javascripts/fixtures/json/patients/CMS158v6/Fail_IPP.json
@@ -1,0 +1,236 @@
+{
+  "_id": "5a9ee161b84846563e7d57e3",
+  "bundleId": "5a57e977942c6d1e61d32f14",
+  "expectedValues": [
+    {
+      "measure_id": "3BBFC929-50C8-44B8-8D34-82BE75C08A70",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "NUMER": 0,
+      "DENEXCEP": 0
+    }
+  ],
+  "familyName": "IPP",
+  "givenNames": [
+    "Fail"
+  ],
+  "notes": "",
+  "qdmPatient": {
+    "_id": "5c880139d7c8ac4c3e1065d7",
+    "birthDatetime": "1984-06-21T08:00:00.000+00:00",
+    "dataElements": [
+      {
+        "_id": "5c880139d7c8ac4c3e1065d8",
+        "anatomicalLocationSite": null,
+        "authorDatetime": "2012-03-06T08:00:00.000+00:00",
+        "components": [
+
+        ],
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "10745001"
+          },
+          {
+            "codeSystem": "ICD-10-PCS",
+            "code": "10D00Z0"
+          },
+          {
+            "codeSystem": "CPT",
+            "code": "59400"
+          }
+        ],
+        "description": "Procedure, Performed: Delivery - Procedure",
+        "hqmfOid": "2.16.840.1.113883.3.560.1.6",
+        "id": {
+          "_id": "5c880139d7c8ac4c3e1065d9",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5aeb77a2b848463d625b4c6f"
+        },
+        "incisionDatetime": null,
+        "method": null,
+        "negationRationale": null,
+        "ordinality": null,
+        "qdmCategory": "procedure",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "relevantPeriod": {
+          "low": "2012-03-06T08:00:00.000+00:00",
+          "high": "2012-03-06T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "result": null,
+        "status": null,
+        "_type": "QDM::ProcedurePerformed"
+      },
+      {
+        "_id": "5c880139d7c8ac4c3e1065d2",
+        "birthDatetime": "1984-06-21T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "code": "21112-8",
+            "codeSystem": "LOINC",
+            "descriptor": null,
+            "codeSystemOid": null,
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.54",
+        "id": {
+          "_id": "5c880139d7c8ac4c3e1065da",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880139d7c8ac4c3e1065d2"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "birthdate",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicBirthdate"
+      },
+      {
+        "_id": "5c880139d7c8ac4c3e1065d3",
+        "dataElementCodes": [
+          {
+            "code": "2186-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "Not Hispanic or Latino",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.56",
+        "id": {
+          "_id": "5c880139d7c8ac4c3e1065db",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880139d7c8ac4c3e1065d3"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "ethnicity",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicEthnicity"
+      },
+      {
+        "_id": "5c880139d7c8ac4c3e1065d4",
+        "dataElementCodes": [
+          {
+            "code": "1002-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "American Indian or Alaska Native",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.59",
+        "id": {
+          "_id": "5c880139d7c8ac4c3e1065dc",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880139d7c8ac4c3e1065d4"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "race",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicRace"
+      },
+      {
+        "_id": "5c880139d7c8ac4c3e1065d5",
+        "dataElementCodes": [
+          {
+            "code": "F",
+            "codeSystem": "AdministrativeGender",
+            "descriptor": "F",
+            "codeSystemOid": "2.16.840.1.113883.5.1",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.55",
+        "id": {
+          "_id": "5c880139d7c8ac4c3e1065dd",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880139d7c8ac4c3e1065d5"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "gender",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicSex"
+      }
+    ],
+    "extendedData": {
+      "type": null,
+      "measure_ids": [
+        "3BBFC929-50C8-44B8-8D34-82BE75C08A70",
+        null
+      ],
+      "source_data_criteria": [
+        {
+          "negation": false,
+          "definition": "procedure",
+          "status": "performed",
+          "title": "Delivery-Procedure",
+          "description": "Procedure, Performed: Delivery - Procedure",
+          "code_list_id": "2.16.840.1.113762.1.4.1078.5",
+          "type": "procedures",
+          "id": "Delivery_Procedure_ProcedurePerformed_d55d2514_1421_44fb_98ca_195188229890_source",
+          "start_date": 1331020800000,
+          "end_date": 1331021700000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "3BBFC929-50C8-44B8-8D34-82BE75C08A70",
+          "cms_id": "CMS158v6",
+          "criteria_id": "161fc9fdd71rb",
+          "codes": {
+            "SNOMED-CT": [
+              "10745001"
+            ],
+            "ICD-10-PCS": [
+              "10D00Z0"
+            ],
+            "CPT": [
+              "59400"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5aeb77a2b848463d625b4c6f"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "id": "MeasurePeriod",
+          "start_date": 0,
+          "end_date": 0,
+          "references": null
+        }
+      ],
+      "is_shared": null,
+      "origin_data": [
+
+      ],
+      "test_id": null,
+      "medical_record_number": "9aa4af6addb9684b2dcb0d69b248031bdbea049c7cd8e8c7105417ab9dd6765e",
+      "medical_record_assigner": "Bonnie",
+      "description": null,
+      "description_category": null,
+      "insurance_providers": "[]"
+    },
+    "qdmVersion": "5.4"
+  }
+}

--- a/spec/javascripts/fixtures/json/patients/CMS158v6/Pass_Numer.json
+++ b/spec/javascripts/fixtures/json/patients/CMS158v6/Pass_Numer.json
@@ -1,0 +1,548 @@
+{
+  "_id": "5a58f275942c6d5479457994",
+  "bundleId": "5a57e977942c6d1e61d32f14",
+  "expectedValues": [
+    {
+      "measure_id": "3BBFC929-50C8-44B8-8D34-82BE75C08A70",
+      "population_index": 0,
+      "IPP": 1,
+      "DENOM": 1,
+      "NUMER": 1,
+      "DENEXCEP": 0
+    }
+  ],
+  "familyName": "Numer",
+  "givenNames": [
+    "Pass"
+  ],
+  "notes": "Based on NUMERPass 2Deliveries_MostRecentDeliveryNUMPass in epecqmtelligen@gmail.com",
+  "qdmPatient": {
+    "_id": "5c880138d7c8ac4c3e1065c1",
+    "birthDatetime": "1986-03-12T08:00:00.000+00:00",
+    "dataElements": [
+      {
+        "_id": "5c880138d7c8ac4c3e1065c2",
+        "anatomicalLocationSite": null,
+        "authorDatetime": "2012-01-11T06:50:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "102879009"
+          }
+        ],
+        "description": "Diagnosis: Delivery - Diagnosis",
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.110",
+        "id": {
+          "_id": "5c880138d7c8ac4c3e1065c3",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5aeb77c8b848463d625b5aab"
+        },
+        "prevalencePeriod": {
+          "low": "2012-01-11T06:50:00.000+00:00",
+          "high": "2012-01-11T09:25:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "qdmCategory": "condition",
+        "qdmVersion": "5.4",
+        "qrdaOid": "2.16.840.1.113883.10.20.24.3.135",
+        "severity": null,
+        "_type": "QDM::Diagnosis"
+      },
+      {
+        "_id": "5c880138d7c8ac4c3e1065c4",
+        "anatomicalLocationSite": null,
+        "authorDatetime": "2012-12-20T08:50:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "102879009"
+          }
+        ],
+        "description": "Diagnosis: Delivery - Diagnosis",
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.110",
+        "id": {
+          "_id": "5c880138d7c8ac4c3e1065c5",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5aeb77c8b848463d625b5aac"
+        },
+        "prevalencePeriod": {
+          "low": "2012-12-20T08:50:00.000+00:00",
+          "high": "2012-12-20T09:25:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "qdmCategory": "condition",
+        "qdmVersion": "5.4",
+        "qrdaOid": "2.16.840.1.113883.10.20.24.3.135",
+        "severity": null,
+        "_type": "QDM::Diagnosis"
+      },
+      {
+        "_id": "5c880138d7c8ac4c3e1065c6",
+        "anatomicalLocationSite": null,
+        "authorDatetime": "2012-01-10T09:30:00.000+00:00",
+        "components": [
+
+        ],
+        "dataElementCodes": [
+          {
+            "codeSystem": "ICD-10-PCS",
+            "code": "10D07Z6"
+          }
+        ],
+        "description": "Procedure, Performed: Delivery - Procedure",
+        "hqmfOid": "2.16.840.1.113883.3.560.1.6",
+        "id": {
+          "_id": "5c880138d7c8ac4c3e1065c7",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5aeb77c8b848463d625b5aad"
+        },
+        "incisionDatetime": null,
+        "method": null,
+        "negationRationale": null,
+        "ordinality": null,
+        "qdmCategory": "procedure",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "relevantPeriod": {
+          "low": "2012-01-10T09:30:00.000+00:00",
+          "high": "2012-01-10T11:30:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "result": null,
+        "status": null,
+        "_type": "QDM::ProcedurePerformed"
+      },
+      {
+        "_id": "5c880138d7c8ac4c3e1065c8",
+        "anatomicalLocationSite": null,
+        "authorDatetime": "2012-12-20T08:40:00.000+00:00",
+        "components": [
+
+        ],
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "5556001"
+          }
+        ],
+        "description": "Procedure, Performed: Delivery - Procedure",
+        "hqmfOid": "2.16.840.1.113883.3.560.1.6",
+        "id": {
+          "_id": "5c880138d7c8ac4c3e1065c9",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5aeb77c8b848463d625b5aae"
+        },
+        "incisionDatetime": null,
+        "method": null,
+        "negationRationale": null,
+        "ordinality": null,
+        "qdmCategory": "procedure",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "relevantPeriod": {
+          "low": "2012-12-20T08:40:00.000+00:00",
+          "high": "2012-12-20T11:55:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "result": null,
+        "status": null,
+        "_type": "QDM::ProcedurePerformed"
+      },
+      {
+        "_id": "5c880138d7c8ac4c3e1065ca",
+        "authorDatetime": "2011-12-20T08:00:00.000+00:00",
+        "components": [
+
+        ],
+        "dataElementCodes": [
+          {
+            "codeSystem": "LOINC",
+            "code": "5195-3"
+          }
+        ],
+        "description": "Laboratory Test, Performed: HBsAg",
+        "hqmfOid": "2.16.840.1.113883.3.560.1.5",
+        "id": {
+          "_id": "5c880138d7c8ac4c3e1065cb",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5aeb77c8b848463d625b5aaf"
+        },
+        "method": null,
+        "negationRationale": null,
+        "qdmCategory": "laboratory_test",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "referenceRange": null,
+        "relevantPeriod": {
+          "low": "2011-12-20T08:00:00.000+00:00",
+          "high": "2011-12-20T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "result": null,
+        "resultDatetime": null,
+        "status": null,
+        "_type": "QDM::LaboratoryTestPerformed"
+      },
+      {
+        "_id": "5c880138d7c8ac4c3e1065cc",
+        "authorDatetime": "2012-04-20T13:00:00.000+00:00",
+        "components": [
+
+        ],
+        "dataElementCodes": [
+          {
+            "codeSystem": "LOINC",
+            "code": "5195-3"
+          }
+        ],
+        "description": "Laboratory Test, Performed: HBsAg",
+        "hqmfOid": "2.16.840.1.113883.3.560.1.5",
+        "id": {
+          "_id": "5c880138d7c8ac4c3e1065cd",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5aeb77c8b848463d625b5ab0"
+        },
+        "method": null,
+        "negationRationale": null,
+        "qdmCategory": "laboratory_test",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "referenceRange": null,
+        "relevantPeriod": {
+          "low": "2012-04-20T13:00:00.000+00:00",
+          "high": "2012-04-20T13:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "result": null,
+        "resultDatetime": null,
+        "status": null,
+        "_type": "QDM::LaboratoryTestPerformed"
+      },
+      {
+        "_id": "5c880138d7c8ac4c3e1065bc",
+        "birthDatetime": "1986-03-12T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "code": "21112-8",
+            "codeSystem": "LOINC",
+            "descriptor": null,
+            "codeSystemOid": null,
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.54",
+        "id": {
+          "_id": "5c880138d7c8ac4c3e1065ce",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880138d7c8ac4c3e1065bc"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "birthdate",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicBirthdate"
+      },
+      {
+        "_id": "5c880138d7c8ac4c3e1065bd",
+        "dataElementCodes": [
+          {
+            "code": "2186-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "Not Hispanic or Latino",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.56",
+        "id": {
+          "_id": "5c880138d7c8ac4c3e1065cf",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880138d7c8ac4c3e1065bd"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "ethnicity",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicEthnicity"
+      },
+      {
+        "_id": "5c880138d7c8ac4c3e1065be",
+        "dataElementCodes": [
+          {
+            "code": "2131-1",
+            "codeSystem": "CDC Race",
+            "descriptor": "Other",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.59",
+        "id": {
+          "_id": "5c880138d7c8ac4c3e1065d0",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880138d7c8ac4c3e1065be"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "race",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicRace"
+      },
+      {
+        "_id": "5c880138d7c8ac4c3e1065bf",
+        "dataElementCodes": [
+          {
+            "code": "F",
+            "codeSystem": "AdministrativeGender",
+            "descriptor": "F",
+            "codeSystemOid": "2.16.840.1.113883.5.1",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.55",
+        "id": {
+          "_id": "5c880138d7c8ac4c3e1065d1",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880138d7c8ac4c3e1065bf"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "gender",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicSex"
+      }
+    ],
+    "extendedData": {
+      "type": null,
+      "measure_ids": [
+        "3BBFC929-50C8-44B8-8D34-82BE75C08A70",
+        null
+      ],
+      "source_data_criteria": [
+        {
+          "negation": false,
+          "definition": "laboratory_test",
+          "status": "performed",
+          "title": "HBsAg",
+          "description": "Laboratory Test, Performed: HBsAg",
+          "code_list_id": "2.16.840.1.113883.3.67.1.101.1.279",
+          "type": "laboratory_tests",
+          "id": "HBsAg_LaboratoryTestPerformed_40280381_3d61_56a7_013e_7f3878ec7630_source",
+          "start_date": 1324368000000,
+          "end_date": 1324368900000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "3BBFC929-50C8-44B8-8D34-82BE75C08A70",
+          "cms_id": "CMS158v6",
+          "criteria_id": "160eb6d07cciv",
+          "codes": {
+            "LOINC": [
+              "5195-3"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5aeb77c8b848463d625b5aaf"
+          },
+          "code_source": "USER_DEFINED"
+        },
+        {
+          "negation": false,
+          "definition": "procedure",
+          "status": "performed",
+          "title": "Delivery-Procedure",
+          "description": "Procedure, Performed: Delivery - Procedure",
+          "code_list_id": "2.16.840.1.113762.1.4.1078.5",
+          "type": "procedures",
+          "id": "Delivery_Procedure_ProcedurePerformed_d55d2514_1421_44fb_98ca_195188229890_source",
+          "start_date": 1326187800000,
+          "end_date": 1326195000000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "3BBFC929-50C8-44B8-8D34-82BE75C08A70",
+          "cms_id": "CMS158v6",
+          "criteria_id": "160eb6db935E3",
+          "codes": {
+            "ICD-10-PCS": [
+              "10D07Z6"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5aeb77c8b848463d625b5aad"
+          },
+          "code_source": "USER_DEFINED"
+        },
+        {
+          "negation": false,
+          "definition": "diagnosis",
+          "title": "Delivery-Diagnosis",
+          "description": "Diagnosis: Delivery - Diagnosis",
+          "code_list_id": "2.16.840.1.113883.3.67.1.101.1.278",
+          "type": "conditions",
+          "id": "Delivery_Diagnosis_Diagnosis_f9272c9f_18fc_4c40_a2bf_d3dfbc477434_source",
+          "start_date": 1326264600000,
+          "end_date": 1326273900000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "3BBFC929-50C8-44B8-8D34-82BE75C08A70",
+          "cms_id": "CMS158v6",
+          "criteria_id": "160eb6ef38dHK",
+          "codes": {
+            "SNOMED-CT": [
+              "102879009"
+            ]
+          },
+          "coded_entry_id": {
+            "$oid": "5aeb77c8b848463d625b5aab"
+          },
+          "code_source": "USER_DEFINED"
+        },
+        {
+          "negation": false,
+          "definition": "laboratory_test",
+          "status": "performed",
+          "title": "HBsAg",
+          "description": "Laboratory Test, Performed: HBsAg",
+          "code_list_id": "2.16.840.1.113883.3.67.1.101.1.279",
+          "type": "laboratory_tests",
+          "id": "HBsAg_LaboratoryTestPerformed_40280381_3d61_56a7_013e_7f3878ec7630_source",
+          "start_date": 1334926800000,
+          "end_date": 1334927700000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "3BBFC929-50C8-44B8-8D34-82BE75C08A70",
+          "cms_id": "CMS158v6",
+          "criteria_id": "160eb6faa51Be",
+          "codes": {
+            "LOINC": [
+              "5195-3"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5aeb77c8b848463d625b5ab0"
+          },
+          "code_source": "USER_DEFINED"
+        },
+        {
+          "negation": false,
+          "definition": "procedure",
+          "status": "performed",
+          "title": "Delivery-Procedure",
+          "description": "Procedure, Performed: Delivery - Procedure",
+          "code_list_id": "2.16.840.1.113762.1.4.1078.5",
+          "type": "procedures",
+          "id": "Delivery_Procedure_ProcedurePerformed_d55d2514_1421_44fb_98ca_195188229890_source",
+          "start_date": 1355992800000,
+          "end_date": 1356004500000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "3BBFC929-50C8-44B8-8D34-82BE75C08A70",
+          "cms_id": "CMS158v6",
+          "criteria_id": "160eb70b9fcZO",
+          "codes": {
+            "SNOMED-CT": [
+              "5556001"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5aeb77c8b848463d625b5aae"
+          },
+          "code_source": "USER_DEFINED"
+        },
+        {
+          "negation": false,
+          "definition": "diagnosis",
+          "title": "Delivery-Diagnosis",
+          "description": "Diagnosis: Delivery - Diagnosis",
+          "code_list_id": "2.16.840.1.113883.3.67.1.101.1.278",
+          "type": "conditions",
+          "id": "Delivery_Diagnosis_Diagnosis_f9272c9f_18fc_4c40_a2bf_d3dfbc477434_source",
+          "start_date": 1355993400000,
+          "end_date": 1355995500000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "3BBFC929-50C8-44B8-8D34-82BE75C08A70",
+          "cms_id": "CMS158v6",
+          "criteria_id": "160eb725935z5",
+          "codes": {
+            "SNOMED-CT": [
+              "102879009"
+            ]
+          },
+          "coded_entry_id": {
+            "$oid": "5aeb77c8b848463d625b5aac"
+          },
+          "code_source": "USER_DEFINED"
+        },
+        {
+          "id": "MeasurePeriod",
+          "start_date": 0,
+          "end_date": 0,
+          "references": null
+        }
+      ],
+      "is_shared": null,
+      "origin_data": [
+
+      ],
+      "test_id": null,
+      "medical_record_number": "c3fcbb95c7ae0994293afa4f6607fe2a29e7cb6c01e348917baa144b93328d47",
+      "medical_record_assigner": "Bonnie",
+      "description": null,
+      "description_category": null,
+      "insurance_providers": "[]"
+    },
+    "qdmVersion": "5.4"
+  }
+}

--- a/spec/javascripts/fixtures/json/patients/CMS160v6/Expired_DENEX.json
+++ b/spec/javascripts/fixtures/json/patients/CMS160v6/Expired_DENEX.json
@@ -1,0 +1,333 @@
+{
+  "_id": "5a9ee716b848465b0064f52c",
+  "bundleId": "5a57e977942c6d1e61d32f14",
+  "expectedValues": [
+    {
+      "measure_id": "A4B9763C-847E-4E02-BB7E-ACC596E90E2C",
+      "population_index": 0,
+      "IPP": 1,
+      "DENOM": 1,
+      "DENEX": 1,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "A4B9763C-847E-4E02-BB7E-ACC596E90E2C",
+      "population_index": 1,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "A4B9763C-847E-4E02-BB7E-ACC596E90E2C",
+      "population_index": 2,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    }
+  ],
+  "familyName": "DENEX",
+  "givenNames": [
+    "Expired"
+  ],
+  "notes": "",
+  "qdmPatient": {
+    "_id": "5c88013bd7c8ac4c3e106624",
+    "birthDatetime": "1970-01-01T08:00:00.000+00:00",
+    "dataElements": [
+      {
+        "_id": "5c88013bd7c8ac4c3e106625",
+        "anatomicalLocationSite": null,
+        "authorDatetime": "2012-04-12T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "19694002"
+          },
+          {
+            "codeSystem": "ICD-10-CM",
+            "code": "F34.1"
+          }
+        ],
+        "description": "Diagnosis: Dysthymia",
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.110",
+        "id": {
+          "_id": "5c88013bd7c8ac4c3e106626",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5aeb77a2b848463d625b4c70"
+        },
+        "prevalencePeriod": {
+          "low": "2012-04-12T08:00:00.000+00:00",
+          "high": "9999-12-31T23:59:59.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "qdmCategory": "condition",
+        "qdmVersion": "5.4",
+        "qrdaOid": "2.16.840.1.113883.10.20.24.3.135",
+        "severity": null,
+        "_type": "QDM::Diagnosis"
+      },
+      {
+        "_id": "5c88013bd7c8ac4c3e106627",
+        "admissionSource": null,
+        "authorDatetime": "2012-11-04T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "CPT",
+            "code": "99201"
+          }
+        ],
+        "description": "Encounter, Performed: Office Visit",
+        "diagnoses": [
+
+        ],
+        "dischargeDisposition": null,
+        "facilityLocations": [
+
+        ],
+        "hqmfOid": "2.16.840.1.113883.3.560.1.79",
+        "id": {
+          "_id": "5c88013bd7c8ac4c3e106628",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5aeb77a2b848463d625b4c71"
+        },
+        "lengthOfStay": {
+          "value": 0,
+          "unit": "days"
+        },
+        "negationRationale": null,
+        "principalDiagnosis": null,
+        "qdmCategory": "encounter",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "relevantPeriod": {
+          "low": "2012-11-04T08:00:00.000+00:00",
+          "high": "2012-11-04T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "_type": "QDM::EncounterPerformed"
+      },
+      {
+        "_id": "5c88013bd7c8ac4c3e10661e",
+        "birthDatetime": "1970-01-01T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "code": "21112-8",
+            "codeSystem": "LOINC",
+            "descriptor": null,
+            "codeSystemOid": null,
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.54",
+        "id": {
+          "_id": "5c88013bd7c8ac4c3e106629",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013bd7c8ac4c3e10661e"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "birthdate",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicBirthdate"
+      },
+      {
+        "_id": "5c88013bd7c8ac4c3e10661f",
+        "dataElementCodes": [
+          {
+            "code": "2186-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "Not Hispanic or Latino",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.56",
+        "id": {
+          "_id": "5c88013bd7c8ac4c3e10662a",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013bd7c8ac4c3e10661f"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "ethnicity",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicEthnicity"
+      },
+      {
+        "_id": "5c88013bd7c8ac4c3e106620",
+        "cause": null,
+        "dataElementCodes": [
+          {
+            "code": "419099009",
+            "codeSystem": "SNOMED-CT",
+            "descriptor": null,
+            "codeSystemOid": null,
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "expiredDatetime": "2012-12-04T08:00:00.000+00:00",
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.57",
+        "id": {
+          "_id": "5c88013bd7c8ac4c3e10662b",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013bd7c8ac4c3e106620"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "expired",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicExpired"
+      },
+      {
+        "_id": "5c88013bd7c8ac4c3e106621",
+        "dataElementCodes": [
+          {
+            "code": "1002-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "American Indian or Alaska Native",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.59",
+        "id": {
+          "_id": "5c88013bd7c8ac4c3e10662c",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013bd7c8ac4c3e106621"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "race",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicRace"
+      },
+      {
+        "_id": "5c88013bd7c8ac4c3e106622",
+        "dataElementCodes": [
+          {
+            "code": "M",
+            "codeSystem": "AdministrativeGender",
+            "descriptor": "M",
+            "codeSystemOid": "2.16.840.1.113883.5.1",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.55",
+        "id": {
+          "_id": "5c88013bd7c8ac4c3e10662d",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013bd7c8ac4c3e106622"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "gender",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicSex"
+      }
+    ],
+    "extendedData": {
+      "type": null,
+      "measure_ids": [
+        "A4B9763C-847E-4E02-BB7E-ACC596E90E2C",
+        null
+      ],
+      "source_data_criteria": [
+        {
+          "negation": false,
+          "definition": "diagnosis",
+          "title": "Dysthymia",
+          "description": "Diagnosis: Dysthymia",
+          "code_list_id": "2.16.840.1.113883.3.67.1.101.1.254",
+          "type": "conditions",
+          "id": "Dysthymia_Diagnosis_6193b77b_e502_40cd_8ff4_a51a269f141a_source",
+          "start_date": 1334217600000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "A4B9763C-847E-4E02-BB7E-ACC596E90E2C",
+          "cms_id": "CMS160v6",
+          "criteria_id": "161fcb4cf7chz",
+          "codes": {
+            "SNOMED-CT": [
+              "19694002"
+            ],
+            "ICD-10-CM": [
+              "F34.1"
+            ]
+          },
+          "coded_entry_id": {
+            "$oid": "5aeb77a2b848463d625b4c70"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "encounter",
+          "status": "performed",
+          "title": "OfficeVisit",
+          "description": "Encounter, Performed: Office Visit",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.101.12.1001",
+          "type": "encounters",
+          "id": "OfficeVisit_EncounterPerformed_40280381_3d61_56a7_013e_8a363827334f_source",
+          "start_date": 1352016000000,
+          "end_date": 1352016900000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "A4B9763C-847E-4E02-BB7E-ACC596E90E2C",
+          "cms_id": "CMS160v6",
+          "criteria_id": "161fcb54fcd6O",
+          "codes": {
+            "CPT": [
+              "99201"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5aeb77a2b848463d625b4c71"
+          },
+          "code_source": "USER_DEFINED"
+        },
+        {
+          "id": "MeasurePeriod",
+          "start_date": 0,
+          "end_date": 0,
+          "references": null
+        }
+      ],
+      "is_shared": null,
+      "origin_data": [
+
+      ],
+      "test_id": null,
+      "medical_record_number": "c41b2fc639938515ddbedfbb122df57bd818474278962683a0c3d50e3e3cbfed",
+      "medical_record_assigner": "Bonnie",
+      "description": null,
+      "description_category": null,
+      "insurance_providers": "[]"
+    },
+    "qdmVersion": "5.4"
+  }
+}

--- a/spec/javascripts/fixtures/json/patients/CMS160v6/Pass_NUM2.json
+++ b/spec/javascripts/fixtures/json/patients/CMS160v6/Pass_NUM2.json
@@ -1,0 +1,421 @@
+{
+  "_id": "5a58f485942c6d5479457a7b",
+  "bundleId": "5a57e977942c6d1e61d32f14",
+  "expectedValues": [
+    {
+      "measure_id": "A4B9763C-847E-4E02-BB7E-ACC596E90E2C",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "A4B9763C-847E-4E02-BB7E-ACC596E90E2C",
+      "population_index": 1,
+      "IPP": 1,
+      "DENOM": 1,
+      "DENEX": 0,
+      "NUMER": 1
+    },
+    {
+      "measure_id": "A4B9763C-847E-4E02-BB7E-ACC596E90E2C",
+      "population_index": 2,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    }
+  ],
+  "familyName": "NUM2",
+  "givenNames": [
+    "Pass"
+  ],
+  "notes": "Based on  NUM2Pass PHQ9>4mo<8moEASMP_BipolarDxSAEMP in epecqmtelligen@gmail.com",
+  "qdmPatient": {
+    "_id": "5c88013bd7c8ac4c3e106611",
+    "birthDatetime": "1965-04-13T08:00:00.000+00:00",
+    "dataElements": [
+      {
+        "_id": "5c88013bd7c8ac4c3e106612",
+        "authorDatetime": "2012-08-31T14:35:00.000+00:00",
+        "components": [
+
+        ],
+        "dataElementCodes": [
+          {
+            "codeSystem": "LOINC",
+            "code": "44261-6"
+          }
+        ],
+        "description": "Assessment, Performed: PHQ-9 Tool",
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.117",
+        "id": {
+          "_id": "5c88013bd7c8ac4c3e106613",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5aeb7763b848463d625b33d9"
+        },
+        "method": null,
+        "negationRationale": null,
+        "qdmCategory": "assessment",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "result": 10,
+        "_type": "QDM::AssessmentPerformed"
+      },
+      {
+        "_id": "5c88013bd7c8ac4c3e106614",
+        "anatomicalLocationSite": null,
+        "authorDatetime": "2012-06-08T14:35:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "ICD-10-CM",
+            "code": "F33.9"
+          }
+        ],
+        "description": "Diagnosis: Major Depression Including Remission",
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.110",
+        "id": {
+          "_id": "5c88013bd7c8ac4c3e106615",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5aeb7763b848463d625b33d6"
+        },
+        "prevalencePeriod": {
+          "low": "2012-06-08T14:35:00.000+00:00",
+          "high": "9999-12-31T23:59:59.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "qdmCategory": "condition",
+        "qdmVersion": "5.4",
+        "qrdaOid": "2.16.840.1.113883.10.20.24.3.135",
+        "severity": null,
+        "_type": "QDM::Diagnosis"
+      },
+      {
+        "_id": "5c88013bd7c8ac4c3e106616",
+        "anatomicalLocationSite": null,
+        "authorDatetime": "2013-11-08T14:35:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "81319007"
+          }
+        ],
+        "description": "Diagnosis: Bipolar Disorder",
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.110",
+        "id": {
+          "_id": "5c88013bd7c8ac4c3e106617",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5aeb7763b848463d625b33d7"
+        },
+        "prevalencePeriod": {
+          "low": "2013-11-08T14:35:00.000+00:00",
+          "high": "9999-12-31T23:59:59.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "qdmCategory": "condition",
+        "qdmVersion": "5.4",
+        "qrdaOid": "2.16.840.1.113883.10.20.24.3.135",
+        "severity": null,
+        "_type": "QDM::Diagnosis"
+      },
+      {
+        "_id": "5c88013bd7c8ac4c3e106618",
+        "admissionSource": null,
+        "authorDatetime": "2012-06-08T14:30:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "CPT",
+            "code": "99201"
+          }
+        ],
+        "description": "Encounter, Performed: Office Visit",
+        "diagnoses": [
+
+        ],
+        "dischargeDisposition": null,
+        "facilityLocations": [
+
+        ],
+        "hqmfOid": "2.16.840.1.113883.3.560.1.79",
+        "id": {
+          "_id": "5c88013bd7c8ac4c3e106619",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5aeb7763b848463d625b33d8"
+        },
+        "lengthOfStay": {
+          "value": 0,
+          "unit": "days"
+        },
+        "negationRationale": null,
+        "principalDiagnosis": null,
+        "qdmCategory": "encounter",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "relevantPeriod": {
+          "low": "2012-06-08T14:30:00.000+00:00",
+          "high": "2012-06-08T14:50:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "_type": "QDM::EncounterPerformed"
+      },
+      {
+        "_id": "5c88013bd7c8ac4c3e10660c",
+        "birthDatetime": "1965-04-13T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "code": "21112-8",
+            "codeSystem": "LOINC",
+            "descriptor": null,
+            "codeSystemOid": null,
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.54",
+        "id": {
+          "_id": "5c88013bd7c8ac4c3e10661a",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013bd7c8ac4c3e10660c"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "birthdate",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicBirthdate"
+      },
+      {
+        "_id": "5c88013bd7c8ac4c3e10660d",
+        "dataElementCodes": [
+          {
+            "code": "2186-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "Not Hispanic or Latino",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.56",
+        "id": {
+          "_id": "5c88013bd7c8ac4c3e10661b",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013bd7c8ac4c3e10660d"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "ethnicity",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicEthnicity"
+      },
+      {
+        "_id": "5c88013bd7c8ac4c3e10660e",
+        "dataElementCodes": [
+          {
+            "code": "1002-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "American Indian or Alaska Native",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.59",
+        "id": {
+          "_id": "5c88013bd7c8ac4c3e10661c",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013bd7c8ac4c3e10660e"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "race",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicRace"
+      },
+      {
+        "_id": "5c88013bd7c8ac4c3e10660f",
+        "dataElementCodes": [
+          {
+            "code": "F",
+            "codeSystem": "AdministrativeGender",
+            "descriptor": "F",
+            "codeSystemOid": "2.16.840.1.113883.5.1",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.55",
+        "id": {
+          "_id": "5c88013bd7c8ac4c3e10661d",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013bd7c8ac4c3e10660f"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "gender",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicSex"
+      }
+    ],
+    "extendedData": {
+      "type": null,
+      "measure_ids": [
+        "A4B9763C-847E-4E02-BB7E-ACC596E90E2C",
+        null
+      ],
+      "source_data_criteria": [
+        {
+          "negation": false,
+          "definition": "encounter",
+          "status": "performed",
+          "title": "OfficeVisit",
+          "description": "Encounter, Performed: Office Visit",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.101.12.1001",
+          "type": "encounters",
+          "id": "OfficeVisit_EncounterPerformed_40280381_3d61_56a7_013e_8a363827334f_source",
+          "start_date": 1339165800000,
+          "end_date": 1339167000000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "A4B9763C-847E-4E02-BB7E-ACC596E90E2C",
+          "cms_id": "CMS160v6",
+          "criteria_id": "160eb75c1d3El",
+          "codes": {
+            "CPT": [
+              "99201"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5aeb7763b848463d625b33d8"
+          },
+          "code_source": "USER_DEFINED"
+        },
+        {
+          "negation": false,
+          "definition": "diagnosis",
+          "title": "MajorDepressionIncludingRemission",
+          "description": "Diagnosis: Major Depression Including Remission",
+          "code_list_id": "2.16.840.113883.3.67.1.101.3.2444",
+          "type": "conditions",
+          "id": "MajorDepressionIncludingRemission_Diagnosis_aa4805f4_54e9_4e60_9bbf_b316aeaa95ba_source",
+          "start_date": 1339166100000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "A4B9763C-847E-4E02-BB7E-ACC596E90E2C",
+          "cms_id": "CMS160v6",
+          "criteria_id": "160eb76956cSo",
+          "codes": {
+            "ICD-10-CM": [
+              "F33.9"
+            ]
+          },
+          "coded_entry_id": {
+            "$oid": "5aeb7763b848463d625b33d6"
+          },
+          "code_source": "USER_DEFINED"
+        },
+        {
+          "negation": false,
+          "definition": "assessment",
+          "status": "performed",
+          "title": "PHQ-9Tool",
+          "description": "Assessment, Performed: PHQ-9 Tool",
+          "code_list_id": "2.16.840.1.113883.3.67.1.101.11.723",
+          "type": "assessments",
+          "id": "PHQ_9Tool_AssessmentPerformed_40280381_3d61_56a7_013e_8a363828336d_source",
+          "start_date": 1346423700000,
+          "value": [
+            {
+              "type": "PQ",
+              "type_cmp": "CD",
+              "value": "10",
+              "unit": ""
+            }
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "A4B9763C-847E-4E02-BB7E-ACC596E90E2C",
+          "cms_id": "CMS160v6",
+          "criteria_id": "160eb8174dclO",
+          "codes": {
+            "LOINC": [
+              "44261-6"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5aeb7763b848463d625b33d9"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "diagnosis",
+          "title": "BipolarDisorder",
+          "description": "Diagnosis: Bipolar Disorder",
+          "code_list_id": "2.16.840.1.113883.3.67.1.101.1.128",
+          "type": "conditions",
+          "id": "BipolarDisorder_Diagnosis_89a1244b_f388_4261_949a_70b82971f63d_source",
+          "start_date": 1383921300000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "A4B9763C-847E-4E02-BB7E-ACC596E90E2C",
+          "cms_id": "CMS160v6",
+          "criteria_id": "160eb7773f7Zc",
+          "codes": {
+            "SNOMED-CT": [
+              "81319007"
+            ]
+          },
+          "coded_entry_id": {
+            "$oid": "5aeb7763b848463d625b33d7"
+          },
+          "code_source": "USER_DEFINED"
+        },
+        {
+          "id": "MeasurePeriod",
+          "start_date": 0,
+          "end_date": 0,
+          "references": null
+        }
+      ],
+      "is_shared": null,
+      "origin_data": [
+
+      ],
+      "test_id": null,
+      "medical_record_number": "62eb0c6cafb20eeb143aaa87226f769ed92076b0173c0a756d62af1145f54b6c",
+      "medical_record_assigner": "Bonnie",
+      "description": null,
+      "description_category": null,
+      "insurance_providers": "[]"
+    },
+    "qdmVersion": "5.4"
+  }
+}

--- a/spec/javascripts/fixtures/json/patients/CMS177v6/Fail_IPP.json
+++ b/spec/javascripts/fixtures/json/patients/CMS177v6/Fail_IPP.json
@@ -1,0 +1,231 @@
+{
+  "_id": "5a9eddefb84846563e7d578c",
+  "bundleId": "5a57e977942c6d1e61d32f14",
+  "expectedValues": [
+    {
+      "measure_id": "848D09DE-7E6B-43C4-BEDD-5A2957CCFFE3",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "NUMER": 0
+    }
+  ],
+  "familyName": "IPP",
+  "givenNames": [
+    "Fail"
+  ],
+  "notes": "",
+  "qdmPatient": {
+    "_id": "5c88013cd7c8ac4c3e106641",
+    "birthDatetime": "2001-03-15T08:00:00.000+00:00",
+    "dataElements": [
+      {
+        "_id": "5c88013cd7c8ac4c3e106642",
+        "admissionSource": null,
+        "authorDatetime": "2012-03-06T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "185463005"
+          },
+          {
+            "codeSystem": "CPT",
+            "code": "99201"
+          }
+        ],
+        "description": "Encounter, Performed: Office Visit",
+        "diagnoses": [
+
+        ],
+        "dischargeDisposition": null,
+        "facilityLocations": [
+
+        ],
+        "hqmfOid": "2.16.840.1.113883.3.560.1.79",
+        "id": {
+          "_id": "5c88013cd7c8ac4c3e106643",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5aeb77a2b848463d625b4c6e"
+        },
+        "lengthOfStay": {
+          "value": 0,
+          "unit": "days"
+        },
+        "negationRationale": null,
+        "principalDiagnosis": null,
+        "qdmCategory": "encounter",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "relevantPeriod": {
+          "low": "2012-03-06T08:00:00.000+00:00",
+          "high": "2012-03-06T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "_type": "QDM::EncounterPerformed"
+      },
+      {
+        "_id": "5c88013cd7c8ac4c3e10663c",
+        "birthDatetime": "2001-03-15T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "code": "21112-8",
+            "codeSystem": "LOINC",
+            "descriptor": null,
+            "codeSystemOid": null,
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.54",
+        "id": {
+          "_id": "5c88013cd7c8ac4c3e106644",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013cd7c8ac4c3e10663c"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "birthdate",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicBirthdate"
+      },
+      {
+        "_id": "5c88013cd7c8ac4c3e10663d",
+        "dataElementCodes": [
+          {
+            "code": "2186-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "Not Hispanic or Latino",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.56",
+        "id": {
+          "_id": "5c88013cd7c8ac4c3e106645",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013cd7c8ac4c3e10663d"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "ethnicity",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicEthnicity"
+      },
+      {
+        "_id": "5c88013cd7c8ac4c3e10663e",
+        "dataElementCodes": [
+          {
+            "code": "1002-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "American Indian or Alaska Native",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.59",
+        "id": {
+          "_id": "5c88013cd7c8ac4c3e106646",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013cd7c8ac4c3e10663e"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "race",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicRace"
+      },
+      {
+        "_id": "5c88013cd7c8ac4c3e10663f",
+        "dataElementCodes": [
+          {
+            "code": "M",
+            "codeSystem": "AdministrativeGender",
+            "descriptor": "M",
+            "codeSystemOid": "2.16.840.1.113883.5.1",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.55",
+        "id": {
+          "_id": "5c88013cd7c8ac4c3e106647",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013cd7c8ac4c3e10663f"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "gender",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicSex"
+      }
+    ],
+    "extendedData": {
+      "type": null,
+      "measure_ids": [
+        "848D09DE-7E6B-43C4-BEDD-5A2957CCFFE3",
+        null
+      ],
+      "source_data_criteria": [
+        {
+          "negation": false,
+          "definition": "encounter",
+          "status": "performed",
+          "title": "OfficeVisit",
+          "description": "Encounter, Performed: Office Visit",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.101.12.1001",
+          "type": "encounters",
+          "id": "OfficeVisit_EncounterPerformed_40280381_3d61_56a7_013e_5d9034eb706f_source",
+          "start_date": 1331020800000,
+          "end_date": 1331021700000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "848D09DE-7E6B-43C4-BEDD-5A2957CCFFE3",
+          "cms_id": "CMS177v6",
+          "criteria_id": "161fc92d3bdZ2",
+          "codes": {
+            "SNOMED-CT": [
+              "185463005"
+            ],
+            "CPT": [
+              "99201"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5aeb77a2b848463d625b4c6e"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "id": "MeasurePeriod",
+          "start_date": 0,
+          "end_date": 0,
+          "references": null
+        }
+      ],
+      "is_shared": null,
+      "origin_data": [
+
+      ],
+      "test_id": null,
+      "medical_record_number": "7073619254c07fe4cccedec594bc09426191af6ccbd402b98746bd2a51d21405",
+      "medical_record_assigner": "Bonnie",
+      "description": null,
+      "description_category": null,
+      "insurance_providers": "[]"
+    },
+    "qdmVersion": "5.4"
+  }
+}

--- a/spec/javascripts/fixtures/json/patients/CMS177v6/Pass_Numer.json
+++ b/spec/javascripts/fixtures/json/patients/CMS177v6/Pass_Numer.json
@@ -1,0 +1,313 @@
+{
+  "_id": "5a58ecb2942c6d500fc8ca0b",
+  "bundleId": "5a57e977942c6d1e61d32f14",
+  "expectedValues": [
+    {
+      "measure_id": "848D09DE-7E6B-43C4-BEDD-5A2957CCFFE3",
+      "population_index": 0,
+      "IPP": 1,
+      "DENOM": 1,
+      "NUMER": 1
+    }
+  ],
+  "familyName": "Numer",
+  "givenNames": [
+    "Pass"
+  ],
+  "notes": "Based on NUMERPass RiskAssessF2FEnc in epecqmama@gmail.com ",
+  "qdmPatient": {
+    "_id": "5c88013cd7c8ac4c3e106633",
+    "birthDatetime": "1995-12-13T08:00:00.000+00:00",
+    "dataElements": [
+      {
+        "_id": "5c88013cd7c8ac4c3e106634",
+        "admissionSource": null,
+        "authorDatetime": "2012-02-11T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "12843005"
+          }
+        ],
+        "description": "Encounter, Performed: Face-to-Face Interaction",
+        "diagnoses": [
+          {
+            "code": "14183003",
+            "codeSystem": "SNOMED-CT",
+            "version": null,
+            "descriptor": "Major Depressive Disorder-Active"
+          }
+        ],
+        "dischargeDisposition": null,
+        "facilityLocations": [
+
+        ],
+        "hqmfOid": "2.16.840.1.113883.3.560.1.79",
+        "id": {
+          "_id": "5c88013cd7c8ac4c3e106635",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5aeb7763b848463d625b33d2"
+        },
+        "lengthOfStay": {
+          "value": 0,
+          "unit": "days"
+        },
+        "negationRationale": null,
+        "principalDiagnosis": {
+          "code": "14183003",
+          "codeSystem": "SNOMED-CT",
+          "descriptor": "Major Depressive Disorder-Active",
+          "codeSystemOid": null,
+          "version": null
+        },
+        "qdmCategory": "encounter",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "relevantPeriod": {
+          "low": "2012-02-11T08:00:00.000+00:00",
+          "high": "2012-02-11T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "_type": "QDM::EncounterPerformed"
+      },
+      {
+        "_id": "5c88013cd7c8ac4c3e106636",
+        "authorDatetime": "2012-02-11T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "225337009"
+          }
+        ],
+        "description": "Intervention, Performed: Suicide Risk Assessment",
+        "hqmfOid": "2.16.840.1.113883.3.560.1.46",
+        "id": {
+          "_id": "5c88013cd7c8ac4c3e106637",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5aeb7763b848463d625b33d4"
+        },
+        "negationRationale": null,
+        "qdmCategory": "intervention",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "relevantPeriod": {
+          "low": "2012-02-11T08:00:00.000+00:00",
+          "high": "2012-02-11T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "result": null,
+        "status": null,
+        "_type": "QDM::InterventionPerformed"
+      },
+      {
+        "_id": "5c88013cd7c8ac4c3e10662e",
+        "birthDatetime": "1995-12-13T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "code": "21112-8",
+            "codeSystem": "LOINC",
+            "descriptor": null,
+            "codeSystemOid": null,
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.54",
+        "id": {
+          "_id": "5c88013cd7c8ac4c3e106638",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013cd7c8ac4c3e10662e"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "birthdate",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicBirthdate"
+      },
+      {
+        "_id": "5c88013cd7c8ac4c3e10662f",
+        "dataElementCodes": [
+          {
+            "code": "2186-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "Not Hispanic or Latino",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.56",
+        "id": {
+          "_id": "5c88013cd7c8ac4c3e106639",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013cd7c8ac4c3e10662f"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "ethnicity",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicEthnicity"
+      },
+      {
+        "_id": "5c88013cd7c8ac4c3e106630",
+        "dataElementCodes": [
+          {
+            "code": "1002-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "American Indian or Alaska Native",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.59",
+        "id": {
+          "_id": "5c88013cd7c8ac4c3e10663a",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013cd7c8ac4c3e106630"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "race",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicRace"
+      },
+      {
+        "_id": "5c88013cd7c8ac4c3e106631",
+        "dataElementCodes": [
+          {
+            "code": "F",
+            "codeSystem": "AdministrativeGender",
+            "descriptor": "F",
+            "codeSystemOid": "2.16.840.1.113883.5.1",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.55",
+        "id": {
+          "_id": "5c88013cd7c8ac4c3e10663b",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013cd7c8ac4c3e106631"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "gender",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicSex"
+      }
+    ],
+    "extendedData": {
+      "type": null,
+      "measure_ids": [
+        "848D09DE-7E6B-43C4-BEDD-5A2957CCFFE3",
+        null
+      ],
+      "source_data_criteria": [
+        {
+          "negation": false,
+          "definition": "encounter",
+          "status": "performed",
+          "title": "Face-to-FaceInteraction",
+          "description": "Encounter, Performed: Face-to-Face Interaction",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.101.12.1048",
+          "type": "encounters",
+          "id": "Face_to_FaceInteraction_EncounterPerformed_40280381_3d61_56a7_013e_5d9034ec707c_source",
+          "start_date": 1328947200000,
+          "end_date": 1328948100000,
+          "value": [
+
+          ],
+          "references": [
+            {
+              "type": "CD",
+              "reference_type": "Related To",
+              "reference_id": "160eb5db5bdEU",
+              "description": "Intervention, Performed: Suicide Risk Assessment",
+              "start_date": "02/11/2012",
+              "end_date": "02/11/2012"
+            }
+          ],
+          "field_values": {
+            "PRINCIPAL_DIAGNOSIS": {
+              "type": "CD",
+              "code_list_id": "2.16.840.1.113883.3.526.3.1491",
+              "field_title": "Principal Diagnosis",
+              "title": "Major Depressive Disorder-Active"
+            }
+          },
+          "hqmf_set_id": "848D09DE-7E6B-43C4-BEDD-5A2957CCFFE3",
+          "cms_id": "CMS177v6",
+          "criteria_id": "160eb5b1d5fas",
+          "codes": {
+            "SNOMED-CT": [
+              "12843005"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5aeb7763b848463d625b33d2"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "intervention",
+          "status": "performed",
+          "title": "SuicideRiskAssessment",
+          "description": "Intervention, Performed: Suicide Risk Assessment",
+          "code_list_id": "2.16.840.1.113883.3.526.3.1484",
+          "type": "interventions",
+          "id": "SuicideRiskAssessment_InterventionPerformed_40280381_3d61_56a7_013e_5d9034ec708a_source",
+          "start_date": 1328947200000,
+          "end_date": 1328948100000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "848D09DE-7E6B-43C4-BEDD-5A2957CCFFE3",
+          "cms_id": "CMS177v6",
+          "criteria_id": "160eb5db5bdEU",
+          "codes": {
+            "SNOMED-CT": [
+              "225337009"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5aeb7763b848463d625b33d4"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "id": "MeasurePeriod",
+          "start_date": 0,
+          "end_date": 0,
+          "references": null
+        }
+      ],
+      "is_shared": null,
+      "origin_data": [
+
+      ],
+      "test_id": null,
+      "medical_record_number": "7d65b9b331c09bb8364fed78d25eb1cbd53d3be035705c792ecca931c549d217",
+      "medical_record_assigner": "Bonnie",
+      "description": null,
+      "description_category": null,
+      "insurance_providers": "[]"
+    },
+    "qdmVersion": "5.4"
+  }
+}

--- a/spec/javascripts/fixtures/json/patients/CMS231v0/Patient_Test 1.json
+++ b/spec/javascripts/fixtures/json/patients/CMS231v0/Patient_Test 1.json
@@ -1,0 +1,417 @@
+{
+  "_id": "5c06ec72b848466bbc906066",
+  "bundleId": "5a57e977942c6d1e61d32f14",
+  "expectedValues": [
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+      "population_index": 0,
+      "IPP": 1,
+      "DENOM": 1,
+      "DENEX": 0,
+      "NUMER": 1
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC",
+      "population_index": 0,
+      "IPP": 1,
+      "MSRPOPL": 1,
+      "MSRPOPLEX": 0,
+      "OBSERV": [
+        0.25
+      ],
+      "OBSERV_UNIT": ""
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&7B905B21-D904-454F-885B-9CE5D19674E3",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "NUMER": 0,
+      "DENEXCEP": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&5B20AFEA-D4AF-4F7A-A5A3-F1F6165B9E5F",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&3000797E-11B1-4F62-A078-341A4002A11C",
+      "population_index": 0,
+      "IPP": 1,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&920D5B27-DF5A-4770-BD60-FC4EE251C4D2",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&BA108B7B-90B4-4692-B1D0-5DB554D2A1A2",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0,
+      "DENEXCEP": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&F03324C2-9147-457B-BC34-811BB7859C91",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    }
+  ],
+  "familyName": "Test 1",
+  "givenNames": [
+    "Patient"
+  ],
+  "notes": "",
+  "qdmPatient": {
+    "_id": "5c880146d7c8ac4c3e1067e1",
+    "birthDatetime": "1940-01-01T08:00:00.000+00:00",
+    "dataElements": [
+      {
+        "_id": "5c880146d7c8ac4c3e1067e2",
+        "authorDatetime": "2011-07-04T08:00:00.000+00:00",
+        "components": [
+
+        ],
+        "dataElementCodes": [
+          {
+            "codeSystem": "LOINC",
+            "code": "59458-0"
+          }
+        ],
+        "description": "Assessment, Performed: Ambulatory Status",
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.117",
+        "id": {
+          "_id": "5c880146d7c8ac4c3e1067e3",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c06ece3b848466bbc906174"
+        },
+        "method": null,
+        "negationRationale": null,
+        "qdmCategory": "assessment",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "result": null,
+        "_type": "QDM::AssessmentPerformed"
+      },
+      {
+        "_id": "5c880146d7c8ac4c3e1067e4",
+        "authorDatetime": "2012-07-04T08:00:00.000+00:00",
+        "components": [
+
+        ],
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "401196007"
+          },
+          {
+            "codeSystem": "LOINC",
+            "code": "52552-7"
+          }
+        ],
+        "description": "Assessment, Performed: Falls Screening",
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.117",
+        "id": {
+          "_id": "5c880146d7c8ac4c3e1067e5",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c06ece3b848466bbc906175"
+        },
+        "method": null,
+        "negationRationale": null,
+        "qdmCategory": "assessment",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "result": null,
+        "_type": "QDM::AssessmentPerformed"
+      },
+      {
+        "_id": "5c880146d7c8ac4c3e1067e6",
+        "admissionSource": null,
+        "authorDatetime": "2012-12-04T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "HCPCS",
+            "code": "G0438"
+          }
+        ],
+        "description": "Encounter, Performed: Annual Wellness Visit",
+        "diagnoses": [
+
+        ],
+        "dischargeDisposition": null,
+        "facilityLocations": [
+
+        ],
+        "hqmfOid": "2.16.840.1.113883.3.560.1.79",
+        "id": {
+          "_id": "5c880146d7c8ac4c3e1067e7",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c06ece3b848466bbc906173"
+        },
+        "lengthOfStay": {
+          "value": 0,
+          "unit": "days"
+        },
+        "negationRationale": null,
+        "principalDiagnosis": null,
+        "qdmCategory": "encounter",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "relevantPeriod": {
+          "low": "2012-12-04T08:00:00.000+00:00",
+          "high": "2012-12-04T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "_type": "QDM::EncounterPerformed"
+      },
+      {
+        "_id": "5c880146d7c8ac4c3e1067dc",
+        "birthDatetime": "1940-01-01T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "code": "21112-8",
+            "codeSystem": "LOINC",
+            "descriptor": null,
+            "codeSystemOid": null,
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.54",
+        "id": {
+          "_id": "5c880146d7c8ac4c3e1067e8",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880146d7c8ac4c3e1067dc"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "birthdate",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicBirthdate"
+      },
+      {
+        "_id": "5c880146d7c8ac4c3e1067dd",
+        "dataElementCodes": [
+          {
+            "code": "2186-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "Not Hispanic or Latino",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.56",
+        "id": {
+          "_id": "5c880146d7c8ac4c3e1067e9",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880146d7c8ac4c3e1067dd"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "ethnicity",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicEthnicity"
+      },
+      {
+        "_id": "5c880146d7c8ac4c3e1067de",
+        "dataElementCodes": [
+          {
+            "code": "1002-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "American Indian or Alaska Native",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.59",
+        "id": {
+          "_id": "5c880146d7c8ac4c3e1067ea",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880146d7c8ac4c3e1067de"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "race",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicRace"
+      },
+      {
+        "_id": "5c880146d7c8ac4c3e1067df",
+        "dataElementCodes": [
+          {
+            "code": "M",
+            "codeSystem": "AdministrativeGender",
+            "descriptor": "M",
+            "codeSystemOid": "2.16.840.1.113883.5.1",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.55",
+        "id": {
+          "_id": "5c880146d7c8ac4c3e1067eb",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880146d7c8ac4c3e1067df"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "gender",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicSex"
+      }
+    ],
+    "extendedData": {
+      "type": null,
+      "measure_ids": [
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+        null,
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&7B905B21-D904-454F-885B-9CE5D19674E3",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&920D5B27-DF5A-4770-BD60-FC4EE251C4D2",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&3000797E-11B1-4F62-A078-341A4002A11C",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&5B20AFEA-D4AF-4F7A-A5A3-F1F6165B9E5F",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&F03324C2-9147-457B-BC34-811BB7859C91",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&BA108B7B-90B4-4692-B1D0-5DB554D2A1A2",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC"
+      ],
+      "source_data_criteria": [
+        {
+          "negation": false,
+          "definition": "assessment",
+          "status": "performed",
+          "title": "AmbulatoryStatus",
+          "description": "Assessment, Performed: Ambulatory Status",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.118.11.1219",
+          "type": "assessments",
+          "id": "AmbulatoryStatus_AssessmentPerformed_eb84926c_ae80_4768_9f88_ea55ed355df6_source",
+          "start_date": 1309766400000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+          "cms_id": "CMS231v0",
+          "criteria_id": "1677b0af52fFX",
+          "codes": {
+            "LOINC": [
+              "59458-0"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5c06ece3b848466bbc906174"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "assessment",
+          "status": "performed",
+          "title": "FallsScreening",
+          "description": "Assessment, Performed: Falls Screening",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.118.12.1028",
+          "type": "assessments",
+          "id": "FallsScreening_AssessmentPerformed_3296d6d9_085b_4acd_84a9_819c01e4e5cd_source",
+          "start_date": 1341388800000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+          "cms_id": "CMS231v0",
+          "criteria_id": "1677b0b4e9bGs",
+          "codes": {
+            "SNOMED-CT": [
+              "401196007"
+            ],
+            "LOINC": [
+              "52552-7"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5c06ece3b848466bbc906175"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "encounter",
+          "status": "performed",
+          "title": "AnnualWellnessVisit",
+          "description": "Encounter, Performed: Annual Wellness Visit",
+          "code_list_id": "2.16.840.1.113883.3.526.3.1240",
+          "type": "encounters",
+          "id": "AnnualWellnessVisit_EncounterPerformed_d50103e4_3ce4_48e3_9489_68dc37fb0b20_source",
+          "start_date": 1354608000000,
+          "end_date": 1354608900000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+          "cms_id": "CMS231v0",
+          "criteria_id": "1677b0ac53a4Q",
+          "codes": {
+            "HCPCS": [
+              "G0438"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5c06ece3b848466bbc906173"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "id": "MeasurePeriod",
+          "start_date": 0,
+          "end_date": 0,
+          "references": null
+        }
+      ],
+      "is_shared": null,
+      "origin_data": [
+
+      ],
+      "test_id": null,
+      "medical_record_number": "d975a2c11a5dbfa9af64642c349f94b5f5e5b43b211617f5d2992dd0438ca8fd",
+      "medical_record_assigner": "Bonnie",
+      "description": null,
+      "description_category": null,
+      "insurance_providers": "[{\"codes\":{\"SOP\":[\"349\"]},\"description\":null,\"end_time\":null,\"financial_responsibility_type\":{\"code\":\"SELF\",\"codeSystem\":\"HL7 Relationship Code\"},\"health_record_field\":null,\"member_id\":\"1234567890\",\"mood_code\":\"EVN\",\"name\":\"Other\",\"negationInd\":null,\"negationReason\":null,\"oid\":null,\"payer\":{\"name\":\"Other\"},\"reason\":null,\"relationship\":null,\"specifics\":null,\"start_time\":1199145600,\"status_code\":null,\"time\":null,\"type\":\"OT\"}]"
+    },
+    "qdmVersion": "5.4"
+  }
+}

--- a/spec/javascripts/fixtures/json/patients/CMS231v0/Patient_Test 2.json
+++ b/spec/javascripts/fixtures/json/patients/CMS231v0/Patient_Test 2.json
@@ -1,0 +1,417 @@
+{
+  "_id": "5c06ecf1b848466bbc906184",
+  "bundleId": "5a57e977942c6d1e61d32f14",
+  "expectedValues": [
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+      "population_index": 0,
+      "IPP": 1,
+      "DENOM": 1,
+      "DENEX": 0,
+      "NUMER": 1
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC",
+      "population_index": 0,
+      "IPP": 1,
+      "MSRPOPL": 1,
+      "MSRPOPLEX": 0,
+      "OBSERV": [
+        0.25
+      ],
+      "OBSERV_UNIT": ""
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&7B905B21-D904-454F-885B-9CE5D19674E3",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "NUMER": 0,
+      "DENEXCEP": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&5B20AFEA-D4AF-4F7A-A5A3-F1F6165B9E5F",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&3000797E-11B1-4F62-A078-341A4002A11C",
+      "population_index": 0,
+      "IPP": 1,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&920D5B27-DF5A-4770-BD60-FC4EE251C4D2",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&BA108B7B-90B4-4692-B1D0-5DB554D2A1A2",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0,
+      "DENEXCEP": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&F03324C2-9147-457B-BC34-811BB7859C91",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    }
+  ],
+  "familyName": "Test 2",
+  "givenNames": [
+    "Patient"
+  ],
+  "notes": "",
+  "qdmPatient": {
+    "_id": "5c880146d7c8ac4c3e1067f1",
+    "birthDatetime": "1940-01-01T08:00:00.000+00:00",
+    "dataElements": [
+      {
+        "_id": "5c880146d7c8ac4c3e1067f2",
+        "authorDatetime": "2011-07-04T08:00:00.000+00:00",
+        "components": [
+
+        ],
+        "dataElementCodes": [
+          {
+            "codeSystem": "LOINC",
+            "code": "59458-0"
+          }
+        ],
+        "description": "Assessment, Performed: Ambulatory Status",
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.117",
+        "id": {
+          "_id": "5c880146d7c8ac4c3e1067f3",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c06ecf1b848466bbc906185"
+        },
+        "method": null,
+        "negationRationale": null,
+        "qdmCategory": "assessment",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "result": null,
+        "_type": "QDM::AssessmentPerformed"
+      },
+      {
+        "_id": "5c880146d7c8ac4c3e1067f4",
+        "authorDatetime": "2012-07-04T08:00:00.000+00:00",
+        "components": [
+
+        ],
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "401196007"
+          },
+          {
+            "codeSystem": "LOINC",
+            "code": "52552-7"
+          }
+        ],
+        "description": "Assessment, Performed: Falls Screening",
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.117",
+        "id": {
+          "_id": "5c880146d7c8ac4c3e1067f5",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c06ecf1b848466bbc906186"
+        },
+        "method": null,
+        "negationRationale": null,
+        "qdmCategory": "assessment",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "result": null,
+        "_type": "QDM::AssessmentPerformed"
+      },
+      {
+        "_id": "5c880146d7c8ac4c3e1067f6",
+        "admissionSource": null,
+        "authorDatetime": "2012-12-04T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "HCPCS",
+            "code": "G0438"
+          }
+        ],
+        "description": "Encounter, Performed: Annual Wellness Visit",
+        "diagnoses": [
+
+        ],
+        "dischargeDisposition": null,
+        "facilityLocations": [
+
+        ],
+        "hqmfOid": "2.16.840.1.113883.3.560.1.79",
+        "id": {
+          "_id": "5c880146d7c8ac4c3e1067f7",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c06ecf1b848466bbc906187"
+        },
+        "lengthOfStay": {
+          "value": 0,
+          "unit": "days"
+        },
+        "negationRationale": null,
+        "principalDiagnosis": null,
+        "qdmCategory": "encounter",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "relevantPeriod": {
+          "low": "2012-12-04T08:00:00.000+00:00",
+          "high": "2012-12-04T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "_type": "QDM::EncounterPerformed"
+      },
+      {
+        "_id": "5c880146d7c8ac4c3e1067ec",
+        "birthDatetime": "1940-01-01T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "code": "21112-8",
+            "codeSystem": "LOINC",
+            "descriptor": null,
+            "codeSystemOid": null,
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.54",
+        "id": {
+          "_id": "5c880146d7c8ac4c3e1067f8",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880146d7c8ac4c3e1067ec"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "birthdate",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicBirthdate"
+      },
+      {
+        "_id": "5c880146d7c8ac4c3e1067ed",
+        "dataElementCodes": [
+          {
+            "code": "2186-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "Not Hispanic or Latino",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.56",
+        "id": {
+          "_id": "5c880146d7c8ac4c3e1067f9",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880146d7c8ac4c3e1067ed"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "ethnicity",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicEthnicity"
+      },
+      {
+        "_id": "5c880146d7c8ac4c3e1067ee",
+        "dataElementCodes": [
+          {
+            "code": "1002-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "American Indian or Alaska Native",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.59",
+        "id": {
+          "_id": "5c880146d7c8ac4c3e1067fa",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880146d7c8ac4c3e1067ee"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "race",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicRace"
+      },
+      {
+        "_id": "5c880146d7c8ac4c3e1067ef",
+        "dataElementCodes": [
+          {
+            "code": "M",
+            "codeSystem": "AdministrativeGender",
+            "descriptor": "M",
+            "codeSystemOid": "2.16.840.1.113883.5.1",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.55",
+        "id": {
+          "_id": "5c880146d7c8ac4c3e1067fb",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880146d7c8ac4c3e1067ef"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "gender",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicSex"
+      }
+    ],
+    "extendedData": {
+      "type": null,
+      "measure_ids": [
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&7B905B21-D904-454F-885B-9CE5D19674E3",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&920D5B27-DF5A-4770-BD60-FC4EE251C4D2",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&3000797E-11B1-4F62-A078-341A4002A11C",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&5B20AFEA-D4AF-4F7A-A5A3-F1F6165B9E5F",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&F03324C2-9147-457B-BC34-811BB7859C91",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&BA108B7B-90B4-4692-B1D0-5DB554D2A1A2",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC",
+        null
+      ],
+      "source_data_criteria": [
+        {
+          "negation": false,
+          "definition": "assessment",
+          "status": "performed",
+          "title": "AmbulatoryStatus",
+          "description": "Assessment, Performed: Ambulatory Status",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.118.11.1219",
+          "type": "assessments",
+          "id": "AmbulatoryStatus_AssessmentPerformed_eb84926c_ae80_4768_9f88_ea55ed355df6_source",
+          "start_date": 1309766400000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+          "cms_id": "CMS231v0",
+          "criteria_id": "1677b0af52fFX",
+          "codes": {
+            "LOINC": [
+              "59458-0"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5c06ecf1b848466bbc906185"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "assessment",
+          "status": "performed",
+          "title": "FallsScreening",
+          "description": "Assessment, Performed: Falls Screening",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.118.12.1028",
+          "type": "assessments",
+          "id": "FallsScreening_AssessmentPerformed_3296d6d9_085b_4acd_84a9_819c01e4e5cd_source",
+          "start_date": 1341388800000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+          "cms_id": "CMS231v0",
+          "criteria_id": "1677b0b4e9bGs",
+          "codes": {
+            "SNOMED-CT": [
+              "401196007"
+            ],
+            "LOINC": [
+              "52552-7"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5c06ecf1b848466bbc906186"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "encounter",
+          "status": "performed",
+          "title": "AnnualWellnessVisit",
+          "description": "Encounter, Performed: Annual Wellness Visit",
+          "code_list_id": "2.16.840.1.113883.3.526.3.1240",
+          "type": "encounters",
+          "id": "AnnualWellnessVisit_EncounterPerformed_d50103e4_3ce4_48e3_9489_68dc37fb0b20_source",
+          "start_date": 1354608000000,
+          "end_date": 1354608900000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+          "cms_id": "CMS231v0",
+          "criteria_id": "1677b0ac53a4Q",
+          "codes": {
+            "HCPCS": [
+              "G0438"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5c06ecf1b848466bbc906187"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "id": "MeasurePeriod",
+          "start_date": 0,
+          "end_date": 0,
+          "references": null
+        }
+      ],
+      "is_shared": null,
+      "origin_data": [
+
+      ],
+      "test_id": null,
+      "medical_record_number": "66e7185c846fb50aaff1541a59d0b72284f89f64783a89bb33f9ae0d93f07361",
+      "medical_record_assigner": "Bonnie",
+      "description": null,
+      "description_category": null,
+      "insurance_providers": "[{\"codes\":{\"SOP\":[\"349\"]},\"description\":null,\"end_time\":null,\"financial_responsibility_type\":{\"code\":\"SELF\",\"codeSystem\":\"HL7 Relationship Code\"},\"health_record_field\":null,\"member_id\":\"1234567890\",\"mood_code\":\"EVN\",\"name\":\"Other\",\"negationInd\":null,\"negationReason\":null,\"oid\":null,\"payer\":{\"name\":\"Other\"},\"reason\":null,\"relationship\":null,\"specifics\":null,\"start_time\":1199145600,\"status_code\":null,\"time\":null,\"type\":\"OT\"}]"
+    },
+    "qdmVersion": "5.4"
+  }
+}

--- a/spec/javascripts/fixtures/json/patients/CMS232v0/Patient_Test 1.json
+++ b/spec/javascripts/fixtures/json/patients/CMS232v0/Patient_Test 1.json
@@ -1,0 +1,417 @@
+{
+  "_id": "5c06ec72b848466bbc906066",
+  "bundleId": "5a57e977942c6d1e61d32f14",
+  "expectedValues": [
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+      "population_index": 0,
+      "IPP": 1,
+      "DENOM": 1,
+      "DENEX": 0,
+      "NUMER": 1
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC",
+      "population_index": 0,
+      "IPP": 1,
+      "MSRPOPL": 1,
+      "MSRPOPLEX": 0,
+      "OBSERV": [
+        0.25
+      ],
+      "OBSERV_UNIT": ""
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&7B905B21-D904-454F-885B-9CE5D19674E3",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "NUMER": 0,
+      "DENEXCEP": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&5B20AFEA-D4AF-4F7A-A5A3-F1F6165B9E5F",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&3000797E-11B1-4F62-A078-341A4002A11C",
+      "population_index": 0,
+      "IPP": 1,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&920D5B27-DF5A-4770-BD60-FC4EE251C4D2",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&BA108B7B-90B4-4692-B1D0-5DB554D2A1A2",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0,
+      "DENEXCEP": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&F03324C2-9147-457B-BC34-811BB7859C91",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    }
+  ],
+  "familyName": "Test 1",
+  "givenNames": [
+    "Patient"
+  ],
+  "notes": "",
+  "qdmPatient": {
+    "_id": "5c880147d7c8ac4c3e106801",
+    "birthDatetime": "1940-01-01T08:00:00.000+00:00",
+    "dataElements": [
+      {
+        "_id": "5c880147d7c8ac4c3e106802",
+        "authorDatetime": "2011-07-04T08:00:00.000+00:00",
+        "components": [
+
+        ],
+        "dataElementCodes": [
+          {
+            "codeSystem": "LOINC",
+            "code": "59458-0"
+          }
+        ],
+        "description": "Assessment, Performed: Ambulatory Status",
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.117",
+        "id": {
+          "_id": "5c880147d7c8ac4c3e106803",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c06ece3b848466bbc906174"
+        },
+        "method": null,
+        "negationRationale": null,
+        "qdmCategory": "assessment",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "result": null,
+        "_type": "QDM::AssessmentPerformed"
+      },
+      {
+        "_id": "5c880147d7c8ac4c3e106804",
+        "authorDatetime": "2012-07-04T08:00:00.000+00:00",
+        "components": [
+
+        ],
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "401196007"
+          },
+          {
+            "codeSystem": "LOINC",
+            "code": "52552-7"
+          }
+        ],
+        "description": "Assessment, Performed: Falls Screening",
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.117",
+        "id": {
+          "_id": "5c880147d7c8ac4c3e106805",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c06ece3b848466bbc906175"
+        },
+        "method": null,
+        "negationRationale": null,
+        "qdmCategory": "assessment",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "result": null,
+        "_type": "QDM::AssessmentPerformed"
+      },
+      {
+        "_id": "5c880147d7c8ac4c3e106806",
+        "admissionSource": null,
+        "authorDatetime": "2012-12-04T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "HCPCS",
+            "code": "G0438"
+          }
+        ],
+        "description": "Encounter, Performed: Annual Wellness Visit",
+        "diagnoses": [
+
+        ],
+        "dischargeDisposition": null,
+        "facilityLocations": [
+
+        ],
+        "hqmfOid": "2.16.840.1.113883.3.560.1.79",
+        "id": {
+          "_id": "5c880147d7c8ac4c3e106807",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c06ece3b848466bbc906173"
+        },
+        "lengthOfStay": {
+          "value": 0,
+          "unit": "days"
+        },
+        "negationRationale": null,
+        "principalDiagnosis": null,
+        "qdmCategory": "encounter",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "relevantPeriod": {
+          "low": "2012-12-04T08:00:00.000+00:00",
+          "high": "2012-12-04T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "_type": "QDM::EncounterPerformed"
+      },
+      {
+        "_id": "5c880147d7c8ac4c3e1067fc",
+        "birthDatetime": "1940-01-01T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "code": "21112-8",
+            "codeSystem": "LOINC",
+            "descriptor": null,
+            "codeSystemOid": null,
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.54",
+        "id": {
+          "_id": "5c880147d7c8ac4c3e106808",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880147d7c8ac4c3e1067fc"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "birthdate",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicBirthdate"
+      },
+      {
+        "_id": "5c880147d7c8ac4c3e1067fd",
+        "dataElementCodes": [
+          {
+            "code": "2186-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "Not Hispanic or Latino",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.56",
+        "id": {
+          "_id": "5c880147d7c8ac4c3e106809",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880147d7c8ac4c3e1067fd"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "ethnicity",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicEthnicity"
+      },
+      {
+        "_id": "5c880147d7c8ac4c3e1067fe",
+        "dataElementCodes": [
+          {
+            "code": "1002-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "American Indian or Alaska Native",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.59",
+        "id": {
+          "_id": "5c880147d7c8ac4c3e10680a",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880147d7c8ac4c3e1067fe"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "race",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicRace"
+      },
+      {
+        "_id": "5c880147d7c8ac4c3e1067ff",
+        "dataElementCodes": [
+          {
+            "code": "M",
+            "codeSystem": "AdministrativeGender",
+            "descriptor": "M",
+            "codeSystemOid": "2.16.840.1.113883.5.1",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.55",
+        "id": {
+          "_id": "5c880147d7c8ac4c3e10680b",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880147d7c8ac4c3e1067ff"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "gender",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicSex"
+      }
+    ],
+    "extendedData": {
+      "type": null,
+      "measure_ids": [
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+        null,
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&7B905B21-D904-454F-885B-9CE5D19674E3",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&920D5B27-DF5A-4770-BD60-FC4EE251C4D2",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&3000797E-11B1-4F62-A078-341A4002A11C",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&5B20AFEA-D4AF-4F7A-A5A3-F1F6165B9E5F",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&F03324C2-9147-457B-BC34-811BB7859C91",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&BA108B7B-90B4-4692-B1D0-5DB554D2A1A2",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC"
+      ],
+      "source_data_criteria": [
+        {
+          "negation": false,
+          "definition": "assessment",
+          "status": "performed",
+          "title": "AmbulatoryStatus",
+          "description": "Assessment, Performed: Ambulatory Status",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.118.11.1219",
+          "type": "assessments",
+          "id": "AmbulatoryStatus_AssessmentPerformed_eb84926c_ae80_4768_9f88_ea55ed355df6_source",
+          "start_date": 1309766400000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+          "cms_id": "CMS231v0",
+          "criteria_id": "1677b0af52fFX",
+          "codes": {
+            "LOINC": [
+              "59458-0"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5c06ece3b848466bbc906174"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "assessment",
+          "status": "performed",
+          "title": "FallsScreening",
+          "description": "Assessment, Performed: Falls Screening",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.118.12.1028",
+          "type": "assessments",
+          "id": "FallsScreening_AssessmentPerformed_3296d6d9_085b_4acd_84a9_819c01e4e5cd_source",
+          "start_date": 1341388800000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+          "cms_id": "CMS231v0",
+          "criteria_id": "1677b0b4e9bGs",
+          "codes": {
+            "SNOMED-CT": [
+              "401196007"
+            ],
+            "LOINC": [
+              "52552-7"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5c06ece3b848466bbc906175"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "encounter",
+          "status": "performed",
+          "title": "AnnualWellnessVisit",
+          "description": "Encounter, Performed: Annual Wellness Visit",
+          "code_list_id": "2.16.840.1.113883.3.526.3.1240",
+          "type": "encounters",
+          "id": "AnnualWellnessVisit_EncounterPerformed_d50103e4_3ce4_48e3_9489_68dc37fb0b20_source",
+          "start_date": 1354608000000,
+          "end_date": 1354608900000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+          "cms_id": "CMS231v0",
+          "criteria_id": "1677b0ac53a4Q",
+          "codes": {
+            "HCPCS": [
+              "G0438"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5c06ece3b848466bbc906173"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "id": "MeasurePeriod",
+          "start_date": 0,
+          "end_date": 0,
+          "references": null
+        }
+      ],
+      "is_shared": null,
+      "origin_data": [
+
+      ],
+      "test_id": null,
+      "medical_record_number": "d975a2c11a5dbfa9af64642c349f94b5f5e5b43b211617f5d2992dd0438ca8fd",
+      "medical_record_assigner": "Bonnie",
+      "description": null,
+      "description_category": null,
+      "insurance_providers": "[{\"codes\":{\"SOP\":[\"349\"]},\"description\":null,\"end_time\":null,\"financial_responsibility_type\":{\"code\":\"SELF\",\"codeSystem\":\"HL7 Relationship Code\"},\"health_record_field\":null,\"member_id\":\"1234567890\",\"mood_code\":\"EVN\",\"name\":\"Other\",\"negationInd\":null,\"negationReason\":null,\"oid\":null,\"payer\":{\"name\":\"Other\"},\"reason\":null,\"relationship\":null,\"specifics\":null,\"start_time\":1199145600,\"status_code\":null,\"time\":null,\"type\":\"OT\"}]"
+    },
+    "qdmVersion": "5.4"
+  }
+}

--- a/spec/javascripts/fixtures/json/patients/CMS232v0/Patient_Test 2.json
+++ b/spec/javascripts/fixtures/json/patients/CMS232v0/Patient_Test 2.json
@@ -1,0 +1,417 @@
+{
+  "_id": "5c06ecf1b848466bbc906184",
+  "bundleId": "5a57e977942c6d1e61d32f14",
+  "expectedValues": [
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+      "population_index": 0,
+      "IPP": 1,
+      "DENOM": 1,
+      "DENEX": 0,
+      "NUMER": 1
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC",
+      "population_index": 0,
+      "IPP": 1,
+      "MSRPOPL": 1,
+      "MSRPOPLEX": 0,
+      "OBSERV": [
+        0.25
+      ],
+      "OBSERV_UNIT": ""
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&7B905B21-D904-454F-885B-9CE5D19674E3",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "NUMER": 0,
+      "DENEXCEP": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&5B20AFEA-D4AF-4F7A-A5A3-F1F6165B9E5F",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&3000797E-11B1-4F62-A078-341A4002A11C",
+      "population_index": 0,
+      "IPP": 1,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&920D5B27-DF5A-4770-BD60-FC4EE251C4D2",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&BA108B7B-90B4-4692-B1D0-5DB554D2A1A2",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0,
+      "DENEXCEP": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&F03324C2-9147-457B-BC34-811BB7859C91",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    }
+  ],
+  "familyName": "Test 2",
+  "givenNames": [
+    "Patient"
+  ],
+  "notes": "",
+  "qdmPatient": {
+    "_id": "5c880147d7c8ac4c3e106811",
+    "birthDatetime": "1940-01-01T08:00:00.000+00:00",
+    "dataElements": [
+      {
+        "_id": "5c880147d7c8ac4c3e106812",
+        "authorDatetime": "2011-07-04T08:00:00.000+00:00",
+        "components": [
+
+        ],
+        "dataElementCodes": [
+          {
+            "codeSystem": "LOINC",
+            "code": "59458-0"
+          }
+        ],
+        "description": "Assessment, Performed: Ambulatory Status",
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.117",
+        "id": {
+          "_id": "5c880147d7c8ac4c3e106813",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c06ecf1b848466bbc906185"
+        },
+        "method": null,
+        "negationRationale": null,
+        "qdmCategory": "assessment",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "result": null,
+        "_type": "QDM::AssessmentPerformed"
+      },
+      {
+        "_id": "5c880147d7c8ac4c3e106814",
+        "authorDatetime": "2012-07-04T08:00:00.000+00:00",
+        "components": [
+
+        ],
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "401196007"
+          },
+          {
+            "codeSystem": "LOINC",
+            "code": "52552-7"
+          }
+        ],
+        "description": "Assessment, Performed: Falls Screening",
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.117",
+        "id": {
+          "_id": "5c880147d7c8ac4c3e106815",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c06ecf1b848466bbc906186"
+        },
+        "method": null,
+        "negationRationale": null,
+        "qdmCategory": "assessment",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "result": null,
+        "_type": "QDM::AssessmentPerformed"
+      },
+      {
+        "_id": "5c880147d7c8ac4c3e106816",
+        "admissionSource": null,
+        "authorDatetime": "2012-12-04T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "HCPCS",
+            "code": "G0438"
+          }
+        ],
+        "description": "Encounter, Performed: Annual Wellness Visit",
+        "diagnoses": [
+
+        ],
+        "dischargeDisposition": null,
+        "facilityLocations": [
+
+        ],
+        "hqmfOid": "2.16.840.1.113883.3.560.1.79",
+        "id": {
+          "_id": "5c880147d7c8ac4c3e106817",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c06ecf1b848466bbc906187"
+        },
+        "lengthOfStay": {
+          "value": 0,
+          "unit": "days"
+        },
+        "negationRationale": null,
+        "principalDiagnosis": null,
+        "qdmCategory": "encounter",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "relevantPeriod": {
+          "low": "2012-12-04T08:00:00.000+00:00",
+          "high": "2012-12-04T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "_type": "QDM::EncounterPerformed"
+      },
+      {
+        "_id": "5c880147d7c8ac4c3e10680c",
+        "birthDatetime": "1940-01-01T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "code": "21112-8",
+            "codeSystem": "LOINC",
+            "descriptor": null,
+            "codeSystemOid": null,
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.54",
+        "id": {
+          "_id": "5c880147d7c8ac4c3e106818",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880147d7c8ac4c3e10680c"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "birthdate",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicBirthdate"
+      },
+      {
+        "_id": "5c880147d7c8ac4c3e10680d",
+        "dataElementCodes": [
+          {
+            "code": "2186-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "Not Hispanic or Latino",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.56",
+        "id": {
+          "_id": "5c880147d7c8ac4c3e106819",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880147d7c8ac4c3e10680d"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "ethnicity",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicEthnicity"
+      },
+      {
+        "_id": "5c880147d7c8ac4c3e10680e",
+        "dataElementCodes": [
+          {
+            "code": "1002-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "American Indian or Alaska Native",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.59",
+        "id": {
+          "_id": "5c880147d7c8ac4c3e10681a",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880147d7c8ac4c3e10680e"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "race",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicRace"
+      },
+      {
+        "_id": "5c880147d7c8ac4c3e10680f",
+        "dataElementCodes": [
+          {
+            "code": "M",
+            "codeSystem": "AdministrativeGender",
+            "descriptor": "M",
+            "codeSystemOid": "2.16.840.1.113883.5.1",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.55",
+        "id": {
+          "_id": "5c880147d7c8ac4c3e10681b",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880147d7c8ac4c3e10680f"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "gender",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicSex"
+      }
+    ],
+    "extendedData": {
+      "type": null,
+      "measure_ids": [
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&7B905B21-D904-454F-885B-9CE5D19674E3",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&920D5B27-DF5A-4770-BD60-FC4EE251C4D2",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&3000797E-11B1-4F62-A078-341A4002A11C",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&5B20AFEA-D4AF-4F7A-A5A3-F1F6165B9E5F",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&F03324C2-9147-457B-BC34-811BB7859C91",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&BA108B7B-90B4-4692-B1D0-5DB554D2A1A2",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC",
+        null
+      ],
+      "source_data_criteria": [
+        {
+          "negation": false,
+          "definition": "assessment",
+          "status": "performed",
+          "title": "AmbulatoryStatus",
+          "description": "Assessment, Performed: Ambulatory Status",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.118.11.1219",
+          "type": "assessments",
+          "id": "AmbulatoryStatus_AssessmentPerformed_eb84926c_ae80_4768_9f88_ea55ed355df6_source",
+          "start_date": 1309766400000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+          "cms_id": "CMS231v0",
+          "criteria_id": "1677b0af52fFX",
+          "codes": {
+            "LOINC": [
+              "59458-0"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5c06ecf1b848466bbc906185"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "assessment",
+          "status": "performed",
+          "title": "FallsScreening",
+          "description": "Assessment, Performed: Falls Screening",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.118.12.1028",
+          "type": "assessments",
+          "id": "FallsScreening_AssessmentPerformed_3296d6d9_085b_4acd_84a9_819c01e4e5cd_source",
+          "start_date": 1341388800000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+          "cms_id": "CMS231v0",
+          "criteria_id": "1677b0b4e9bGs",
+          "codes": {
+            "SNOMED-CT": [
+              "401196007"
+            ],
+            "LOINC": [
+              "52552-7"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5c06ecf1b848466bbc906186"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "encounter",
+          "status": "performed",
+          "title": "AnnualWellnessVisit",
+          "description": "Encounter, Performed: Annual Wellness Visit",
+          "code_list_id": "2.16.840.1.113883.3.526.3.1240",
+          "type": "encounters",
+          "id": "AnnualWellnessVisit_EncounterPerformed_d50103e4_3ce4_48e3_9489_68dc37fb0b20_source",
+          "start_date": 1354608000000,
+          "end_date": 1354608900000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+          "cms_id": "CMS231v0",
+          "criteria_id": "1677b0ac53a4Q",
+          "codes": {
+            "HCPCS": [
+              "G0438"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5c06ecf1b848466bbc906187"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "id": "MeasurePeriod",
+          "start_date": 0,
+          "end_date": 0,
+          "references": null
+        }
+      ],
+      "is_shared": null,
+      "origin_data": [
+
+      ],
+      "test_id": null,
+      "medical_record_number": "66e7185c846fb50aaff1541a59d0b72284f89f64783a89bb33f9ae0d93f07361",
+      "medical_record_assigner": "Bonnie",
+      "description": null,
+      "description_category": null,
+      "insurance_providers": "[{\"codes\":{\"SOP\":[\"349\"]},\"description\":null,\"end_time\":null,\"financial_responsibility_type\":{\"code\":\"SELF\",\"codeSystem\":\"HL7 Relationship Code\"},\"health_record_field\":null,\"member_id\":\"1234567890\",\"mood_code\":\"EVN\",\"name\":\"Other\",\"negationInd\":null,\"negationReason\":null,\"oid\":null,\"payer\":{\"name\":\"Other\"},\"reason\":null,\"relationship\":null,\"specifics\":null,\"start_time\":1199145600,\"status_code\":null,\"time\":null,\"type\":\"OT\"}]"
+    },
+    "qdmVersion": "5.4"
+  }
+}

--- a/spec/javascripts/fixtures/json/patients/CMS233v0/Patient_Test 1.json
+++ b/spec/javascripts/fixtures/json/patients/CMS233v0/Patient_Test 1.json
@@ -1,0 +1,417 @@
+{
+  "_id": "5c06ec72b848466bbc906066",
+  "bundleId": "5a57e977942c6d1e61d32f14",
+  "expectedValues": [
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+      "population_index": 0,
+      "IPP": 1,
+      "DENOM": 1,
+      "DENEX": 0,
+      "NUMER": 1
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC",
+      "population_index": 0,
+      "IPP": 1,
+      "MSRPOPL": 1,
+      "MSRPOPLEX": 0,
+      "OBSERV": [
+        0.25
+      ],
+      "OBSERV_UNIT": ""
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&7B905B21-D904-454F-885B-9CE5D19674E3",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "NUMER": 0,
+      "DENEXCEP": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&5B20AFEA-D4AF-4F7A-A5A3-F1F6165B9E5F",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&3000797E-11B1-4F62-A078-341A4002A11C",
+      "population_index": 0,
+      "IPP": 1,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&920D5B27-DF5A-4770-BD60-FC4EE251C4D2",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&BA108B7B-90B4-4692-B1D0-5DB554D2A1A2",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0,
+      "DENEXCEP": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&F03324C2-9147-457B-BC34-811BB7859C91",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    }
+  ],
+  "familyName": "Test 1",
+  "givenNames": [
+    "Patient"
+  ],
+  "notes": "",
+  "qdmPatient": {
+    "_id": "5c880147d7c8ac4c3e106821",
+    "birthDatetime": "1940-01-01T08:00:00.000+00:00",
+    "dataElements": [
+      {
+        "_id": "5c880147d7c8ac4c3e106822",
+        "authorDatetime": "2011-07-04T08:00:00.000+00:00",
+        "components": [
+
+        ],
+        "dataElementCodes": [
+          {
+            "codeSystem": "LOINC",
+            "code": "59458-0"
+          }
+        ],
+        "description": "Assessment, Performed: Ambulatory Status",
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.117",
+        "id": {
+          "_id": "5c880147d7c8ac4c3e106823",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c06ece3b848466bbc906174"
+        },
+        "method": null,
+        "negationRationale": null,
+        "qdmCategory": "assessment",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "result": null,
+        "_type": "QDM::AssessmentPerformed"
+      },
+      {
+        "_id": "5c880147d7c8ac4c3e106824",
+        "authorDatetime": "2012-07-04T08:00:00.000+00:00",
+        "components": [
+
+        ],
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "401196007"
+          },
+          {
+            "codeSystem": "LOINC",
+            "code": "52552-7"
+          }
+        ],
+        "description": "Assessment, Performed: Falls Screening",
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.117",
+        "id": {
+          "_id": "5c880147d7c8ac4c3e106825",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c06ece3b848466bbc906175"
+        },
+        "method": null,
+        "negationRationale": null,
+        "qdmCategory": "assessment",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "result": null,
+        "_type": "QDM::AssessmentPerformed"
+      },
+      {
+        "_id": "5c880147d7c8ac4c3e106826",
+        "admissionSource": null,
+        "authorDatetime": "2012-12-04T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "HCPCS",
+            "code": "G0438"
+          }
+        ],
+        "description": "Encounter, Performed: Annual Wellness Visit",
+        "diagnoses": [
+
+        ],
+        "dischargeDisposition": null,
+        "facilityLocations": [
+
+        ],
+        "hqmfOid": "2.16.840.1.113883.3.560.1.79",
+        "id": {
+          "_id": "5c880147d7c8ac4c3e106827",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c06ece3b848466bbc906173"
+        },
+        "lengthOfStay": {
+          "value": 0,
+          "unit": "days"
+        },
+        "negationRationale": null,
+        "principalDiagnosis": null,
+        "qdmCategory": "encounter",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "relevantPeriod": {
+          "low": "2012-12-04T08:00:00.000+00:00",
+          "high": "2012-12-04T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "_type": "QDM::EncounterPerformed"
+      },
+      {
+        "_id": "5c880147d7c8ac4c3e10681c",
+        "birthDatetime": "1940-01-01T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "code": "21112-8",
+            "codeSystem": "LOINC",
+            "descriptor": null,
+            "codeSystemOid": null,
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.54",
+        "id": {
+          "_id": "5c880147d7c8ac4c3e106828",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880147d7c8ac4c3e10681c"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "birthdate",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicBirthdate"
+      },
+      {
+        "_id": "5c880147d7c8ac4c3e10681d",
+        "dataElementCodes": [
+          {
+            "code": "2186-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "Not Hispanic or Latino",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.56",
+        "id": {
+          "_id": "5c880147d7c8ac4c3e106829",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880147d7c8ac4c3e10681d"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "ethnicity",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicEthnicity"
+      },
+      {
+        "_id": "5c880147d7c8ac4c3e10681e",
+        "dataElementCodes": [
+          {
+            "code": "1002-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "American Indian or Alaska Native",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.59",
+        "id": {
+          "_id": "5c880147d7c8ac4c3e10682a",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880147d7c8ac4c3e10681e"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "race",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicRace"
+      },
+      {
+        "_id": "5c880147d7c8ac4c3e10681f",
+        "dataElementCodes": [
+          {
+            "code": "M",
+            "codeSystem": "AdministrativeGender",
+            "descriptor": "M",
+            "codeSystemOid": "2.16.840.1.113883.5.1",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.55",
+        "id": {
+          "_id": "5c880147d7c8ac4c3e10682b",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880147d7c8ac4c3e10681f"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "gender",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicSex"
+      }
+    ],
+    "extendedData": {
+      "type": null,
+      "measure_ids": [
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+        null,
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&7B905B21-D904-454F-885B-9CE5D19674E3",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&920D5B27-DF5A-4770-BD60-FC4EE251C4D2",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&3000797E-11B1-4F62-A078-341A4002A11C",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&5B20AFEA-D4AF-4F7A-A5A3-F1F6165B9E5F",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&F03324C2-9147-457B-BC34-811BB7859C91",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&BA108B7B-90B4-4692-B1D0-5DB554D2A1A2",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC"
+      ],
+      "source_data_criteria": [
+        {
+          "negation": false,
+          "definition": "assessment",
+          "status": "performed",
+          "title": "AmbulatoryStatus",
+          "description": "Assessment, Performed: Ambulatory Status",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.118.11.1219",
+          "type": "assessments",
+          "id": "AmbulatoryStatus_AssessmentPerformed_eb84926c_ae80_4768_9f88_ea55ed355df6_source",
+          "start_date": 1309766400000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+          "cms_id": "CMS231v0",
+          "criteria_id": "1677b0af52fFX",
+          "codes": {
+            "LOINC": [
+              "59458-0"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5c06ece3b848466bbc906174"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "assessment",
+          "status": "performed",
+          "title": "FallsScreening",
+          "description": "Assessment, Performed: Falls Screening",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.118.12.1028",
+          "type": "assessments",
+          "id": "FallsScreening_AssessmentPerformed_3296d6d9_085b_4acd_84a9_819c01e4e5cd_source",
+          "start_date": 1341388800000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+          "cms_id": "CMS231v0",
+          "criteria_id": "1677b0b4e9bGs",
+          "codes": {
+            "SNOMED-CT": [
+              "401196007"
+            ],
+            "LOINC": [
+              "52552-7"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5c06ece3b848466bbc906175"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "encounter",
+          "status": "performed",
+          "title": "AnnualWellnessVisit",
+          "description": "Encounter, Performed: Annual Wellness Visit",
+          "code_list_id": "2.16.840.1.113883.3.526.3.1240",
+          "type": "encounters",
+          "id": "AnnualWellnessVisit_EncounterPerformed_d50103e4_3ce4_48e3_9489_68dc37fb0b20_source",
+          "start_date": 1354608000000,
+          "end_date": 1354608900000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+          "cms_id": "CMS231v0",
+          "criteria_id": "1677b0ac53a4Q",
+          "codes": {
+            "HCPCS": [
+              "G0438"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5c06ece3b848466bbc906173"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "id": "MeasurePeriod",
+          "start_date": 0,
+          "end_date": 0,
+          "references": null
+        }
+      ],
+      "is_shared": null,
+      "origin_data": [
+
+      ],
+      "test_id": null,
+      "medical_record_number": "d975a2c11a5dbfa9af64642c349f94b5f5e5b43b211617f5d2992dd0438ca8fd",
+      "medical_record_assigner": "Bonnie",
+      "description": null,
+      "description_category": null,
+      "insurance_providers": "[{\"codes\":{\"SOP\":[\"349\"]},\"description\":null,\"end_time\":null,\"financial_responsibility_type\":{\"code\":\"SELF\",\"codeSystem\":\"HL7 Relationship Code\"},\"health_record_field\":null,\"member_id\":\"1234567890\",\"mood_code\":\"EVN\",\"name\":\"Other\",\"negationInd\":null,\"negationReason\":null,\"oid\":null,\"payer\":{\"name\":\"Other\"},\"reason\":null,\"relationship\":null,\"specifics\":null,\"start_time\":1199145600,\"status_code\":null,\"time\":null,\"type\":\"OT\"}]"
+    },
+    "qdmVersion": "5.4"
+  }
+}

--- a/spec/javascripts/fixtures/json/patients/CMS233v0/Patient_Test 2.json
+++ b/spec/javascripts/fixtures/json/patients/CMS233v0/Patient_Test 2.json
@@ -1,0 +1,417 @@
+{
+  "_id": "5c06ecf1b848466bbc906184",
+  "bundleId": "5a57e977942c6d1e61d32f14",
+  "expectedValues": [
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+      "population_index": 0,
+      "IPP": 1,
+      "DENOM": 1,
+      "DENEX": 0,
+      "NUMER": 1
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC",
+      "population_index": 0,
+      "IPP": 1,
+      "MSRPOPL": 1,
+      "MSRPOPLEX": 0,
+      "OBSERV": [
+        0.25
+      ],
+      "OBSERV_UNIT": ""
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&7B905B21-D904-454F-885B-9CE5D19674E3",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "NUMER": 0,
+      "DENEXCEP": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&5B20AFEA-D4AF-4F7A-A5A3-F1F6165B9E5F",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&3000797E-11B1-4F62-A078-341A4002A11C",
+      "population_index": 0,
+      "IPP": 1,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&920D5B27-DF5A-4770-BD60-FC4EE251C4D2",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&BA108B7B-90B4-4692-B1D0-5DB554D2A1A2",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0,
+      "DENEXCEP": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&F03324C2-9147-457B-BC34-811BB7859C91",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    }
+  ],
+  "familyName": "Test 2",
+  "givenNames": [
+    "Patient"
+  ],
+  "notes": "",
+  "qdmPatient": {
+    "_id": "5c880147d7c8ac4c3e106831",
+    "birthDatetime": "1940-01-01T08:00:00.000+00:00",
+    "dataElements": [
+      {
+        "_id": "5c880147d7c8ac4c3e106832",
+        "authorDatetime": "2011-07-04T08:00:00.000+00:00",
+        "components": [
+
+        ],
+        "dataElementCodes": [
+          {
+            "codeSystem": "LOINC",
+            "code": "59458-0"
+          }
+        ],
+        "description": "Assessment, Performed: Ambulatory Status",
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.117",
+        "id": {
+          "_id": "5c880147d7c8ac4c3e106833",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c06ecf1b848466bbc906185"
+        },
+        "method": null,
+        "negationRationale": null,
+        "qdmCategory": "assessment",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "result": null,
+        "_type": "QDM::AssessmentPerformed"
+      },
+      {
+        "_id": "5c880147d7c8ac4c3e106834",
+        "authorDatetime": "2012-07-04T08:00:00.000+00:00",
+        "components": [
+
+        ],
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "401196007"
+          },
+          {
+            "codeSystem": "LOINC",
+            "code": "52552-7"
+          }
+        ],
+        "description": "Assessment, Performed: Falls Screening",
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.117",
+        "id": {
+          "_id": "5c880147d7c8ac4c3e106835",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c06ecf1b848466bbc906186"
+        },
+        "method": null,
+        "negationRationale": null,
+        "qdmCategory": "assessment",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "result": null,
+        "_type": "QDM::AssessmentPerformed"
+      },
+      {
+        "_id": "5c880147d7c8ac4c3e106836",
+        "admissionSource": null,
+        "authorDatetime": "2012-12-04T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "HCPCS",
+            "code": "G0438"
+          }
+        ],
+        "description": "Encounter, Performed: Annual Wellness Visit",
+        "diagnoses": [
+
+        ],
+        "dischargeDisposition": null,
+        "facilityLocations": [
+
+        ],
+        "hqmfOid": "2.16.840.1.113883.3.560.1.79",
+        "id": {
+          "_id": "5c880147d7c8ac4c3e106837",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c06ecf1b848466bbc906187"
+        },
+        "lengthOfStay": {
+          "value": 0,
+          "unit": "days"
+        },
+        "negationRationale": null,
+        "principalDiagnosis": null,
+        "qdmCategory": "encounter",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "relevantPeriod": {
+          "low": "2012-12-04T08:00:00.000+00:00",
+          "high": "2012-12-04T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "_type": "QDM::EncounterPerformed"
+      },
+      {
+        "_id": "5c880147d7c8ac4c3e10682c",
+        "birthDatetime": "1940-01-01T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "code": "21112-8",
+            "codeSystem": "LOINC",
+            "descriptor": null,
+            "codeSystemOid": null,
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.54",
+        "id": {
+          "_id": "5c880147d7c8ac4c3e106838",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880147d7c8ac4c3e10682c"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "birthdate",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicBirthdate"
+      },
+      {
+        "_id": "5c880147d7c8ac4c3e10682d",
+        "dataElementCodes": [
+          {
+            "code": "2186-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "Not Hispanic or Latino",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.56",
+        "id": {
+          "_id": "5c880147d7c8ac4c3e106839",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880147d7c8ac4c3e10682d"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "ethnicity",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicEthnicity"
+      },
+      {
+        "_id": "5c880147d7c8ac4c3e10682e",
+        "dataElementCodes": [
+          {
+            "code": "1002-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "American Indian or Alaska Native",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.59",
+        "id": {
+          "_id": "5c880147d7c8ac4c3e10683a",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880147d7c8ac4c3e10682e"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "race",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicRace"
+      },
+      {
+        "_id": "5c880147d7c8ac4c3e10682f",
+        "dataElementCodes": [
+          {
+            "code": "M",
+            "codeSystem": "AdministrativeGender",
+            "descriptor": "M",
+            "codeSystemOid": "2.16.840.1.113883.5.1",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.55",
+        "id": {
+          "_id": "5c880147d7c8ac4c3e10683b",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880147d7c8ac4c3e10682f"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "gender",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicSex"
+      }
+    ],
+    "extendedData": {
+      "type": null,
+      "measure_ids": [
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&7B905B21-D904-454F-885B-9CE5D19674E3",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&920D5B27-DF5A-4770-BD60-FC4EE251C4D2",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&3000797E-11B1-4F62-A078-341A4002A11C",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&5B20AFEA-D4AF-4F7A-A5A3-F1F6165B9E5F",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&F03324C2-9147-457B-BC34-811BB7859C91",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&BA108B7B-90B4-4692-B1D0-5DB554D2A1A2",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC",
+        null
+      ],
+      "source_data_criteria": [
+        {
+          "negation": false,
+          "definition": "assessment",
+          "status": "performed",
+          "title": "AmbulatoryStatus",
+          "description": "Assessment, Performed: Ambulatory Status",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.118.11.1219",
+          "type": "assessments",
+          "id": "AmbulatoryStatus_AssessmentPerformed_eb84926c_ae80_4768_9f88_ea55ed355df6_source",
+          "start_date": 1309766400000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+          "cms_id": "CMS231v0",
+          "criteria_id": "1677b0af52fFX",
+          "codes": {
+            "LOINC": [
+              "59458-0"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5c06ecf1b848466bbc906185"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "assessment",
+          "status": "performed",
+          "title": "FallsScreening",
+          "description": "Assessment, Performed: Falls Screening",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.118.12.1028",
+          "type": "assessments",
+          "id": "FallsScreening_AssessmentPerformed_3296d6d9_085b_4acd_84a9_819c01e4e5cd_source",
+          "start_date": 1341388800000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+          "cms_id": "CMS231v0",
+          "criteria_id": "1677b0b4e9bGs",
+          "codes": {
+            "SNOMED-CT": [
+              "401196007"
+            ],
+            "LOINC": [
+              "52552-7"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5c06ecf1b848466bbc906186"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "encounter",
+          "status": "performed",
+          "title": "AnnualWellnessVisit",
+          "description": "Encounter, Performed: Annual Wellness Visit",
+          "code_list_id": "2.16.840.1.113883.3.526.3.1240",
+          "type": "encounters",
+          "id": "AnnualWellnessVisit_EncounterPerformed_d50103e4_3ce4_48e3_9489_68dc37fb0b20_source",
+          "start_date": 1354608000000,
+          "end_date": 1354608900000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+          "cms_id": "CMS231v0",
+          "criteria_id": "1677b0ac53a4Q",
+          "codes": {
+            "HCPCS": [
+              "G0438"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5c06ecf1b848466bbc906187"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "id": "MeasurePeriod",
+          "start_date": 0,
+          "end_date": 0,
+          "references": null
+        }
+      ],
+      "is_shared": null,
+      "origin_data": [
+
+      ],
+      "test_id": null,
+      "medical_record_number": "66e7185c846fb50aaff1541a59d0b72284f89f64783a89bb33f9ae0d93f07361",
+      "medical_record_assigner": "Bonnie",
+      "description": null,
+      "description_category": null,
+      "insurance_providers": "[{\"codes\":{\"SOP\":[\"349\"]},\"description\":null,\"end_time\":null,\"financial_responsibility_type\":{\"code\":\"SELF\",\"codeSystem\":\"HL7 Relationship Code\"},\"health_record_field\":null,\"member_id\":\"1234567890\",\"mood_code\":\"EVN\",\"name\":\"Other\",\"negationInd\":null,\"negationReason\":null,\"oid\":null,\"payer\":{\"name\":\"Other\"},\"reason\":null,\"relationship\":null,\"specifics\":null,\"start_time\":1199145600,\"status_code\":null,\"time\":null,\"type\":\"OT\"}]"
+    },
+    "qdmVersion": "5.4"
+  }
+}

--- a/spec/javascripts/fixtures/json/patients/CMS234v0/Patient_Test 1.json
+++ b/spec/javascripts/fixtures/json/patients/CMS234v0/Patient_Test 1.json
@@ -1,0 +1,417 @@
+{
+  "_id": "5c06ec72b848466bbc906066",
+  "bundleId": "5a57e977942c6d1e61d32f14",
+  "expectedValues": [
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+      "population_index": 0,
+      "IPP": 1,
+      "DENOM": 1,
+      "DENEX": 0,
+      "NUMER": 1
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC",
+      "population_index": 0,
+      "IPP": 1,
+      "MSRPOPL": 1,
+      "MSRPOPLEX": 0,
+      "OBSERV": [
+        0.25
+      ],
+      "OBSERV_UNIT": ""
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&7B905B21-D904-454F-885B-9CE5D19674E3",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "NUMER": 0,
+      "DENEXCEP": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&5B20AFEA-D4AF-4F7A-A5A3-F1F6165B9E5F",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&3000797E-11B1-4F62-A078-341A4002A11C",
+      "population_index": 0,
+      "IPP": 1,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&920D5B27-DF5A-4770-BD60-FC4EE251C4D2",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&BA108B7B-90B4-4692-B1D0-5DB554D2A1A2",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0,
+      "DENEXCEP": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&F03324C2-9147-457B-BC34-811BB7859C91",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    }
+  ],
+  "familyName": "Test 1",
+  "givenNames": [
+    "Patient"
+  ],
+  "notes": "",
+  "qdmPatient": {
+    "_id": "5c880147d7c8ac4c3e106841",
+    "birthDatetime": "1940-01-01T08:00:00.000+00:00",
+    "dataElements": [
+      {
+        "_id": "5c880147d7c8ac4c3e106842",
+        "authorDatetime": "2011-07-04T08:00:00.000+00:00",
+        "components": [
+
+        ],
+        "dataElementCodes": [
+          {
+            "codeSystem": "LOINC",
+            "code": "59458-0"
+          }
+        ],
+        "description": "Assessment, Performed: Ambulatory Status",
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.117",
+        "id": {
+          "_id": "5c880147d7c8ac4c3e106843",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c06ece3b848466bbc906174"
+        },
+        "method": null,
+        "negationRationale": null,
+        "qdmCategory": "assessment",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "result": null,
+        "_type": "QDM::AssessmentPerformed"
+      },
+      {
+        "_id": "5c880147d7c8ac4c3e106844",
+        "authorDatetime": "2012-07-04T08:00:00.000+00:00",
+        "components": [
+
+        ],
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "401196007"
+          },
+          {
+            "codeSystem": "LOINC",
+            "code": "52552-7"
+          }
+        ],
+        "description": "Assessment, Performed: Falls Screening",
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.117",
+        "id": {
+          "_id": "5c880147d7c8ac4c3e106845",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c06ece3b848466bbc906175"
+        },
+        "method": null,
+        "negationRationale": null,
+        "qdmCategory": "assessment",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "result": null,
+        "_type": "QDM::AssessmentPerformed"
+      },
+      {
+        "_id": "5c880147d7c8ac4c3e106846",
+        "admissionSource": null,
+        "authorDatetime": "2012-12-04T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "HCPCS",
+            "code": "G0438"
+          }
+        ],
+        "description": "Encounter, Performed: Annual Wellness Visit",
+        "diagnoses": [
+
+        ],
+        "dischargeDisposition": null,
+        "facilityLocations": [
+
+        ],
+        "hqmfOid": "2.16.840.1.113883.3.560.1.79",
+        "id": {
+          "_id": "5c880147d7c8ac4c3e106847",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c06ece3b848466bbc906173"
+        },
+        "lengthOfStay": {
+          "value": 0,
+          "unit": "days"
+        },
+        "negationRationale": null,
+        "principalDiagnosis": null,
+        "qdmCategory": "encounter",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "relevantPeriod": {
+          "low": "2012-12-04T08:00:00.000+00:00",
+          "high": "2012-12-04T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "_type": "QDM::EncounterPerformed"
+      },
+      {
+        "_id": "5c880147d7c8ac4c3e10683c",
+        "birthDatetime": "1940-01-01T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "code": "21112-8",
+            "codeSystem": "LOINC",
+            "descriptor": null,
+            "codeSystemOid": null,
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.54",
+        "id": {
+          "_id": "5c880147d7c8ac4c3e106848",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880147d7c8ac4c3e10683c"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "birthdate",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicBirthdate"
+      },
+      {
+        "_id": "5c880147d7c8ac4c3e10683d",
+        "dataElementCodes": [
+          {
+            "code": "2186-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "Not Hispanic or Latino",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.56",
+        "id": {
+          "_id": "5c880147d7c8ac4c3e106849",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880147d7c8ac4c3e10683d"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "ethnicity",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicEthnicity"
+      },
+      {
+        "_id": "5c880147d7c8ac4c3e10683e",
+        "dataElementCodes": [
+          {
+            "code": "1002-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "American Indian or Alaska Native",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.59",
+        "id": {
+          "_id": "5c880147d7c8ac4c3e10684a",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880147d7c8ac4c3e10683e"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "race",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicRace"
+      },
+      {
+        "_id": "5c880147d7c8ac4c3e10683f",
+        "dataElementCodes": [
+          {
+            "code": "M",
+            "codeSystem": "AdministrativeGender",
+            "descriptor": "M",
+            "codeSystemOid": "2.16.840.1.113883.5.1",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.55",
+        "id": {
+          "_id": "5c880147d7c8ac4c3e10684b",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880147d7c8ac4c3e10683f"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "gender",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicSex"
+      }
+    ],
+    "extendedData": {
+      "type": null,
+      "measure_ids": [
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+        null,
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&7B905B21-D904-454F-885B-9CE5D19674E3",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&920D5B27-DF5A-4770-BD60-FC4EE251C4D2",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&3000797E-11B1-4F62-A078-341A4002A11C",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&5B20AFEA-D4AF-4F7A-A5A3-F1F6165B9E5F",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&F03324C2-9147-457B-BC34-811BB7859C91",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&BA108B7B-90B4-4692-B1D0-5DB554D2A1A2",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC"
+      ],
+      "source_data_criteria": [
+        {
+          "negation": false,
+          "definition": "assessment",
+          "status": "performed",
+          "title": "AmbulatoryStatus",
+          "description": "Assessment, Performed: Ambulatory Status",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.118.11.1219",
+          "type": "assessments",
+          "id": "AmbulatoryStatus_AssessmentPerformed_eb84926c_ae80_4768_9f88_ea55ed355df6_source",
+          "start_date": 1309766400000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+          "cms_id": "CMS231v0",
+          "criteria_id": "1677b0af52fFX",
+          "codes": {
+            "LOINC": [
+              "59458-0"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5c06ece3b848466bbc906174"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "assessment",
+          "status": "performed",
+          "title": "FallsScreening",
+          "description": "Assessment, Performed: Falls Screening",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.118.12.1028",
+          "type": "assessments",
+          "id": "FallsScreening_AssessmentPerformed_3296d6d9_085b_4acd_84a9_819c01e4e5cd_source",
+          "start_date": 1341388800000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+          "cms_id": "CMS231v0",
+          "criteria_id": "1677b0b4e9bGs",
+          "codes": {
+            "SNOMED-CT": [
+              "401196007"
+            ],
+            "LOINC": [
+              "52552-7"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5c06ece3b848466bbc906175"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "encounter",
+          "status": "performed",
+          "title": "AnnualWellnessVisit",
+          "description": "Encounter, Performed: Annual Wellness Visit",
+          "code_list_id": "2.16.840.1.113883.3.526.3.1240",
+          "type": "encounters",
+          "id": "AnnualWellnessVisit_EncounterPerformed_d50103e4_3ce4_48e3_9489_68dc37fb0b20_source",
+          "start_date": 1354608000000,
+          "end_date": 1354608900000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+          "cms_id": "CMS231v0",
+          "criteria_id": "1677b0ac53a4Q",
+          "codes": {
+            "HCPCS": [
+              "G0438"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5c06ece3b848466bbc906173"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "id": "MeasurePeriod",
+          "start_date": 0,
+          "end_date": 0,
+          "references": null
+        }
+      ],
+      "is_shared": null,
+      "origin_data": [
+
+      ],
+      "test_id": null,
+      "medical_record_number": "d975a2c11a5dbfa9af64642c349f94b5f5e5b43b211617f5d2992dd0438ca8fd",
+      "medical_record_assigner": "Bonnie",
+      "description": null,
+      "description_category": null,
+      "insurance_providers": "[{\"codes\":{\"SOP\":[\"349\"]},\"description\":null,\"end_time\":null,\"financial_responsibility_type\":{\"code\":\"SELF\",\"codeSystem\":\"HL7 Relationship Code\"},\"health_record_field\":null,\"member_id\":\"1234567890\",\"mood_code\":\"EVN\",\"name\":\"Other\",\"negationInd\":null,\"negationReason\":null,\"oid\":null,\"payer\":{\"name\":\"Other\"},\"reason\":null,\"relationship\":null,\"specifics\":null,\"start_time\":1199145600,\"status_code\":null,\"time\":null,\"type\":\"OT\"}]"
+    },
+    "qdmVersion": "5.4"
+  }
+}

--- a/spec/javascripts/fixtures/json/patients/CMS234v0/Patient_Test 2.json
+++ b/spec/javascripts/fixtures/json/patients/CMS234v0/Patient_Test 2.json
@@ -1,0 +1,417 @@
+{
+  "_id": "5c06ecf1b848466bbc906184",
+  "bundleId": "5a57e977942c6d1e61d32f14",
+  "expectedValues": [
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+      "population_index": 0,
+      "IPP": 1,
+      "DENOM": 1,
+      "DENEX": 0,
+      "NUMER": 1
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC",
+      "population_index": 0,
+      "IPP": 1,
+      "MSRPOPL": 1,
+      "MSRPOPLEX": 0,
+      "OBSERV": [
+        0.25
+      ],
+      "OBSERV_UNIT": ""
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&7B905B21-D904-454F-885B-9CE5D19674E3",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "NUMER": 0,
+      "DENEXCEP": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&5B20AFEA-D4AF-4F7A-A5A3-F1F6165B9E5F",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&3000797E-11B1-4F62-A078-341A4002A11C",
+      "population_index": 0,
+      "IPP": 1,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&920D5B27-DF5A-4770-BD60-FC4EE251C4D2",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&BA108B7B-90B4-4692-B1D0-5DB554D2A1A2",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0,
+      "DENEXCEP": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&F03324C2-9147-457B-BC34-811BB7859C91",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    }
+  ],
+  "familyName": "Test 2",
+  "givenNames": [
+    "Patient"
+  ],
+  "notes": "",
+  "qdmPatient": {
+    "_id": "5c880147d7c8ac4c3e106851",
+    "birthDatetime": "1940-01-01T08:00:00.000+00:00",
+    "dataElements": [
+      {
+        "_id": "5c880147d7c8ac4c3e106852",
+        "authorDatetime": "2011-07-04T08:00:00.000+00:00",
+        "components": [
+
+        ],
+        "dataElementCodes": [
+          {
+            "codeSystem": "LOINC",
+            "code": "59458-0"
+          }
+        ],
+        "description": "Assessment, Performed: Ambulatory Status",
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.117",
+        "id": {
+          "_id": "5c880147d7c8ac4c3e106853",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c06ecf1b848466bbc906185"
+        },
+        "method": null,
+        "negationRationale": null,
+        "qdmCategory": "assessment",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "result": null,
+        "_type": "QDM::AssessmentPerformed"
+      },
+      {
+        "_id": "5c880147d7c8ac4c3e106854",
+        "authorDatetime": "2012-07-04T08:00:00.000+00:00",
+        "components": [
+
+        ],
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "401196007"
+          },
+          {
+            "codeSystem": "LOINC",
+            "code": "52552-7"
+          }
+        ],
+        "description": "Assessment, Performed: Falls Screening",
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.117",
+        "id": {
+          "_id": "5c880147d7c8ac4c3e106855",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c06ecf1b848466bbc906186"
+        },
+        "method": null,
+        "negationRationale": null,
+        "qdmCategory": "assessment",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "result": null,
+        "_type": "QDM::AssessmentPerformed"
+      },
+      {
+        "_id": "5c880147d7c8ac4c3e106856",
+        "admissionSource": null,
+        "authorDatetime": "2012-12-04T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "HCPCS",
+            "code": "G0438"
+          }
+        ],
+        "description": "Encounter, Performed: Annual Wellness Visit",
+        "diagnoses": [
+
+        ],
+        "dischargeDisposition": null,
+        "facilityLocations": [
+
+        ],
+        "hqmfOid": "2.16.840.1.113883.3.560.1.79",
+        "id": {
+          "_id": "5c880147d7c8ac4c3e106857",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c06ecf1b848466bbc906187"
+        },
+        "lengthOfStay": {
+          "value": 0,
+          "unit": "days"
+        },
+        "negationRationale": null,
+        "principalDiagnosis": null,
+        "qdmCategory": "encounter",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "relevantPeriod": {
+          "low": "2012-12-04T08:00:00.000+00:00",
+          "high": "2012-12-04T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "_type": "QDM::EncounterPerformed"
+      },
+      {
+        "_id": "5c880147d7c8ac4c3e10684c",
+        "birthDatetime": "1940-01-01T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "code": "21112-8",
+            "codeSystem": "LOINC",
+            "descriptor": null,
+            "codeSystemOid": null,
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.54",
+        "id": {
+          "_id": "5c880147d7c8ac4c3e106858",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880147d7c8ac4c3e10684c"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "birthdate",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicBirthdate"
+      },
+      {
+        "_id": "5c880147d7c8ac4c3e10684d",
+        "dataElementCodes": [
+          {
+            "code": "2186-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "Not Hispanic or Latino",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.56",
+        "id": {
+          "_id": "5c880147d7c8ac4c3e106859",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880147d7c8ac4c3e10684d"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "ethnicity",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicEthnicity"
+      },
+      {
+        "_id": "5c880147d7c8ac4c3e10684e",
+        "dataElementCodes": [
+          {
+            "code": "1002-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "American Indian or Alaska Native",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.59",
+        "id": {
+          "_id": "5c880147d7c8ac4c3e10685a",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880147d7c8ac4c3e10684e"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "race",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicRace"
+      },
+      {
+        "_id": "5c880147d7c8ac4c3e10684f",
+        "dataElementCodes": [
+          {
+            "code": "M",
+            "codeSystem": "AdministrativeGender",
+            "descriptor": "M",
+            "codeSystemOid": "2.16.840.1.113883.5.1",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.55",
+        "id": {
+          "_id": "5c880147d7c8ac4c3e10685b",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880147d7c8ac4c3e10684f"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "gender",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicSex"
+      }
+    ],
+    "extendedData": {
+      "type": null,
+      "measure_ids": [
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&7B905B21-D904-454F-885B-9CE5D19674E3",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&920D5B27-DF5A-4770-BD60-FC4EE251C4D2",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&3000797E-11B1-4F62-A078-341A4002A11C",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&5B20AFEA-D4AF-4F7A-A5A3-F1F6165B9E5F",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&F03324C2-9147-457B-BC34-811BB7859C91",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&BA108B7B-90B4-4692-B1D0-5DB554D2A1A2",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC",
+        null
+      ],
+      "source_data_criteria": [
+        {
+          "negation": false,
+          "definition": "assessment",
+          "status": "performed",
+          "title": "AmbulatoryStatus",
+          "description": "Assessment, Performed: Ambulatory Status",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.118.11.1219",
+          "type": "assessments",
+          "id": "AmbulatoryStatus_AssessmentPerformed_eb84926c_ae80_4768_9f88_ea55ed355df6_source",
+          "start_date": 1309766400000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+          "cms_id": "CMS231v0",
+          "criteria_id": "1677b0af52fFX",
+          "codes": {
+            "LOINC": [
+              "59458-0"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5c06ecf1b848466bbc906185"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "assessment",
+          "status": "performed",
+          "title": "FallsScreening",
+          "description": "Assessment, Performed: Falls Screening",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.118.12.1028",
+          "type": "assessments",
+          "id": "FallsScreening_AssessmentPerformed_3296d6d9_085b_4acd_84a9_819c01e4e5cd_source",
+          "start_date": 1341388800000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+          "cms_id": "CMS231v0",
+          "criteria_id": "1677b0b4e9bGs",
+          "codes": {
+            "SNOMED-CT": [
+              "401196007"
+            ],
+            "LOINC": [
+              "52552-7"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5c06ecf1b848466bbc906186"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "encounter",
+          "status": "performed",
+          "title": "AnnualWellnessVisit",
+          "description": "Encounter, Performed: Annual Wellness Visit",
+          "code_list_id": "2.16.840.1.113883.3.526.3.1240",
+          "type": "encounters",
+          "id": "AnnualWellnessVisit_EncounterPerformed_d50103e4_3ce4_48e3_9489_68dc37fb0b20_source",
+          "start_date": 1354608000000,
+          "end_date": 1354608900000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+          "cms_id": "CMS231v0",
+          "criteria_id": "1677b0ac53a4Q",
+          "codes": {
+            "HCPCS": [
+              "G0438"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5c06ecf1b848466bbc906187"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "id": "MeasurePeriod",
+          "start_date": 0,
+          "end_date": 0,
+          "references": null
+        }
+      ],
+      "is_shared": null,
+      "origin_data": [
+
+      ],
+      "test_id": null,
+      "medical_record_number": "66e7185c846fb50aaff1541a59d0b72284f89f64783a89bb33f9ae0d93f07361",
+      "medical_record_assigner": "Bonnie",
+      "description": null,
+      "description_category": null,
+      "insurance_providers": "[{\"codes\":{\"SOP\":[\"349\"]},\"description\":null,\"end_time\":null,\"financial_responsibility_type\":{\"code\":\"SELF\",\"codeSystem\":\"HL7 Relationship Code\"},\"health_record_field\":null,\"member_id\":\"1234567890\",\"mood_code\":\"EVN\",\"name\":\"Other\",\"negationInd\":null,\"negationReason\":null,\"oid\":null,\"payer\":{\"name\":\"Other\"},\"reason\":null,\"relationship\":null,\"specifics\":null,\"start_time\":1199145600,\"status_code\":null,\"time\":null,\"type\":\"OT\"}]"
+    },
+    "qdmVersion": "5.4"
+  }
+}

--- a/spec/javascripts/fixtures/json/patients/CMS238v0/Patient_Test 1.json
+++ b/spec/javascripts/fixtures/json/patients/CMS238v0/Patient_Test 1.json
@@ -1,0 +1,417 @@
+{
+  "_id": "5c06ec72b848466bbc906066",
+  "bundleId": "5a57e977942c6d1e61d32f14",
+  "expectedValues": [
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+      "population_index": 0,
+      "IPP": 1,
+      "DENOM": 1,
+      "DENEX": 0,
+      "NUMER": 1
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC",
+      "population_index": 0,
+      "IPP": 1,
+      "MSRPOPL": 1,
+      "MSRPOPLEX": 0,
+      "OBSERV": [
+        0.25
+      ],
+      "OBSERV_UNIT": ""
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&7B905B21-D904-454F-885B-9CE5D19674E3",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "NUMER": 0,
+      "DENEXCEP": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&5B20AFEA-D4AF-4F7A-A5A3-F1F6165B9E5F",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&3000797E-11B1-4F62-A078-341A4002A11C",
+      "population_index": 0,
+      "IPP": 1,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&920D5B27-DF5A-4770-BD60-FC4EE251C4D2",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&BA108B7B-90B4-4692-B1D0-5DB554D2A1A2",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0,
+      "DENEXCEP": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&F03324C2-9147-457B-BC34-811BB7859C91",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    }
+  ],
+  "familyName": "Test 1",
+  "givenNames": [
+    "Patient"
+  ],
+  "notes": "",
+  "qdmPatient": {
+    "_id": "5c880148d7c8ac4c3e106861",
+    "birthDatetime": "1940-01-01T08:00:00.000+00:00",
+    "dataElements": [
+      {
+        "_id": "5c880148d7c8ac4c3e106862",
+        "authorDatetime": "2011-07-04T08:00:00.000+00:00",
+        "components": [
+
+        ],
+        "dataElementCodes": [
+          {
+            "codeSystem": "LOINC",
+            "code": "59458-0"
+          }
+        ],
+        "description": "Assessment, Performed: Ambulatory Status",
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.117",
+        "id": {
+          "_id": "5c880148d7c8ac4c3e106863",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c06ece3b848466bbc906174"
+        },
+        "method": null,
+        "negationRationale": null,
+        "qdmCategory": "assessment",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "result": null,
+        "_type": "QDM::AssessmentPerformed"
+      },
+      {
+        "_id": "5c880148d7c8ac4c3e106864",
+        "authorDatetime": "2012-07-04T08:00:00.000+00:00",
+        "components": [
+
+        ],
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "401196007"
+          },
+          {
+            "codeSystem": "LOINC",
+            "code": "52552-7"
+          }
+        ],
+        "description": "Assessment, Performed: Falls Screening",
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.117",
+        "id": {
+          "_id": "5c880148d7c8ac4c3e106865",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c06ece3b848466bbc906175"
+        },
+        "method": null,
+        "negationRationale": null,
+        "qdmCategory": "assessment",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "result": null,
+        "_type": "QDM::AssessmentPerformed"
+      },
+      {
+        "_id": "5c880148d7c8ac4c3e106866",
+        "admissionSource": null,
+        "authorDatetime": "2012-12-04T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "HCPCS",
+            "code": "G0438"
+          }
+        ],
+        "description": "Encounter, Performed: Annual Wellness Visit",
+        "diagnoses": [
+
+        ],
+        "dischargeDisposition": null,
+        "facilityLocations": [
+
+        ],
+        "hqmfOid": "2.16.840.1.113883.3.560.1.79",
+        "id": {
+          "_id": "5c880148d7c8ac4c3e106867",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c06ece3b848466bbc906173"
+        },
+        "lengthOfStay": {
+          "value": 0,
+          "unit": "days"
+        },
+        "negationRationale": null,
+        "principalDiagnosis": null,
+        "qdmCategory": "encounter",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "relevantPeriod": {
+          "low": "2012-12-04T08:00:00.000+00:00",
+          "high": "2012-12-04T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "_type": "QDM::EncounterPerformed"
+      },
+      {
+        "_id": "5c880148d7c8ac4c3e10685c",
+        "birthDatetime": "1940-01-01T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "code": "21112-8",
+            "codeSystem": "LOINC",
+            "descriptor": null,
+            "codeSystemOid": null,
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.54",
+        "id": {
+          "_id": "5c880148d7c8ac4c3e106868",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880148d7c8ac4c3e10685c"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "birthdate",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicBirthdate"
+      },
+      {
+        "_id": "5c880148d7c8ac4c3e10685d",
+        "dataElementCodes": [
+          {
+            "code": "2186-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "Not Hispanic or Latino",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.56",
+        "id": {
+          "_id": "5c880148d7c8ac4c3e106869",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880148d7c8ac4c3e10685d"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "ethnicity",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicEthnicity"
+      },
+      {
+        "_id": "5c880148d7c8ac4c3e10685e",
+        "dataElementCodes": [
+          {
+            "code": "1002-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "American Indian or Alaska Native",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.59",
+        "id": {
+          "_id": "5c880148d7c8ac4c3e10686a",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880148d7c8ac4c3e10685e"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "race",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicRace"
+      },
+      {
+        "_id": "5c880148d7c8ac4c3e10685f",
+        "dataElementCodes": [
+          {
+            "code": "M",
+            "codeSystem": "AdministrativeGender",
+            "descriptor": "M",
+            "codeSystemOid": "2.16.840.1.113883.5.1",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.55",
+        "id": {
+          "_id": "5c880148d7c8ac4c3e10686b",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880148d7c8ac4c3e10685f"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "gender",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicSex"
+      }
+    ],
+    "extendedData": {
+      "type": null,
+      "measure_ids": [
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+        null,
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&7B905B21-D904-454F-885B-9CE5D19674E3",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&920D5B27-DF5A-4770-BD60-FC4EE251C4D2",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&3000797E-11B1-4F62-A078-341A4002A11C",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&5B20AFEA-D4AF-4F7A-A5A3-F1F6165B9E5F",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&F03324C2-9147-457B-BC34-811BB7859C91",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&BA108B7B-90B4-4692-B1D0-5DB554D2A1A2",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC"
+      ],
+      "source_data_criteria": [
+        {
+          "negation": false,
+          "definition": "assessment",
+          "status": "performed",
+          "title": "AmbulatoryStatus",
+          "description": "Assessment, Performed: Ambulatory Status",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.118.11.1219",
+          "type": "assessments",
+          "id": "AmbulatoryStatus_AssessmentPerformed_eb84926c_ae80_4768_9f88_ea55ed355df6_source",
+          "start_date": 1309766400000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+          "cms_id": "CMS231v0",
+          "criteria_id": "1677b0af52fFX",
+          "codes": {
+            "LOINC": [
+              "59458-0"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5c06ece3b848466bbc906174"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "assessment",
+          "status": "performed",
+          "title": "FallsScreening",
+          "description": "Assessment, Performed: Falls Screening",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.118.12.1028",
+          "type": "assessments",
+          "id": "FallsScreening_AssessmentPerformed_3296d6d9_085b_4acd_84a9_819c01e4e5cd_source",
+          "start_date": 1341388800000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+          "cms_id": "CMS231v0",
+          "criteria_id": "1677b0b4e9bGs",
+          "codes": {
+            "SNOMED-CT": [
+              "401196007"
+            ],
+            "LOINC": [
+              "52552-7"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5c06ece3b848466bbc906175"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "encounter",
+          "status": "performed",
+          "title": "AnnualWellnessVisit",
+          "description": "Encounter, Performed: Annual Wellness Visit",
+          "code_list_id": "2.16.840.1.113883.3.526.3.1240",
+          "type": "encounters",
+          "id": "AnnualWellnessVisit_EncounterPerformed_d50103e4_3ce4_48e3_9489_68dc37fb0b20_source",
+          "start_date": 1354608000000,
+          "end_date": 1354608900000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+          "cms_id": "CMS231v0",
+          "criteria_id": "1677b0ac53a4Q",
+          "codes": {
+            "HCPCS": [
+              "G0438"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5c06ece3b848466bbc906173"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "id": "MeasurePeriod",
+          "start_date": 0,
+          "end_date": 0,
+          "references": null
+        }
+      ],
+      "is_shared": null,
+      "origin_data": [
+
+      ],
+      "test_id": null,
+      "medical_record_number": "d975a2c11a5dbfa9af64642c349f94b5f5e5b43b211617f5d2992dd0438ca8fd",
+      "medical_record_assigner": "Bonnie",
+      "description": null,
+      "description_category": null,
+      "insurance_providers": "[{\"codes\":{\"SOP\":[\"349\"]},\"description\":null,\"end_time\":null,\"financial_responsibility_type\":{\"code\":\"SELF\",\"codeSystem\":\"HL7 Relationship Code\"},\"health_record_field\":null,\"member_id\":\"1234567890\",\"mood_code\":\"EVN\",\"name\":\"Other\",\"negationInd\":null,\"negationReason\":null,\"oid\":null,\"payer\":{\"name\":\"Other\"},\"reason\":null,\"relationship\":null,\"specifics\":null,\"start_time\":1199145600,\"status_code\":null,\"time\":null,\"type\":\"OT\"}]"
+    },
+    "qdmVersion": "5.4"
+  }
+}

--- a/spec/javascripts/fixtures/json/patients/CMS238v0/Patient_Test 2.json
+++ b/spec/javascripts/fixtures/json/patients/CMS238v0/Patient_Test 2.json
@@ -1,0 +1,417 @@
+{
+  "_id": "5c06ecf1b848466bbc906184",
+  "bundleId": "5a57e977942c6d1e61d32f14",
+  "expectedValues": [
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+      "population_index": 0,
+      "IPP": 1,
+      "DENOM": 1,
+      "DENEX": 0,
+      "NUMER": 1
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC",
+      "population_index": 0,
+      "IPP": 1,
+      "MSRPOPL": 1,
+      "MSRPOPLEX": 0,
+      "OBSERV": [
+        0.25
+      ],
+      "OBSERV_UNIT": ""
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&7B905B21-D904-454F-885B-9CE5D19674E3",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "NUMER": 0,
+      "DENEXCEP": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&5B20AFEA-D4AF-4F7A-A5A3-F1F6165B9E5F",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&3000797E-11B1-4F62-A078-341A4002A11C",
+      "population_index": 0,
+      "IPP": 1,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&920D5B27-DF5A-4770-BD60-FC4EE251C4D2",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&BA108B7B-90B4-4692-B1D0-5DB554D2A1A2",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0,
+      "DENEXCEP": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&F03324C2-9147-457B-BC34-811BB7859C91",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    }
+  ],
+  "familyName": "Test 2",
+  "givenNames": [
+    "Patient"
+  ],
+  "notes": "",
+  "qdmPatient": {
+    "_id": "5c880148d7c8ac4c3e106871",
+    "birthDatetime": "1940-01-01T08:00:00.000+00:00",
+    "dataElements": [
+      {
+        "_id": "5c880148d7c8ac4c3e106872",
+        "authorDatetime": "2011-07-04T08:00:00.000+00:00",
+        "components": [
+
+        ],
+        "dataElementCodes": [
+          {
+            "codeSystem": "LOINC",
+            "code": "59458-0"
+          }
+        ],
+        "description": "Assessment, Performed: Ambulatory Status",
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.117",
+        "id": {
+          "_id": "5c880148d7c8ac4c3e106873",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c06ecf1b848466bbc906185"
+        },
+        "method": null,
+        "negationRationale": null,
+        "qdmCategory": "assessment",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "result": null,
+        "_type": "QDM::AssessmentPerformed"
+      },
+      {
+        "_id": "5c880148d7c8ac4c3e106874",
+        "authorDatetime": "2012-07-04T08:00:00.000+00:00",
+        "components": [
+
+        ],
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "401196007"
+          },
+          {
+            "codeSystem": "LOINC",
+            "code": "52552-7"
+          }
+        ],
+        "description": "Assessment, Performed: Falls Screening",
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.117",
+        "id": {
+          "_id": "5c880148d7c8ac4c3e106875",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c06ecf1b848466bbc906186"
+        },
+        "method": null,
+        "negationRationale": null,
+        "qdmCategory": "assessment",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "result": null,
+        "_type": "QDM::AssessmentPerformed"
+      },
+      {
+        "_id": "5c880148d7c8ac4c3e106876",
+        "admissionSource": null,
+        "authorDatetime": "2012-12-04T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "HCPCS",
+            "code": "G0438"
+          }
+        ],
+        "description": "Encounter, Performed: Annual Wellness Visit",
+        "diagnoses": [
+
+        ],
+        "dischargeDisposition": null,
+        "facilityLocations": [
+
+        ],
+        "hqmfOid": "2.16.840.1.113883.3.560.1.79",
+        "id": {
+          "_id": "5c880148d7c8ac4c3e106877",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c06ecf1b848466bbc906187"
+        },
+        "lengthOfStay": {
+          "value": 0,
+          "unit": "days"
+        },
+        "negationRationale": null,
+        "principalDiagnosis": null,
+        "qdmCategory": "encounter",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "relevantPeriod": {
+          "low": "2012-12-04T08:00:00.000+00:00",
+          "high": "2012-12-04T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "_type": "QDM::EncounterPerformed"
+      },
+      {
+        "_id": "5c880148d7c8ac4c3e10686c",
+        "birthDatetime": "1940-01-01T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "code": "21112-8",
+            "codeSystem": "LOINC",
+            "descriptor": null,
+            "codeSystemOid": null,
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.54",
+        "id": {
+          "_id": "5c880148d7c8ac4c3e106878",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880148d7c8ac4c3e10686c"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "birthdate",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicBirthdate"
+      },
+      {
+        "_id": "5c880148d7c8ac4c3e10686d",
+        "dataElementCodes": [
+          {
+            "code": "2186-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "Not Hispanic or Latino",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.56",
+        "id": {
+          "_id": "5c880148d7c8ac4c3e106879",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880148d7c8ac4c3e10686d"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "ethnicity",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicEthnicity"
+      },
+      {
+        "_id": "5c880148d7c8ac4c3e10686e",
+        "dataElementCodes": [
+          {
+            "code": "1002-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "American Indian or Alaska Native",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.59",
+        "id": {
+          "_id": "5c880148d7c8ac4c3e10687a",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880148d7c8ac4c3e10686e"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "race",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicRace"
+      },
+      {
+        "_id": "5c880148d7c8ac4c3e10686f",
+        "dataElementCodes": [
+          {
+            "code": "M",
+            "codeSystem": "AdministrativeGender",
+            "descriptor": "M",
+            "codeSystemOid": "2.16.840.1.113883.5.1",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.55",
+        "id": {
+          "_id": "5c880148d7c8ac4c3e10687b",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880148d7c8ac4c3e10686f"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "gender",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicSex"
+      }
+    ],
+    "extendedData": {
+      "type": null,
+      "measure_ids": [
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&7B905B21-D904-454F-885B-9CE5D19674E3",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&920D5B27-DF5A-4770-BD60-FC4EE251C4D2",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&3000797E-11B1-4F62-A078-341A4002A11C",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&5B20AFEA-D4AF-4F7A-A5A3-F1F6165B9E5F",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&F03324C2-9147-457B-BC34-811BB7859C91",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&BA108B7B-90B4-4692-B1D0-5DB554D2A1A2",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC",
+        null
+      ],
+      "source_data_criteria": [
+        {
+          "negation": false,
+          "definition": "assessment",
+          "status": "performed",
+          "title": "AmbulatoryStatus",
+          "description": "Assessment, Performed: Ambulatory Status",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.118.11.1219",
+          "type": "assessments",
+          "id": "AmbulatoryStatus_AssessmentPerformed_eb84926c_ae80_4768_9f88_ea55ed355df6_source",
+          "start_date": 1309766400000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+          "cms_id": "CMS231v0",
+          "criteria_id": "1677b0af52fFX",
+          "codes": {
+            "LOINC": [
+              "59458-0"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5c06ecf1b848466bbc906185"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "assessment",
+          "status": "performed",
+          "title": "FallsScreening",
+          "description": "Assessment, Performed: Falls Screening",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.118.12.1028",
+          "type": "assessments",
+          "id": "FallsScreening_AssessmentPerformed_3296d6d9_085b_4acd_84a9_819c01e4e5cd_source",
+          "start_date": 1341388800000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+          "cms_id": "CMS231v0",
+          "criteria_id": "1677b0b4e9bGs",
+          "codes": {
+            "SNOMED-CT": [
+              "401196007"
+            ],
+            "LOINC": [
+              "52552-7"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5c06ecf1b848466bbc906186"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "encounter",
+          "status": "performed",
+          "title": "AnnualWellnessVisit",
+          "description": "Encounter, Performed: Annual Wellness Visit",
+          "code_list_id": "2.16.840.1.113883.3.526.3.1240",
+          "type": "encounters",
+          "id": "AnnualWellnessVisit_EncounterPerformed_d50103e4_3ce4_48e3_9489_68dc37fb0b20_source",
+          "start_date": 1354608000000,
+          "end_date": 1354608900000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+          "cms_id": "CMS231v0",
+          "criteria_id": "1677b0ac53a4Q",
+          "codes": {
+            "HCPCS": [
+              "G0438"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5c06ecf1b848466bbc906187"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "id": "MeasurePeriod",
+          "start_date": 0,
+          "end_date": 0,
+          "references": null
+        }
+      ],
+      "is_shared": null,
+      "origin_data": [
+
+      ],
+      "test_id": null,
+      "medical_record_number": "66e7185c846fb50aaff1541a59d0b72284f89f64783a89bb33f9ae0d93f07361",
+      "medical_record_assigner": "Bonnie",
+      "description": null,
+      "description_category": null,
+      "insurance_providers": "[{\"codes\":{\"SOP\":[\"349\"]},\"description\":null,\"end_time\":null,\"financial_responsibility_type\":{\"code\":\"SELF\",\"codeSystem\":\"HL7 Relationship Code\"},\"health_record_field\":null,\"member_id\":\"1234567890\",\"mood_code\":\"EVN\",\"name\":\"Other\",\"negationInd\":null,\"negationReason\":null,\"oid\":null,\"payer\":{\"name\":\"Other\"},\"reason\":null,\"relationship\":null,\"specifics\":null,\"start_time\":1199145600,\"status_code\":null,\"time\":null,\"type\":\"OT\"}]"
+    },
+    "qdmVersion": "5.4"
+  }
+}

--- a/spec/javascripts/fixtures/json/patients/CMS241v0/Patient_Test 1.json
+++ b/spec/javascripts/fixtures/json/patients/CMS241v0/Patient_Test 1.json
@@ -1,0 +1,417 @@
+{
+  "_id": "5c06ec72b848466bbc906066",
+  "bundleId": "5a57e977942c6d1e61d32f14",
+  "expectedValues": [
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+      "population_index": 0,
+      "IPP": 1,
+      "DENOM": 1,
+      "DENEX": 0,
+      "NUMER": 1
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC",
+      "population_index": 0,
+      "IPP": 1,
+      "MSRPOPL": 1,
+      "MSRPOPLEX": 0,
+      "OBSERV": [
+        0.25
+      ],
+      "OBSERV_UNIT": ""
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&7B905B21-D904-454F-885B-9CE5D19674E3",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "NUMER": 0,
+      "DENEXCEP": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&5B20AFEA-D4AF-4F7A-A5A3-F1F6165B9E5F",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&3000797E-11B1-4F62-A078-341A4002A11C",
+      "population_index": 0,
+      "IPP": 1,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&920D5B27-DF5A-4770-BD60-FC4EE251C4D2",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&BA108B7B-90B4-4692-B1D0-5DB554D2A1A2",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0,
+      "DENEXCEP": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&F03324C2-9147-457B-BC34-811BB7859C91",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    }
+  ],
+  "familyName": "Test 1",
+  "givenNames": [
+    "Patient"
+  ],
+  "notes": "",
+  "qdmPatient": {
+    "_id": "5c880148d7c8ac4c3e106881",
+    "birthDatetime": "1940-01-01T08:00:00.000+00:00",
+    "dataElements": [
+      {
+        "_id": "5c880148d7c8ac4c3e106882",
+        "authorDatetime": "2011-07-04T08:00:00.000+00:00",
+        "components": [
+
+        ],
+        "dataElementCodes": [
+          {
+            "codeSystem": "LOINC",
+            "code": "59458-0"
+          }
+        ],
+        "description": "Assessment, Performed: Ambulatory Status",
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.117",
+        "id": {
+          "_id": "5c880148d7c8ac4c3e106883",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c06ece3b848466bbc906174"
+        },
+        "method": null,
+        "negationRationale": null,
+        "qdmCategory": "assessment",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "result": null,
+        "_type": "QDM::AssessmentPerformed"
+      },
+      {
+        "_id": "5c880148d7c8ac4c3e106884",
+        "authorDatetime": "2012-07-04T08:00:00.000+00:00",
+        "components": [
+
+        ],
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "401196007"
+          },
+          {
+            "codeSystem": "LOINC",
+            "code": "52552-7"
+          }
+        ],
+        "description": "Assessment, Performed: Falls Screening",
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.117",
+        "id": {
+          "_id": "5c880148d7c8ac4c3e106885",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c06ece3b848466bbc906175"
+        },
+        "method": null,
+        "negationRationale": null,
+        "qdmCategory": "assessment",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "result": null,
+        "_type": "QDM::AssessmentPerformed"
+      },
+      {
+        "_id": "5c880148d7c8ac4c3e106886",
+        "admissionSource": null,
+        "authorDatetime": "2012-12-04T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "HCPCS",
+            "code": "G0438"
+          }
+        ],
+        "description": "Encounter, Performed: Annual Wellness Visit",
+        "diagnoses": [
+
+        ],
+        "dischargeDisposition": null,
+        "facilityLocations": [
+
+        ],
+        "hqmfOid": "2.16.840.1.113883.3.560.1.79",
+        "id": {
+          "_id": "5c880148d7c8ac4c3e106887",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c06ece3b848466bbc906173"
+        },
+        "lengthOfStay": {
+          "value": 0,
+          "unit": "days"
+        },
+        "negationRationale": null,
+        "principalDiagnosis": null,
+        "qdmCategory": "encounter",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "relevantPeriod": {
+          "low": "2012-12-04T08:00:00.000+00:00",
+          "high": "2012-12-04T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "_type": "QDM::EncounterPerformed"
+      },
+      {
+        "_id": "5c880148d7c8ac4c3e10687c",
+        "birthDatetime": "1940-01-01T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "code": "21112-8",
+            "codeSystem": "LOINC",
+            "descriptor": null,
+            "codeSystemOid": null,
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.54",
+        "id": {
+          "_id": "5c880148d7c8ac4c3e106888",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880148d7c8ac4c3e10687c"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "birthdate",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicBirthdate"
+      },
+      {
+        "_id": "5c880148d7c8ac4c3e10687d",
+        "dataElementCodes": [
+          {
+            "code": "2186-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "Not Hispanic or Latino",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.56",
+        "id": {
+          "_id": "5c880148d7c8ac4c3e106889",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880148d7c8ac4c3e10687d"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "ethnicity",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicEthnicity"
+      },
+      {
+        "_id": "5c880148d7c8ac4c3e10687e",
+        "dataElementCodes": [
+          {
+            "code": "1002-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "American Indian or Alaska Native",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.59",
+        "id": {
+          "_id": "5c880148d7c8ac4c3e10688a",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880148d7c8ac4c3e10687e"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "race",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicRace"
+      },
+      {
+        "_id": "5c880148d7c8ac4c3e10687f",
+        "dataElementCodes": [
+          {
+            "code": "M",
+            "codeSystem": "AdministrativeGender",
+            "descriptor": "M",
+            "codeSystemOid": "2.16.840.1.113883.5.1",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.55",
+        "id": {
+          "_id": "5c880148d7c8ac4c3e10688b",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880148d7c8ac4c3e10687f"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "gender",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicSex"
+      }
+    ],
+    "extendedData": {
+      "type": null,
+      "measure_ids": [
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+        null,
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&7B905B21-D904-454F-885B-9CE5D19674E3",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&920D5B27-DF5A-4770-BD60-FC4EE251C4D2",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&3000797E-11B1-4F62-A078-341A4002A11C",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&5B20AFEA-D4AF-4F7A-A5A3-F1F6165B9E5F",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&F03324C2-9147-457B-BC34-811BB7859C91",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&BA108B7B-90B4-4692-B1D0-5DB554D2A1A2",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC"
+      ],
+      "source_data_criteria": [
+        {
+          "negation": false,
+          "definition": "assessment",
+          "status": "performed",
+          "title": "AmbulatoryStatus",
+          "description": "Assessment, Performed: Ambulatory Status",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.118.11.1219",
+          "type": "assessments",
+          "id": "AmbulatoryStatus_AssessmentPerformed_eb84926c_ae80_4768_9f88_ea55ed355df6_source",
+          "start_date": 1309766400000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+          "cms_id": "CMS231v0",
+          "criteria_id": "1677b0af52fFX",
+          "codes": {
+            "LOINC": [
+              "59458-0"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5c06ece3b848466bbc906174"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "assessment",
+          "status": "performed",
+          "title": "FallsScreening",
+          "description": "Assessment, Performed: Falls Screening",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.118.12.1028",
+          "type": "assessments",
+          "id": "FallsScreening_AssessmentPerformed_3296d6d9_085b_4acd_84a9_819c01e4e5cd_source",
+          "start_date": 1341388800000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+          "cms_id": "CMS231v0",
+          "criteria_id": "1677b0b4e9bGs",
+          "codes": {
+            "SNOMED-CT": [
+              "401196007"
+            ],
+            "LOINC": [
+              "52552-7"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5c06ece3b848466bbc906175"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "encounter",
+          "status": "performed",
+          "title": "AnnualWellnessVisit",
+          "description": "Encounter, Performed: Annual Wellness Visit",
+          "code_list_id": "2.16.840.1.113883.3.526.3.1240",
+          "type": "encounters",
+          "id": "AnnualWellnessVisit_EncounterPerformed_d50103e4_3ce4_48e3_9489_68dc37fb0b20_source",
+          "start_date": 1354608000000,
+          "end_date": 1354608900000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+          "cms_id": "CMS231v0",
+          "criteria_id": "1677b0ac53a4Q",
+          "codes": {
+            "HCPCS": [
+              "G0438"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5c06ece3b848466bbc906173"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "id": "MeasurePeriod",
+          "start_date": 0,
+          "end_date": 0,
+          "references": null
+        }
+      ],
+      "is_shared": null,
+      "origin_data": [
+
+      ],
+      "test_id": null,
+      "medical_record_number": "d975a2c11a5dbfa9af64642c349f94b5f5e5b43b211617f5d2992dd0438ca8fd",
+      "medical_record_assigner": "Bonnie",
+      "description": null,
+      "description_category": null,
+      "insurance_providers": "[{\"codes\":{\"SOP\":[\"349\"]},\"description\":null,\"end_time\":null,\"financial_responsibility_type\":{\"code\":\"SELF\",\"codeSystem\":\"HL7 Relationship Code\"},\"health_record_field\":null,\"member_id\":\"1234567890\",\"mood_code\":\"EVN\",\"name\":\"Other\",\"negationInd\":null,\"negationReason\":null,\"oid\":null,\"payer\":{\"name\":\"Other\"},\"reason\":null,\"relationship\":null,\"specifics\":null,\"start_time\":1199145600,\"status_code\":null,\"time\":null,\"type\":\"OT\"}]"
+    },
+    "qdmVersion": "5.4"
+  }
+}

--- a/spec/javascripts/fixtures/json/patients/CMS241v0/Patient_Test 2.json
+++ b/spec/javascripts/fixtures/json/patients/CMS241v0/Patient_Test 2.json
@@ -1,0 +1,417 @@
+{
+  "_id": "5c06ecf1b848466bbc906184",
+  "bundleId": "5a57e977942c6d1e61d32f14",
+  "expectedValues": [
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+      "population_index": 0,
+      "IPP": 1,
+      "DENOM": 1,
+      "DENEX": 0,
+      "NUMER": 1
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC",
+      "population_index": 0,
+      "IPP": 1,
+      "MSRPOPL": 1,
+      "MSRPOPLEX": 0,
+      "OBSERV": [
+        0.25
+      ],
+      "OBSERV_UNIT": ""
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&7B905B21-D904-454F-885B-9CE5D19674E3",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "NUMER": 0,
+      "DENEXCEP": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&5B20AFEA-D4AF-4F7A-A5A3-F1F6165B9E5F",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&3000797E-11B1-4F62-A078-341A4002A11C",
+      "population_index": 0,
+      "IPP": 1,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&920D5B27-DF5A-4770-BD60-FC4EE251C4D2",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&BA108B7B-90B4-4692-B1D0-5DB554D2A1A2",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0,
+      "DENEXCEP": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&F03324C2-9147-457B-BC34-811BB7859C91",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    }
+  ],
+  "familyName": "Test 2",
+  "givenNames": [
+    "Patient"
+  ],
+  "notes": "",
+  "qdmPatient": {
+    "_id": "5c880148d7c8ac4c3e106891",
+    "birthDatetime": "1940-01-01T08:00:00.000+00:00",
+    "dataElements": [
+      {
+        "_id": "5c880148d7c8ac4c3e106892",
+        "authorDatetime": "2011-07-04T08:00:00.000+00:00",
+        "components": [
+
+        ],
+        "dataElementCodes": [
+          {
+            "codeSystem": "LOINC",
+            "code": "59458-0"
+          }
+        ],
+        "description": "Assessment, Performed: Ambulatory Status",
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.117",
+        "id": {
+          "_id": "5c880148d7c8ac4c3e106893",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c06ecf1b848466bbc906185"
+        },
+        "method": null,
+        "negationRationale": null,
+        "qdmCategory": "assessment",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "result": null,
+        "_type": "QDM::AssessmentPerformed"
+      },
+      {
+        "_id": "5c880148d7c8ac4c3e106894",
+        "authorDatetime": "2012-07-04T08:00:00.000+00:00",
+        "components": [
+
+        ],
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "401196007"
+          },
+          {
+            "codeSystem": "LOINC",
+            "code": "52552-7"
+          }
+        ],
+        "description": "Assessment, Performed: Falls Screening",
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.117",
+        "id": {
+          "_id": "5c880148d7c8ac4c3e106895",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c06ecf1b848466bbc906186"
+        },
+        "method": null,
+        "negationRationale": null,
+        "qdmCategory": "assessment",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "result": null,
+        "_type": "QDM::AssessmentPerformed"
+      },
+      {
+        "_id": "5c880148d7c8ac4c3e106896",
+        "admissionSource": null,
+        "authorDatetime": "2012-12-04T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "HCPCS",
+            "code": "G0438"
+          }
+        ],
+        "description": "Encounter, Performed: Annual Wellness Visit",
+        "diagnoses": [
+
+        ],
+        "dischargeDisposition": null,
+        "facilityLocations": [
+
+        ],
+        "hqmfOid": "2.16.840.1.113883.3.560.1.79",
+        "id": {
+          "_id": "5c880148d7c8ac4c3e106897",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c06ecf1b848466bbc906187"
+        },
+        "lengthOfStay": {
+          "value": 0,
+          "unit": "days"
+        },
+        "negationRationale": null,
+        "principalDiagnosis": null,
+        "qdmCategory": "encounter",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "relevantPeriod": {
+          "low": "2012-12-04T08:00:00.000+00:00",
+          "high": "2012-12-04T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "_type": "QDM::EncounterPerformed"
+      },
+      {
+        "_id": "5c880148d7c8ac4c3e10688c",
+        "birthDatetime": "1940-01-01T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "code": "21112-8",
+            "codeSystem": "LOINC",
+            "descriptor": null,
+            "codeSystemOid": null,
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.54",
+        "id": {
+          "_id": "5c880148d7c8ac4c3e106898",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880148d7c8ac4c3e10688c"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "birthdate",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicBirthdate"
+      },
+      {
+        "_id": "5c880148d7c8ac4c3e10688d",
+        "dataElementCodes": [
+          {
+            "code": "2186-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "Not Hispanic or Latino",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.56",
+        "id": {
+          "_id": "5c880148d7c8ac4c3e106899",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880148d7c8ac4c3e10688d"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "ethnicity",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicEthnicity"
+      },
+      {
+        "_id": "5c880148d7c8ac4c3e10688e",
+        "dataElementCodes": [
+          {
+            "code": "1002-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "American Indian or Alaska Native",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.59",
+        "id": {
+          "_id": "5c880148d7c8ac4c3e10689a",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880148d7c8ac4c3e10688e"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "race",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicRace"
+      },
+      {
+        "_id": "5c880148d7c8ac4c3e10688f",
+        "dataElementCodes": [
+          {
+            "code": "M",
+            "codeSystem": "AdministrativeGender",
+            "descriptor": "M",
+            "codeSystemOid": "2.16.840.1.113883.5.1",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.55",
+        "id": {
+          "_id": "5c880148d7c8ac4c3e10689b",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880148d7c8ac4c3e10688f"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "gender",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicSex"
+      }
+    ],
+    "extendedData": {
+      "type": null,
+      "measure_ids": [
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&7B905B21-D904-454F-885B-9CE5D19674E3",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&920D5B27-DF5A-4770-BD60-FC4EE251C4D2",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&3000797E-11B1-4F62-A078-341A4002A11C",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&5B20AFEA-D4AF-4F7A-A5A3-F1F6165B9E5F",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&F03324C2-9147-457B-BC34-811BB7859C91",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&BA108B7B-90B4-4692-B1D0-5DB554D2A1A2",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC",
+        null
+      ],
+      "source_data_criteria": [
+        {
+          "negation": false,
+          "definition": "assessment",
+          "status": "performed",
+          "title": "AmbulatoryStatus",
+          "description": "Assessment, Performed: Ambulatory Status",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.118.11.1219",
+          "type": "assessments",
+          "id": "AmbulatoryStatus_AssessmentPerformed_eb84926c_ae80_4768_9f88_ea55ed355df6_source",
+          "start_date": 1309766400000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+          "cms_id": "CMS231v0",
+          "criteria_id": "1677b0af52fFX",
+          "codes": {
+            "LOINC": [
+              "59458-0"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5c06ecf1b848466bbc906185"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "assessment",
+          "status": "performed",
+          "title": "FallsScreening",
+          "description": "Assessment, Performed: Falls Screening",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.118.12.1028",
+          "type": "assessments",
+          "id": "FallsScreening_AssessmentPerformed_3296d6d9_085b_4acd_84a9_819c01e4e5cd_source",
+          "start_date": 1341388800000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+          "cms_id": "CMS231v0",
+          "criteria_id": "1677b0b4e9bGs",
+          "codes": {
+            "SNOMED-CT": [
+              "401196007"
+            ],
+            "LOINC": [
+              "52552-7"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5c06ecf1b848466bbc906186"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "encounter",
+          "status": "performed",
+          "title": "AnnualWellnessVisit",
+          "description": "Encounter, Performed: Annual Wellness Visit",
+          "code_list_id": "2.16.840.1.113883.3.526.3.1240",
+          "type": "encounters",
+          "id": "AnnualWellnessVisit_EncounterPerformed_d50103e4_3ce4_48e3_9489_68dc37fb0b20_source",
+          "start_date": 1354608000000,
+          "end_date": 1354608900000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+          "cms_id": "CMS231v0",
+          "criteria_id": "1677b0ac53a4Q",
+          "codes": {
+            "HCPCS": [
+              "G0438"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5c06ecf1b848466bbc906187"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "id": "MeasurePeriod",
+          "start_date": 0,
+          "end_date": 0,
+          "references": null
+        }
+      ],
+      "is_shared": null,
+      "origin_data": [
+
+      ],
+      "test_id": null,
+      "medical_record_number": "66e7185c846fb50aaff1541a59d0b72284f89f64783a89bb33f9ae0d93f07361",
+      "medical_record_assigner": "Bonnie",
+      "description": null,
+      "description_category": null,
+      "insurance_providers": "[{\"codes\":{\"SOP\":[\"349\"]},\"description\":null,\"end_time\":null,\"financial_responsibility_type\":{\"code\":\"SELF\",\"codeSystem\":\"HL7 Relationship Code\"},\"health_record_field\":null,\"member_id\":\"1234567890\",\"mood_code\":\"EVN\",\"name\":\"Other\",\"negationInd\":null,\"negationReason\":null,\"oid\":null,\"payer\":{\"name\":\"Other\"},\"reason\":null,\"relationship\":null,\"specifics\":null,\"start_time\":1199145600,\"status_code\":null,\"time\":null,\"type\":\"OT\"}]"
+    },
+    "qdmVersion": "5.4"
+  }
+}

--- a/spec/javascripts/fixtures/json/patients/CMS244v0/Patient_Test 1.json
+++ b/spec/javascripts/fixtures/json/patients/CMS244v0/Patient_Test 1.json
@@ -1,0 +1,417 @@
+{
+  "_id": "5c06ec72b848466bbc906066",
+  "bundleId": "5a57e977942c6d1e61d32f14",
+  "expectedValues": [
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+      "population_index": 0,
+      "IPP": 1,
+      "DENOM": 1,
+      "DENEX": 0,
+      "NUMER": 1
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC",
+      "population_index": 0,
+      "IPP": 1,
+      "MSRPOPL": 1,
+      "MSRPOPLEX": 0,
+      "OBSERV": [
+        0.25
+      ],
+      "OBSERV_UNIT": ""
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&7B905B21-D904-454F-885B-9CE5D19674E3",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "NUMER": 0,
+      "DENEXCEP": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&5B20AFEA-D4AF-4F7A-A5A3-F1F6165B9E5F",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&3000797E-11B1-4F62-A078-341A4002A11C",
+      "population_index": 0,
+      "IPP": 1,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&920D5B27-DF5A-4770-BD60-FC4EE251C4D2",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&BA108B7B-90B4-4692-B1D0-5DB554D2A1A2",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0,
+      "DENEXCEP": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&F03324C2-9147-457B-BC34-811BB7859C91",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    }
+  ],
+  "familyName": "Test 1",
+  "givenNames": [
+    "Patient"
+  ],
+  "notes": "",
+  "qdmPatient": {
+    "_id": "5c880148d7c8ac4c3e1068a1",
+    "birthDatetime": "1940-01-01T08:00:00.000+00:00",
+    "dataElements": [
+      {
+        "_id": "5c880148d7c8ac4c3e1068a2",
+        "authorDatetime": "2011-07-04T08:00:00.000+00:00",
+        "components": [
+
+        ],
+        "dataElementCodes": [
+          {
+            "codeSystem": "LOINC",
+            "code": "59458-0"
+          }
+        ],
+        "description": "Assessment, Performed: Ambulatory Status",
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.117",
+        "id": {
+          "_id": "5c880148d7c8ac4c3e1068a3",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c06ece3b848466bbc906174"
+        },
+        "method": null,
+        "negationRationale": null,
+        "qdmCategory": "assessment",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "result": null,
+        "_type": "QDM::AssessmentPerformed"
+      },
+      {
+        "_id": "5c880148d7c8ac4c3e1068a4",
+        "authorDatetime": "2012-07-04T08:00:00.000+00:00",
+        "components": [
+
+        ],
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "401196007"
+          },
+          {
+            "codeSystem": "LOINC",
+            "code": "52552-7"
+          }
+        ],
+        "description": "Assessment, Performed: Falls Screening",
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.117",
+        "id": {
+          "_id": "5c880148d7c8ac4c3e1068a5",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c06ece3b848466bbc906175"
+        },
+        "method": null,
+        "negationRationale": null,
+        "qdmCategory": "assessment",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "result": null,
+        "_type": "QDM::AssessmentPerformed"
+      },
+      {
+        "_id": "5c880148d7c8ac4c3e1068a6",
+        "admissionSource": null,
+        "authorDatetime": "2012-12-04T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "HCPCS",
+            "code": "G0438"
+          }
+        ],
+        "description": "Encounter, Performed: Annual Wellness Visit",
+        "diagnoses": [
+
+        ],
+        "dischargeDisposition": null,
+        "facilityLocations": [
+
+        ],
+        "hqmfOid": "2.16.840.1.113883.3.560.1.79",
+        "id": {
+          "_id": "5c880148d7c8ac4c3e1068a7",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c06ece3b848466bbc906173"
+        },
+        "lengthOfStay": {
+          "value": 0,
+          "unit": "days"
+        },
+        "negationRationale": null,
+        "principalDiagnosis": null,
+        "qdmCategory": "encounter",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "relevantPeriod": {
+          "low": "2012-12-04T08:00:00.000+00:00",
+          "high": "2012-12-04T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "_type": "QDM::EncounterPerformed"
+      },
+      {
+        "_id": "5c880148d7c8ac4c3e10689c",
+        "birthDatetime": "1940-01-01T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "code": "21112-8",
+            "codeSystem": "LOINC",
+            "descriptor": null,
+            "codeSystemOid": null,
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.54",
+        "id": {
+          "_id": "5c880148d7c8ac4c3e1068a8",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880148d7c8ac4c3e10689c"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "birthdate",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicBirthdate"
+      },
+      {
+        "_id": "5c880148d7c8ac4c3e10689d",
+        "dataElementCodes": [
+          {
+            "code": "2186-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "Not Hispanic or Latino",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.56",
+        "id": {
+          "_id": "5c880148d7c8ac4c3e1068a9",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880148d7c8ac4c3e10689d"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "ethnicity",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicEthnicity"
+      },
+      {
+        "_id": "5c880148d7c8ac4c3e10689e",
+        "dataElementCodes": [
+          {
+            "code": "1002-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "American Indian or Alaska Native",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.59",
+        "id": {
+          "_id": "5c880148d7c8ac4c3e1068aa",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880148d7c8ac4c3e10689e"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "race",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicRace"
+      },
+      {
+        "_id": "5c880148d7c8ac4c3e10689f",
+        "dataElementCodes": [
+          {
+            "code": "M",
+            "codeSystem": "AdministrativeGender",
+            "descriptor": "M",
+            "codeSystemOid": "2.16.840.1.113883.5.1",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.55",
+        "id": {
+          "_id": "5c880148d7c8ac4c3e1068ab",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880148d7c8ac4c3e10689f"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "gender",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicSex"
+      }
+    ],
+    "extendedData": {
+      "type": null,
+      "measure_ids": [
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+        null,
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&7B905B21-D904-454F-885B-9CE5D19674E3",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&920D5B27-DF5A-4770-BD60-FC4EE251C4D2",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&3000797E-11B1-4F62-A078-341A4002A11C",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&5B20AFEA-D4AF-4F7A-A5A3-F1F6165B9E5F",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&F03324C2-9147-457B-BC34-811BB7859C91",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&BA108B7B-90B4-4692-B1D0-5DB554D2A1A2",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC"
+      ],
+      "source_data_criteria": [
+        {
+          "negation": false,
+          "definition": "assessment",
+          "status": "performed",
+          "title": "AmbulatoryStatus",
+          "description": "Assessment, Performed: Ambulatory Status",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.118.11.1219",
+          "type": "assessments",
+          "id": "AmbulatoryStatus_AssessmentPerformed_eb84926c_ae80_4768_9f88_ea55ed355df6_source",
+          "start_date": 1309766400000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+          "cms_id": "CMS231v0",
+          "criteria_id": "1677b0af52fFX",
+          "codes": {
+            "LOINC": [
+              "59458-0"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5c06ece3b848466bbc906174"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "assessment",
+          "status": "performed",
+          "title": "FallsScreening",
+          "description": "Assessment, Performed: Falls Screening",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.118.12.1028",
+          "type": "assessments",
+          "id": "FallsScreening_AssessmentPerformed_3296d6d9_085b_4acd_84a9_819c01e4e5cd_source",
+          "start_date": 1341388800000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+          "cms_id": "CMS231v0",
+          "criteria_id": "1677b0b4e9bGs",
+          "codes": {
+            "SNOMED-CT": [
+              "401196007"
+            ],
+            "LOINC": [
+              "52552-7"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5c06ece3b848466bbc906175"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "encounter",
+          "status": "performed",
+          "title": "AnnualWellnessVisit",
+          "description": "Encounter, Performed: Annual Wellness Visit",
+          "code_list_id": "2.16.840.1.113883.3.526.3.1240",
+          "type": "encounters",
+          "id": "AnnualWellnessVisit_EncounterPerformed_d50103e4_3ce4_48e3_9489_68dc37fb0b20_source",
+          "start_date": 1354608000000,
+          "end_date": 1354608900000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+          "cms_id": "CMS231v0",
+          "criteria_id": "1677b0ac53a4Q",
+          "codes": {
+            "HCPCS": [
+              "G0438"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5c06ece3b848466bbc906173"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "id": "MeasurePeriod",
+          "start_date": 0,
+          "end_date": 0,
+          "references": null
+        }
+      ],
+      "is_shared": null,
+      "origin_data": [
+
+      ],
+      "test_id": null,
+      "medical_record_number": "d975a2c11a5dbfa9af64642c349f94b5f5e5b43b211617f5d2992dd0438ca8fd",
+      "medical_record_assigner": "Bonnie",
+      "description": null,
+      "description_category": null,
+      "insurance_providers": "[{\"codes\":{\"SOP\":[\"349\"]},\"description\":null,\"end_time\":null,\"financial_responsibility_type\":{\"code\":\"SELF\",\"codeSystem\":\"HL7 Relationship Code\"},\"health_record_field\":null,\"member_id\":\"1234567890\",\"mood_code\":\"EVN\",\"name\":\"Other\",\"negationInd\":null,\"negationReason\":null,\"oid\":null,\"payer\":{\"name\":\"Other\"},\"reason\":null,\"relationship\":null,\"specifics\":null,\"start_time\":1199145600,\"status_code\":null,\"time\":null,\"type\":\"OT\"}]"
+    },
+    "qdmVersion": "5.4"
+  }
+}

--- a/spec/javascripts/fixtures/json/patients/CMS244v0/Patient_Test 2.json
+++ b/spec/javascripts/fixtures/json/patients/CMS244v0/Patient_Test 2.json
@@ -1,0 +1,417 @@
+{
+  "_id": "5c06ecf1b848466bbc906184",
+  "bundleId": "5a57e977942c6d1e61d32f14",
+  "expectedValues": [
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+      "population_index": 0,
+      "IPP": 1,
+      "DENOM": 1,
+      "DENEX": 0,
+      "NUMER": 1
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC",
+      "population_index": 0,
+      "IPP": 1,
+      "MSRPOPL": 1,
+      "MSRPOPLEX": 0,
+      "OBSERV": [
+        0.25
+      ],
+      "OBSERV_UNIT": ""
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&7B905B21-D904-454F-885B-9CE5D19674E3",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "NUMER": 0,
+      "DENEXCEP": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&5B20AFEA-D4AF-4F7A-A5A3-F1F6165B9E5F",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&3000797E-11B1-4F62-A078-341A4002A11C",
+      "population_index": 0,
+      "IPP": 1,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&920D5B27-DF5A-4770-BD60-FC4EE251C4D2",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&BA108B7B-90B4-4692-B1D0-5DB554D2A1A2",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0,
+      "DENEXCEP": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&F03324C2-9147-457B-BC34-811BB7859C91",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    }
+  ],
+  "familyName": "Test 2",
+  "givenNames": [
+    "Patient"
+  ],
+  "notes": "",
+  "qdmPatient": {
+    "_id": "5c880148d7c8ac4c3e1068b1",
+    "birthDatetime": "1940-01-01T08:00:00.000+00:00",
+    "dataElements": [
+      {
+        "_id": "5c880148d7c8ac4c3e1068b2",
+        "authorDatetime": "2011-07-04T08:00:00.000+00:00",
+        "components": [
+
+        ],
+        "dataElementCodes": [
+          {
+            "codeSystem": "LOINC",
+            "code": "59458-0"
+          }
+        ],
+        "description": "Assessment, Performed: Ambulatory Status",
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.117",
+        "id": {
+          "_id": "5c880148d7c8ac4c3e1068b3",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c06ecf1b848466bbc906185"
+        },
+        "method": null,
+        "negationRationale": null,
+        "qdmCategory": "assessment",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "result": null,
+        "_type": "QDM::AssessmentPerformed"
+      },
+      {
+        "_id": "5c880148d7c8ac4c3e1068b4",
+        "authorDatetime": "2012-07-04T08:00:00.000+00:00",
+        "components": [
+
+        ],
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "401196007"
+          },
+          {
+            "codeSystem": "LOINC",
+            "code": "52552-7"
+          }
+        ],
+        "description": "Assessment, Performed: Falls Screening",
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.117",
+        "id": {
+          "_id": "5c880148d7c8ac4c3e1068b5",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c06ecf1b848466bbc906186"
+        },
+        "method": null,
+        "negationRationale": null,
+        "qdmCategory": "assessment",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "result": null,
+        "_type": "QDM::AssessmentPerformed"
+      },
+      {
+        "_id": "5c880148d7c8ac4c3e1068b6",
+        "admissionSource": null,
+        "authorDatetime": "2012-12-04T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "HCPCS",
+            "code": "G0438"
+          }
+        ],
+        "description": "Encounter, Performed: Annual Wellness Visit",
+        "diagnoses": [
+
+        ],
+        "dischargeDisposition": null,
+        "facilityLocations": [
+
+        ],
+        "hqmfOid": "2.16.840.1.113883.3.560.1.79",
+        "id": {
+          "_id": "5c880148d7c8ac4c3e1068b7",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c06ecf1b848466bbc906187"
+        },
+        "lengthOfStay": {
+          "value": 0,
+          "unit": "days"
+        },
+        "negationRationale": null,
+        "principalDiagnosis": null,
+        "qdmCategory": "encounter",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "relevantPeriod": {
+          "low": "2012-12-04T08:00:00.000+00:00",
+          "high": "2012-12-04T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "_type": "QDM::EncounterPerformed"
+      },
+      {
+        "_id": "5c880148d7c8ac4c3e1068ac",
+        "birthDatetime": "1940-01-01T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "code": "21112-8",
+            "codeSystem": "LOINC",
+            "descriptor": null,
+            "codeSystemOid": null,
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.54",
+        "id": {
+          "_id": "5c880148d7c8ac4c3e1068b8",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880148d7c8ac4c3e1068ac"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "birthdate",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicBirthdate"
+      },
+      {
+        "_id": "5c880148d7c8ac4c3e1068ad",
+        "dataElementCodes": [
+          {
+            "code": "2186-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "Not Hispanic or Latino",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.56",
+        "id": {
+          "_id": "5c880148d7c8ac4c3e1068b9",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880148d7c8ac4c3e1068ad"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "ethnicity",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicEthnicity"
+      },
+      {
+        "_id": "5c880148d7c8ac4c3e1068ae",
+        "dataElementCodes": [
+          {
+            "code": "1002-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "American Indian or Alaska Native",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.59",
+        "id": {
+          "_id": "5c880148d7c8ac4c3e1068ba",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880148d7c8ac4c3e1068ae"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "race",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicRace"
+      },
+      {
+        "_id": "5c880148d7c8ac4c3e1068af",
+        "dataElementCodes": [
+          {
+            "code": "M",
+            "codeSystem": "AdministrativeGender",
+            "descriptor": "M",
+            "codeSystemOid": "2.16.840.1.113883.5.1",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.55",
+        "id": {
+          "_id": "5c880148d7c8ac4c3e1068bb",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880148d7c8ac4c3e1068af"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "gender",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicSex"
+      }
+    ],
+    "extendedData": {
+      "type": null,
+      "measure_ids": [
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&7B905B21-D904-454F-885B-9CE5D19674E3",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&920D5B27-DF5A-4770-BD60-FC4EE251C4D2",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&3000797E-11B1-4F62-A078-341A4002A11C",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&5B20AFEA-D4AF-4F7A-A5A3-F1F6165B9E5F",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&F03324C2-9147-457B-BC34-811BB7859C91",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&BA108B7B-90B4-4692-B1D0-5DB554D2A1A2",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC",
+        null
+      ],
+      "source_data_criteria": [
+        {
+          "negation": false,
+          "definition": "assessment",
+          "status": "performed",
+          "title": "AmbulatoryStatus",
+          "description": "Assessment, Performed: Ambulatory Status",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.118.11.1219",
+          "type": "assessments",
+          "id": "AmbulatoryStatus_AssessmentPerformed_eb84926c_ae80_4768_9f88_ea55ed355df6_source",
+          "start_date": 1309766400000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+          "cms_id": "CMS231v0",
+          "criteria_id": "1677b0af52fFX",
+          "codes": {
+            "LOINC": [
+              "59458-0"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5c06ecf1b848466bbc906185"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "assessment",
+          "status": "performed",
+          "title": "FallsScreening",
+          "description": "Assessment, Performed: Falls Screening",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.118.12.1028",
+          "type": "assessments",
+          "id": "FallsScreening_AssessmentPerformed_3296d6d9_085b_4acd_84a9_819c01e4e5cd_source",
+          "start_date": 1341388800000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+          "cms_id": "CMS231v0",
+          "criteria_id": "1677b0b4e9bGs",
+          "codes": {
+            "SNOMED-CT": [
+              "401196007"
+            ],
+            "LOINC": [
+              "52552-7"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5c06ecf1b848466bbc906186"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "encounter",
+          "status": "performed",
+          "title": "AnnualWellnessVisit",
+          "description": "Encounter, Performed: Annual Wellness Visit",
+          "code_list_id": "2.16.840.1.113883.3.526.3.1240",
+          "type": "encounters",
+          "id": "AnnualWellnessVisit_EncounterPerformed_d50103e4_3ce4_48e3_9489_68dc37fb0b20_source",
+          "start_date": 1354608000000,
+          "end_date": 1354608900000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+          "cms_id": "CMS231v0",
+          "criteria_id": "1677b0ac53a4Q",
+          "codes": {
+            "HCPCS": [
+              "G0438"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5c06ecf1b848466bbc906187"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "id": "MeasurePeriod",
+          "start_date": 0,
+          "end_date": 0,
+          "references": null
+        }
+      ],
+      "is_shared": null,
+      "origin_data": [
+
+      ],
+      "test_id": null,
+      "medical_record_number": "66e7185c846fb50aaff1541a59d0b72284f89f64783a89bb33f9ae0d93f07361",
+      "medical_record_assigner": "Bonnie",
+      "description": null,
+      "description_category": null,
+      "insurance_providers": "[{\"codes\":{\"SOP\":[\"349\"]},\"description\":null,\"end_time\":null,\"financial_responsibility_type\":{\"code\":\"SELF\",\"codeSystem\":\"HL7 Relationship Code\"},\"health_record_field\":null,\"member_id\":\"1234567890\",\"mood_code\":\"EVN\",\"name\":\"Other\",\"negationInd\":null,\"negationReason\":null,\"oid\":null,\"payer\":{\"name\":\"Other\"},\"reason\":null,\"relationship\":null,\"specifics\":null,\"start_time\":1199145600,\"status_code\":null,\"time\":null,\"type\":\"OT\"}]"
+    },
+    "qdmVersion": "5.4"
+  }
+}

--- a/spec/javascripts/fixtures/json/patients/CMS321v0/Patient_Test 1.json
+++ b/spec/javascripts/fixtures/json/patients/CMS321v0/Patient_Test 1.json
@@ -1,0 +1,417 @@
+{
+  "_id": "5c06ec72b848466bbc906066",
+  "bundleId": "5a57e977942c6d1e61d32f14",
+  "expectedValues": [
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+      "population_index": 0,
+      "IPP": 1,
+      "DENOM": 1,
+      "DENEX": 0,
+      "NUMER": 1
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC",
+      "population_index": 0,
+      "IPP": 1,
+      "MSRPOPL": 1,
+      "MSRPOPLEX": 0,
+      "OBSERV": [
+        0.25
+      ],
+      "OBSERV_UNIT": ""
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&7B905B21-D904-454F-885B-9CE5D19674E3",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "NUMER": 0,
+      "DENEXCEP": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&5B20AFEA-D4AF-4F7A-A5A3-F1F6165B9E5F",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&3000797E-11B1-4F62-A078-341A4002A11C",
+      "population_index": 0,
+      "IPP": 1,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&920D5B27-DF5A-4770-BD60-FC4EE251C4D2",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&BA108B7B-90B4-4692-B1D0-5DB554D2A1A2",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0,
+      "DENEXCEP": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&F03324C2-9147-457B-BC34-811BB7859C91",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    }
+  ],
+  "familyName": "Test 1",
+  "givenNames": [
+    "Patient"
+  ],
+  "notes": "",
+  "qdmPatient": {
+    "_id": "5c880148d7c8ac4c3e1068c1",
+    "birthDatetime": "1940-01-01T08:00:00.000+00:00",
+    "dataElements": [
+      {
+        "_id": "5c880148d7c8ac4c3e1068c2",
+        "authorDatetime": "2011-07-04T08:00:00.000+00:00",
+        "components": [
+
+        ],
+        "dataElementCodes": [
+          {
+            "codeSystem": "LOINC",
+            "code": "59458-0"
+          }
+        ],
+        "description": "Assessment, Performed: Ambulatory Status",
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.117",
+        "id": {
+          "_id": "5c880148d7c8ac4c3e1068c3",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c06ece3b848466bbc906174"
+        },
+        "method": null,
+        "negationRationale": null,
+        "qdmCategory": "assessment",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "result": null,
+        "_type": "QDM::AssessmentPerformed"
+      },
+      {
+        "_id": "5c880148d7c8ac4c3e1068c4",
+        "authorDatetime": "2012-07-04T08:00:00.000+00:00",
+        "components": [
+
+        ],
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "401196007"
+          },
+          {
+            "codeSystem": "LOINC",
+            "code": "52552-7"
+          }
+        ],
+        "description": "Assessment, Performed: Falls Screening",
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.117",
+        "id": {
+          "_id": "5c880148d7c8ac4c3e1068c5",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c06ece3b848466bbc906175"
+        },
+        "method": null,
+        "negationRationale": null,
+        "qdmCategory": "assessment",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "result": null,
+        "_type": "QDM::AssessmentPerformed"
+      },
+      {
+        "_id": "5c880148d7c8ac4c3e1068c6",
+        "admissionSource": null,
+        "authorDatetime": "2012-12-04T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "HCPCS",
+            "code": "G0438"
+          }
+        ],
+        "description": "Encounter, Performed: Annual Wellness Visit",
+        "diagnoses": [
+
+        ],
+        "dischargeDisposition": null,
+        "facilityLocations": [
+
+        ],
+        "hqmfOid": "2.16.840.1.113883.3.560.1.79",
+        "id": {
+          "_id": "5c880148d7c8ac4c3e1068c7",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c06ece3b848466bbc906173"
+        },
+        "lengthOfStay": {
+          "value": 0,
+          "unit": "days"
+        },
+        "negationRationale": null,
+        "principalDiagnosis": null,
+        "qdmCategory": "encounter",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "relevantPeriod": {
+          "low": "2012-12-04T08:00:00.000+00:00",
+          "high": "2012-12-04T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "_type": "QDM::EncounterPerformed"
+      },
+      {
+        "_id": "5c880148d7c8ac4c3e1068bc",
+        "birthDatetime": "1940-01-01T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "code": "21112-8",
+            "codeSystem": "LOINC",
+            "descriptor": null,
+            "codeSystemOid": null,
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.54",
+        "id": {
+          "_id": "5c880148d7c8ac4c3e1068c8",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880148d7c8ac4c3e1068bc"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "birthdate",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicBirthdate"
+      },
+      {
+        "_id": "5c880148d7c8ac4c3e1068bd",
+        "dataElementCodes": [
+          {
+            "code": "2186-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "Not Hispanic or Latino",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.56",
+        "id": {
+          "_id": "5c880148d7c8ac4c3e1068c9",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880148d7c8ac4c3e1068bd"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "ethnicity",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicEthnicity"
+      },
+      {
+        "_id": "5c880148d7c8ac4c3e1068be",
+        "dataElementCodes": [
+          {
+            "code": "1002-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "American Indian or Alaska Native",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.59",
+        "id": {
+          "_id": "5c880148d7c8ac4c3e1068ca",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880148d7c8ac4c3e1068be"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "race",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicRace"
+      },
+      {
+        "_id": "5c880148d7c8ac4c3e1068bf",
+        "dataElementCodes": [
+          {
+            "code": "M",
+            "codeSystem": "AdministrativeGender",
+            "descriptor": "M",
+            "codeSystemOid": "2.16.840.1.113883.5.1",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.55",
+        "id": {
+          "_id": "5c880148d7c8ac4c3e1068cb",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880148d7c8ac4c3e1068bf"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "gender",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicSex"
+      }
+    ],
+    "extendedData": {
+      "type": null,
+      "measure_ids": [
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+        null,
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&7B905B21-D904-454F-885B-9CE5D19674E3",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&920D5B27-DF5A-4770-BD60-FC4EE251C4D2",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&3000797E-11B1-4F62-A078-341A4002A11C",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&5B20AFEA-D4AF-4F7A-A5A3-F1F6165B9E5F",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&F03324C2-9147-457B-BC34-811BB7859C91",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&BA108B7B-90B4-4692-B1D0-5DB554D2A1A2",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC"
+      ],
+      "source_data_criteria": [
+        {
+          "negation": false,
+          "definition": "assessment",
+          "status": "performed",
+          "title": "AmbulatoryStatus",
+          "description": "Assessment, Performed: Ambulatory Status",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.118.11.1219",
+          "type": "assessments",
+          "id": "AmbulatoryStatus_AssessmentPerformed_eb84926c_ae80_4768_9f88_ea55ed355df6_source",
+          "start_date": 1309766400000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+          "cms_id": "CMS231v0",
+          "criteria_id": "1677b0af52fFX",
+          "codes": {
+            "LOINC": [
+              "59458-0"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5c06ece3b848466bbc906174"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "assessment",
+          "status": "performed",
+          "title": "FallsScreening",
+          "description": "Assessment, Performed: Falls Screening",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.118.12.1028",
+          "type": "assessments",
+          "id": "FallsScreening_AssessmentPerformed_3296d6d9_085b_4acd_84a9_819c01e4e5cd_source",
+          "start_date": 1341388800000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+          "cms_id": "CMS231v0",
+          "criteria_id": "1677b0b4e9bGs",
+          "codes": {
+            "SNOMED-CT": [
+              "401196007"
+            ],
+            "LOINC": [
+              "52552-7"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5c06ece3b848466bbc906175"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "encounter",
+          "status": "performed",
+          "title": "AnnualWellnessVisit",
+          "description": "Encounter, Performed: Annual Wellness Visit",
+          "code_list_id": "2.16.840.1.113883.3.526.3.1240",
+          "type": "encounters",
+          "id": "AnnualWellnessVisit_EncounterPerformed_d50103e4_3ce4_48e3_9489_68dc37fb0b20_source",
+          "start_date": 1354608000000,
+          "end_date": 1354608900000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+          "cms_id": "CMS231v0",
+          "criteria_id": "1677b0ac53a4Q",
+          "codes": {
+            "HCPCS": [
+              "G0438"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5c06ece3b848466bbc906173"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "id": "MeasurePeriod",
+          "start_date": 0,
+          "end_date": 0,
+          "references": null
+        }
+      ],
+      "is_shared": null,
+      "origin_data": [
+
+      ],
+      "test_id": null,
+      "medical_record_number": "d975a2c11a5dbfa9af64642c349f94b5f5e5b43b211617f5d2992dd0438ca8fd",
+      "medical_record_assigner": "Bonnie",
+      "description": null,
+      "description_category": null,
+      "insurance_providers": "[{\"codes\":{\"SOP\":[\"349\"]},\"description\":null,\"end_time\":null,\"financial_responsibility_type\":{\"code\":\"SELF\",\"codeSystem\":\"HL7 Relationship Code\"},\"health_record_field\":null,\"member_id\":\"1234567890\",\"mood_code\":\"EVN\",\"name\":\"Other\",\"negationInd\":null,\"negationReason\":null,\"oid\":null,\"payer\":{\"name\":\"Other\"},\"reason\":null,\"relationship\":null,\"specifics\":null,\"start_time\":1199145600,\"status_code\":null,\"time\":null,\"type\":\"OT\"}]"
+    },
+    "qdmVersion": "5.4"
+  }
+}

--- a/spec/javascripts/fixtures/json/patients/CMS321v0/Patient_Test 2.json
+++ b/spec/javascripts/fixtures/json/patients/CMS321v0/Patient_Test 2.json
@@ -1,0 +1,417 @@
+{
+  "_id": "5c06ecf1b848466bbc906184",
+  "bundleId": "5a57e977942c6d1e61d32f14",
+  "expectedValues": [
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+      "population_index": 0,
+      "IPP": 1,
+      "DENOM": 1,
+      "DENEX": 0,
+      "NUMER": 1
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC",
+      "population_index": 0,
+      "IPP": 1,
+      "MSRPOPL": 1,
+      "MSRPOPLEX": 0,
+      "OBSERV": [
+        0.25
+      ],
+      "OBSERV_UNIT": ""
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&7B905B21-D904-454F-885B-9CE5D19674E3",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "NUMER": 0,
+      "DENEXCEP": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&5B20AFEA-D4AF-4F7A-A5A3-F1F6165B9E5F",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&3000797E-11B1-4F62-A078-341A4002A11C",
+      "population_index": 0,
+      "IPP": 1,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&920D5B27-DF5A-4770-BD60-FC4EE251C4D2",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&BA108B7B-90B4-4692-B1D0-5DB554D2A1A2",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0,
+      "DENEXCEP": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&F03324C2-9147-457B-BC34-811BB7859C91",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    }
+  ],
+  "familyName": "Test 2",
+  "givenNames": [
+    "Patient"
+  ],
+  "notes": "",
+  "qdmPatient": {
+    "_id": "5c880149d7c8ac4c3e1068d1",
+    "birthDatetime": "1940-01-01T08:00:00.000+00:00",
+    "dataElements": [
+      {
+        "_id": "5c880149d7c8ac4c3e1068d2",
+        "authorDatetime": "2011-07-04T08:00:00.000+00:00",
+        "components": [
+
+        ],
+        "dataElementCodes": [
+          {
+            "codeSystem": "LOINC",
+            "code": "59458-0"
+          }
+        ],
+        "description": "Assessment, Performed: Ambulatory Status",
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.117",
+        "id": {
+          "_id": "5c880149d7c8ac4c3e1068d3",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c06ecf1b848466bbc906185"
+        },
+        "method": null,
+        "negationRationale": null,
+        "qdmCategory": "assessment",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "result": null,
+        "_type": "QDM::AssessmentPerformed"
+      },
+      {
+        "_id": "5c880149d7c8ac4c3e1068d4",
+        "authorDatetime": "2012-07-04T08:00:00.000+00:00",
+        "components": [
+
+        ],
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "401196007"
+          },
+          {
+            "codeSystem": "LOINC",
+            "code": "52552-7"
+          }
+        ],
+        "description": "Assessment, Performed: Falls Screening",
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.117",
+        "id": {
+          "_id": "5c880149d7c8ac4c3e1068d5",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c06ecf1b848466bbc906186"
+        },
+        "method": null,
+        "negationRationale": null,
+        "qdmCategory": "assessment",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "result": null,
+        "_type": "QDM::AssessmentPerformed"
+      },
+      {
+        "_id": "5c880149d7c8ac4c3e1068d6",
+        "admissionSource": null,
+        "authorDatetime": "2012-12-04T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "HCPCS",
+            "code": "G0438"
+          }
+        ],
+        "description": "Encounter, Performed: Annual Wellness Visit",
+        "diagnoses": [
+
+        ],
+        "dischargeDisposition": null,
+        "facilityLocations": [
+
+        ],
+        "hqmfOid": "2.16.840.1.113883.3.560.1.79",
+        "id": {
+          "_id": "5c880149d7c8ac4c3e1068d7",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c06ecf1b848466bbc906187"
+        },
+        "lengthOfStay": {
+          "value": 0,
+          "unit": "days"
+        },
+        "negationRationale": null,
+        "principalDiagnosis": null,
+        "qdmCategory": "encounter",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "relevantPeriod": {
+          "low": "2012-12-04T08:00:00.000+00:00",
+          "high": "2012-12-04T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "_type": "QDM::EncounterPerformed"
+      },
+      {
+        "_id": "5c880149d7c8ac4c3e1068cc",
+        "birthDatetime": "1940-01-01T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "code": "21112-8",
+            "codeSystem": "LOINC",
+            "descriptor": null,
+            "codeSystemOid": null,
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.54",
+        "id": {
+          "_id": "5c880149d7c8ac4c3e1068d8",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880149d7c8ac4c3e1068cc"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "birthdate",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicBirthdate"
+      },
+      {
+        "_id": "5c880149d7c8ac4c3e1068cd",
+        "dataElementCodes": [
+          {
+            "code": "2186-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "Not Hispanic or Latino",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.56",
+        "id": {
+          "_id": "5c880149d7c8ac4c3e1068d9",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880149d7c8ac4c3e1068cd"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "ethnicity",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicEthnicity"
+      },
+      {
+        "_id": "5c880149d7c8ac4c3e1068ce",
+        "dataElementCodes": [
+          {
+            "code": "1002-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "American Indian or Alaska Native",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.59",
+        "id": {
+          "_id": "5c880149d7c8ac4c3e1068da",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880149d7c8ac4c3e1068ce"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "race",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicRace"
+      },
+      {
+        "_id": "5c880149d7c8ac4c3e1068cf",
+        "dataElementCodes": [
+          {
+            "code": "M",
+            "codeSystem": "AdministrativeGender",
+            "descriptor": "M",
+            "codeSystemOid": "2.16.840.1.113883.5.1",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.55",
+        "id": {
+          "_id": "5c880149d7c8ac4c3e1068db",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880149d7c8ac4c3e1068cf"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "gender",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicSex"
+      }
+    ],
+    "extendedData": {
+      "type": null,
+      "measure_ids": [
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&7B905B21-D904-454F-885B-9CE5D19674E3",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&920D5B27-DF5A-4770-BD60-FC4EE251C4D2",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&3000797E-11B1-4F62-A078-341A4002A11C",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&5B20AFEA-D4AF-4F7A-A5A3-F1F6165B9E5F",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&F03324C2-9147-457B-BC34-811BB7859C91",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&BA108B7B-90B4-4692-B1D0-5DB554D2A1A2",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC",
+        null
+      ],
+      "source_data_criteria": [
+        {
+          "negation": false,
+          "definition": "assessment",
+          "status": "performed",
+          "title": "AmbulatoryStatus",
+          "description": "Assessment, Performed: Ambulatory Status",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.118.11.1219",
+          "type": "assessments",
+          "id": "AmbulatoryStatus_AssessmentPerformed_eb84926c_ae80_4768_9f88_ea55ed355df6_source",
+          "start_date": 1309766400000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+          "cms_id": "CMS231v0",
+          "criteria_id": "1677b0af52fFX",
+          "codes": {
+            "LOINC": [
+              "59458-0"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5c06ecf1b848466bbc906185"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "assessment",
+          "status": "performed",
+          "title": "FallsScreening",
+          "description": "Assessment, Performed: Falls Screening",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.118.12.1028",
+          "type": "assessments",
+          "id": "FallsScreening_AssessmentPerformed_3296d6d9_085b_4acd_84a9_819c01e4e5cd_source",
+          "start_date": 1341388800000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+          "cms_id": "CMS231v0",
+          "criteria_id": "1677b0b4e9bGs",
+          "codes": {
+            "SNOMED-CT": [
+              "401196007"
+            ],
+            "LOINC": [
+              "52552-7"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5c06ecf1b848466bbc906186"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "encounter",
+          "status": "performed",
+          "title": "AnnualWellnessVisit",
+          "description": "Encounter, Performed: Annual Wellness Visit",
+          "code_list_id": "2.16.840.1.113883.3.526.3.1240",
+          "type": "encounters",
+          "id": "AnnualWellnessVisit_EncounterPerformed_d50103e4_3ce4_48e3_9489_68dc37fb0b20_source",
+          "start_date": 1354608000000,
+          "end_date": 1354608900000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+          "cms_id": "CMS231v0",
+          "criteria_id": "1677b0ac53a4Q",
+          "codes": {
+            "HCPCS": [
+              "G0438"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5c06ecf1b848466bbc906187"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "id": "MeasurePeriod",
+          "start_date": 0,
+          "end_date": 0,
+          "references": null
+        }
+      ],
+      "is_shared": null,
+      "origin_data": [
+
+      ],
+      "test_id": null,
+      "medical_record_number": "66e7185c846fb50aaff1541a59d0b72284f89f64783a89bb33f9ae0d93f07361",
+      "medical_record_assigner": "Bonnie",
+      "description": null,
+      "description_category": null,
+      "insurance_providers": "[{\"codes\":{\"SOP\":[\"349\"]},\"description\":null,\"end_time\":null,\"financial_responsibility_type\":{\"code\":\"SELF\",\"codeSystem\":\"HL7 Relationship Code\"},\"health_record_field\":null,\"member_id\":\"1234567890\",\"mood_code\":\"EVN\",\"name\":\"Other\",\"negationInd\":null,\"negationReason\":null,\"oid\":null,\"payer\":{\"name\":\"Other\"},\"reason\":null,\"relationship\":null,\"specifics\":null,\"start_time\":1199145600,\"status_code\":null,\"time\":null,\"type\":\"OT\"}]"
+    },
+    "qdmVersion": "5.4"
+  }
+}

--- a/spec/javascripts/fixtures/json/patients/CMS32v7/Visit_1 ED.json
+++ b/spec/javascripts/fixtures/json/patients/CMS32v7/Visit_1 ED.json
@@ -1,0 +1,348 @@
+{
+  "_id": "5a58e9b6942c6d4bb26bb2f6",
+  "bundleId": "5a57e977942c6d1e61d32f14",
+  "expectedValues": [
+    {
+      "measure_id": "3FD13096-2C8F-40B5-9297-B714E8DE9133",
+      "population_index": 0,
+      "IPP": 1,
+      "MSRPOPL": 1,
+      "MSRPOPLEX": 0,
+      "OBSERV_UNIT": " mins",
+      "OBSERV": [
+        15
+      ]
+    },
+    {
+      "measure_id": "3FD13096-2C8F-40B5-9297-B714E8DE9133",
+      "population_index": 1,
+      "STRAT": 1,
+      "IPP": 1,
+      "MSRPOPL": 1,
+      "MSRPOPLEX": 0,
+      "OBSERV_UNIT": " mins",
+      "OBSERV": [
+        15
+      ]
+    },
+    {
+      "measure_id": "3FD13096-2C8F-40B5-9297-B714E8DE9133",
+      "population_index": 2,
+      "STRAT": 0,
+      "IPP": 0,
+      "MSRPOPL": 0,
+      "MSRPOPLEX": 0,
+      "OBSERV_UNIT": " mins"
+    },
+    {
+      "measure_id": "3FD13096-2C8F-40B5-9297-B714E8DE9133",
+      "population_index": 3,
+      "STRAT": 0,
+      "IPP": 0,
+      "MSRPOPL": 0,
+      "MSRPOPLEX": 0,
+      "OBSERV_UNIT": " mins"
+    }
+  ],
+  "familyName": "1 ED",
+  "givenNames": [
+    "Visit"
+  ],
+  "notes": "",
+  "qdmPatient": {
+    "_id": "5c88013cd7c8ac4c3e10664d",
+    "birthDatetime": "1994-01-01T08:00:00.000+00:00",
+    "dataElements": [
+      {
+        "_id": "5c88013cd7c8ac4c3e10664e",
+        "admissionSource": null,
+        "authorDatetime": "2012-06-10T05:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "4525004"
+          }
+        ],
+        "description": "Encounter, Performed: Emergency Department Visit",
+        "diagnoses": [
+          {
+            "code": "10278007",
+            "codeSystem": "SNOMED-CT",
+            "version": null,
+            "descriptor": "Psychiatric/Mental Health Diagnosis"
+          }
+        ],
+        "dischargeDisposition": null,
+        "facilityLocations": [
+
+        ],
+        "hqmfOid": "2.16.840.1.113883.3.560.1.79",
+        "id": {
+          "_id": "5c88013cd7c8ac4c3e10664f",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5aeb7763b848463d625b33cf"
+        },
+        "lengthOfStay": {
+          "value": 0,
+          "unit": "days"
+        },
+        "negationRationale": null,
+        "principalDiagnosis": {
+          "code": "10278007",
+          "codeSystem": "SNOMED-CT",
+          "descriptor": "Psychiatric/Mental Health Diagnosis",
+          "codeSystemOid": null,
+          "version": null
+        },
+        "qdmCategory": "encounter",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "relevantPeriod": {
+          "low": "2012-06-10T05:00:00.000+00:00",
+          "high": "2012-06-10T05:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "_type": "QDM::EncounterPerformed"
+      },
+      {
+        "_id": "5c88013cd7c8ac4c3e106650",
+        "admissionSource": null,
+        "authorDatetime": "2012-06-11T09:15:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "183452005"
+          }
+        ],
+        "description": "Encounter, Performed: Encounter Inpatient",
+        "diagnoses": [
+
+        ],
+        "dischargeDisposition": null,
+        "facilityLocations": [
+
+        ],
+        "hqmfOid": "2.16.840.1.113883.3.560.1.79",
+        "id": {
+          "_id": "5c88013cd7c8ac4c3e106651",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5aeb7763b848463d625b33d1"
+        },
+        "lengthOfStay": {
+          "value": 3,
+          "unit": "days"
+        },
+        "negationRationale": null,
+        "principalDiagnosis": null,
+        "qdmCategory": "encounter",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "relevantPeriod": {
+          "low": "2012-06-11T09:15:00.000+00:00",
+          "high": "2012-06-14T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "_type": "QDM::EncounterPerformed"
+      },
+      {
+        "_id": "5c88013cd7c8ac4c3e106648",
+        "birthDatetime": "1994-01-01T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "code": "21112-8",
+            "codeSystem": "LOINC",
+            "descriptor": null,
+            "codeSystemOid": null,
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.54",
+        "id": {
+          "_id": "5c88013cd7c8ac4c3e106652",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013cd7c8ac4c3e106648"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "birthdate",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicBirthdate"
+      },
+      {
+        "_id": "5c88013cd7c8ac4c3e106649",
+        "dataElementCodes": [
+          {
+            "code": "2186-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "Not Hispanic or Latino",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.56",
+        "id": {
+          "_id": "5c88013cd7c8ac4c3e106653",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013cd7c8ac4c3e106649"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "ethnicity",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicEthnicity"
+      },
+      {
+        "_id": "5c88013cd7c8ac4c3e10664a",
+        "dataElementCodes": [
+          {
+            "code": "1002-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "American Indian or Alaska Native",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.59",
+        "id": {
+          "_id": "5c88013cd7c8ac4c3e106654",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013cd7c8ac4c3e10664a"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "race",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicRace"
+      },
+      {
+        "_id": "5c88013cd7c8ac4c3e10664b",
+        "dataElementCodes": [
+          {
+            "code": "M",
+            "codeSystem": "AdministrativeGender",
+            "descriptor": "M",
+            "codeSystemOid": "2.16.840.1.113883.5.1",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.55",
+        "id": {
+          "_id": "5c88013cd7c8ac4c3e106655",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013cd7c8ac4c3e10664b"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "gender",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicSex"
+      }
+    ],
+    "extendedData": {
+      "type": null,
+      "measure_ids": [
+        "3FD13096-2C8F-40B5-9297-B714E8DE9133",
+        null
+      ],
+      "source_data_criteria": [
+        {
+          "negation": false,
+          "definition": "encounter",
+          "status": "performed",
+          "title": "EmergencyDepartmentVisit",
+          "description": "Encounter, Performed: Emergency Department Visit",
+          "code_list_id": "2.16.840.1.113883.3.117.1.7.1.292",
+          "type": "encounters",
+          "id": "EmergencyDepartmentVisit_EncounterPerformed_e9dfea5a_0011_42cc_b048_3a8748c1c4b0_source",
+          "start_date": 1339304400000,
+          "end_date": 1339305300000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+            "PRINCIPAL_DIAGNOSIS": {
+              "type": "CD",
+              "code_list_id": "2.16.840.1.113883.3.117.1.7.1.299",
+              "field_title": "Principal Diagnosis",
+              "title": "Psychiatric/Mental Health Patient"
+            }
+          },
+          "hqmf_set_id": "3FD13096-2C8F-40B5-9297-B714E8DE9133",
+          "cms_id": "CMS32v7",
+          "criteria_id": "160eb4e203aVV",
+          "codes": {
+            "SNOMED-CT": [
+              "4525004"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5aeb7763b848463d625b33cf"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "encounter",
+          "status": "performed",
+          "title": "EncounterInpatient",
+          "description": "Encounter, Performed: Encounter Inpatient",
+          "code_list_id": "2.16.840.1.113883.3.666.5.307",
+          "type": "encounters",
+          "id": "EncounterInpatient_EncounterPerformed_2f356da9_9e4f_442a_9232_4a10ae95334c_source",
+          "start_date": 1339406100000,
+          "end_date": 1339661700000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "3FD13096-2C8F-40B5-9297-B714E8DE9133",
+          "cms_id": "CMS32v7",
+          "criteria_id": "160eb4f4767dk",
+          "codes": {
+            "SNOMED-CT": [
+              "183452005"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5aeb7763b848463d625b33d1"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "id": "MeasurePeriod",
+          "start_date": 0,
+          "end_date": 0,
+          "references": null
+        }
+      ],
+      "is_shared": null,
+      "origin_data": [
+
+      ],
+      "test_id": null,
+      "medical_record_number": "ae884d4ce89724e1ec3c435032e573ae1433d5c257b3c4755178898fdbab8abd",
+      "medical_record_assigner": "Bonnie",
+      "description": null,
+      "description_category": null,
+      "insurance_providers": "[]"
+    },
+    "qdmVersion": "5.4"
+  }
+}

--- a/spec/javascripts/fixtures/json/patients/CMS32v7/Visits 1 Excl_2 ED.json
+++ b/spec/javascripts/fixtures/json/patients/CMS32v7/Visits 1 Excl_2 ED.json
@@ -1,0 +1,452 @@
+{
+  "_id": "5a593ff0942c6d0773593dff",
+  "bundleId": "5a57e977942c6d1e61d32f14",
+  "expectedValues": [
+    {
+      "measure_id": "3FD13096-2C8F-40B5-9297-B714E8DE9133",
+      "population_index": 0,
+      "IPP": 2,
+      "MSRPOPL": 2,
+      "MSRPOPLEX": 1,
+      "OBSERV_UNIT": " mins",
+      "OBSERV": [
+        15,
+        25
+      ]
+    },
+    {
+      "measure_id": "3FD13096-2C8F-40B5-9297-B714E8DE9133",
+      "population_index": 1,
+      "STRAT": 2,
+      "IPP": 2,
+      "MSRPOPL": 2,
+      "MSRPOPLEX": 1,
+      "OBSERV_UNIT": " mins",
+      "OBSERV": [
+        15,
+        25
+      ]
+    },
+    {
+      "measure_id": "3FD13096-2C8F-40B5-9297-B714E8DE9133",
+      "population_index": 2,
+      "STRAT": 0,
+      "IPP": 0,
+      "MSRPOPL": 0,
+      "MSRPOPLEX": 0,
+      "OBSERV_UNIT": " mins"
+    },
+    {
+      "measure_id": "3FD13096-2C8F-40B5-9297-B714E8DE9133",
+      "population_index": 3,
+      "STRAT": 0,
+      "IPP": 0,
+      "MSRPOPL": 0,
+      "MSRPOPLEX": 0,
+      "OBSERV_UNIT": " mins"
+    }
+  ],
+  "familyName": "2 ED",
+  "givenNames": [
+    "Visits 1 Excl"
+  ],
+  "notes": "",
+  "qdmPatient": {
+    "_id": "5c88013dd7c8ac4c3e10666b",
+    "birthDatetime": "1994-01-01T08:00:00.000+00:00",
+    "dataElements": [
+      {
+        "_id": "5c88013dd7c8ac4c3e10666c",
+        "admissionSource": null,
+        "authorDatetime": "2012-06-10T05:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "4525004"
+          }
+        ],
+        "description": "Encounter, Performed: Emergency Department Visit",
+        "diagnoses": [
+          {
+            "code": "10278007",
+            "codeSystem": "SNOMED-CT",
+            "version": null,
+            "descriptor": "Psychiatric/Mental Health Diagnosis"
+          }
+        ],
+        "dischargeDisposition": null,
+        "facilityLocations": [
+
+        ],
+        "hqmfOid": "2.16.840.1.113883.3.560.1.79",
+        "id": {
+          "_id": "5c88013dd7c8ac4c3e10666d",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5aeb77ccb848463d625b5d4d"
+        },
+        "lengthOfStay": {
+          "value": 0,
+          "unit": "days"
+        },
+        "negationRationale": null,
+        "principalDiagnosis": {
+          "code": "10278007",
+          "codeSystem": "SNOMED-CT",
+          "descriptor": "Psychiatric/Mental Health Diagnosis",
+          "codeSystemOid": null,
+          "version": null
+        },
+        "qdmCategory": "encounter",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "relevantPeriod": {
+          "low": "2012-06-10T05:00:00.000+00:00",
+          "high": "2012-06-10T05:25:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "_type": "QDM::EncounterPerformed"
+      },
+      {
+        "_id": "5c88013dd7c8ac4c3e10666e",
+        "admissionSource": null,
+        "authorDatetime": "2012-06-10T09:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "4525004"
+          }
+        ],
+        "description": "Encounter, Performed: Emergency Department Visit",
+        "diagnoses": [
+          {
+            "code": "10278007",
+            "codeSystem": "SNOMED-CT",
+            "version": null,
+            "descriptor": "Psychiatric/Mental Health Diagnosis"
+          }
+        ],
+        "dischargeDisposition": {
+          "code": "371828006",
+          "codeSystem": "SNOMED-CT",
+          "descriptor": "Patient deceased during stay (discharge status = dead) (finding)",
+          "codeSystemOid": null,
+          "version": null
+        },
+        "facilityLocations": [
+
+        ],
+        "hqmfOid": "2.16.840.1.113883.3.560.1.79",
+        "id": {
+          "_id": "5c88013dd7c8ac4c3e10666f",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5aeb77ccb848463d625b5d4f"
+        },
+        "lengthOfStay": {
+          "value": 0,
+          "unit": "days"
+        },
+        "negationRationale": null,
+        "principalDiagnosis": {
+          "code": "10278007",
+          "codeSystem": "SNOMED-CT",
+          "descriptor": "Psychiatric/Mental Health Diagnosis",
+          "codeSystemOid": null,
+          "version": null
+        },
+        "qdmCategory": "encounter",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "relevantPeriod": {
+          "low": "2012-06-10T09:00:00.000+00:00",
+          "high": "2012-06-10T09:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "_type": "QDM::EncounterPerformed"
+      },
+      {
+        "_id": "5c88013dd7c8ac4c3e106670",
+        "admissionSource": null,
+        "authorDatetime": "2012-06-11T09:15:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "183452005"
+          }
+        ],
+        "description": "Encounter, Performed: Encounter Inpatient",
+        "diagnoses": [
+
+        ],
+        "dischargeDisposition": null,
+        "facilityLocations": [
+
+        ],
+        "hqmfOid": "2.16.840.1.113883.3.560.1.79",
+        "id": {
+          "_id": "5c88013dd7c8ac4c3e106671",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5aeb77ccb848463d625b5d51"
+        },
+        "lengthOfStay": {
+          "value": 3,
+          "unit": "days"
+        },
+        "negationRationale": null,
+        "principalDiagnosis": null,
+        "qdmCategory": "encounter",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "relevantPeriod": {
+          "low": "2012-06-11T09:15:00.000+00:00",
+          "high": "2012-06-14T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "_type": "QDM::EncounterPerformed"
+      },
+      {
+        "_id": "5c88013dd7c8ac4c3e106666",
+        "birthDatetime": "1994-01-01T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "code": "21112-8",
+            "codeSystem": "LOINC",
+            "descriptor": null,
+            "codeSystemOid": null,
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.54",
+        "id": {
+          "_id": "5c88013dd7c8ac4c3e106672",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013dd7c8ac4c3e106666"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "birthdate",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicBirthdate"
+      },
+      {
+        "_id": "5c88013dd7c8ac4c3e106667",
+        "dataElementCodes": [
+          {
+            "code": "2186-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "Not Hispanic or Latino",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.56",
+        "id": {
+          "_id": "5c88013dd7c8ac4c3e106673",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013dd7c8ac4c3e106667"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "ethnicity",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicEthnicity"
+      },
+      {
+        "_id": "5c88013dd7c8ac4c3e106668",
+        "dataElementCodes": [
+          {
+            "code": "1002-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "American Indian or Alaska Native",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.59",
+        "id": {
+          "_id": "5c88013dd7c8ac4c3e106674",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013dd7c8ac4c3e106668"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "race",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicRace"
+      },
+      {
+        "_id": "5c88013dd7c8ac4c3e106669",
+        "dataElementCodes": [
+          {
+            "code": "M",
+            "codeSystem": "AdministrativeGender",
+            "descriptor": "M",
+            "codeSystemOid": "2.16.840.1.113883.5.1",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.55",
+        "id": {
+          "_id": "5c88013dd7c8ac4c3e106675",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013dd7c8ac4c3e106669"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "gender",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicSex"
+      }
+    ],
+    "extendedData": {
+      "type": null,
+      "measure_ids": [
+        "3FD13096-2C8F-40B5-9297-B714E8DE9133",
+        null
+      ],
+      "source_data_criteria": [
+        {
+          "negation": false,
+          "definition": "encounter",
+          "status": "performed",
+          "title": "EmergencyDepartmentVisit",
+          "description": "Encounter, Performed: Emergency Department Visit",
+          "code_list_id": "2.16.840.1.113883.3.117.1.7.1.292",
+          "type": "encounters",
+          "id": "EmergencyDepartmentVisit_EncounterPerformed_e9dfea5a_0011_42cc_b048_3a8748c1c4b0_source",
+          "start_date": 1339304400000,
+          "end_date": 1339305900000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+            "PRINCIPAL_DIAGNOSIS": {
+              "type": "CD",
+              "code_list_id": "2.16.840.1.113883.3.117.1.7.1.299",
+              "field_title": "Principal Diagnosis",
+              "title": "Psychiatric/Mental Health Patient"
+            }
+          },
+          "hqmf_set_id": "3FD13096-2C8F-40B5-9297-B714E8DE9133",
+          "cms_id": "CMS32v7",
+          "criteria_id": "160eb4e203aVV",
+          "codes": {
+            "SNOMED-CT": [
+              "4525004"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5aeb77ccb848463d625b5d4d"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "encounter",
+          "status": "performed",
+          "title": "EmergencyDepartmentVisit",
+          "description": "Encounter, Performed: Emergency Department Visit",
+          "code_list_id": "2.16.840.1.113883.3.117.1.7.1.292",
+          "type": "encounters",
+          "id": "EmergencyDepartmentVisit_EncounterPerformed_e9dfea5a_0011_42cc_b048_3a8748c1c4b0_source",
+          "start_date": 1339318800000,
+          "end_date": 1339319700000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+            "DISCHARGE_STATUS": {
+              "type": "CD",
+              "code_list_id": "30e1af73-5672-4e74-ab09-dab8b4aac67f",
+              "field_title": "Discharge Disposition",
+              "title": "Patient deceased during stay (discharge status = dead) (finding)"
+            },
+            "PRINCIPAL_DIAGNOSIS": {
+              "type": "CD",
+              "code_list_id": "2.16.840.1.113883.3.117.1.7.1.299",
+              "field_title": "Principal Diagnosis",
+              "title": "Psychiatric/Mental Health Patient"
+            }
+          },
+          "hqmf_set_id": "3FD13096-2C8F-40B5-9297-B714E8DE9133",
+          "cms_id": "CMS32v7",
+          "criteria_id": "160ec970f24Bn",
+          "codes": {
+            "SNOMED-CT": [
+              "4525004"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5aeb77ccb848463d625b5d4f"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "encounter",
+          "status": "performed",
+          "title": "EncounterInpatient",
+          "description": "Encounter, Performed: Encounter Inpatient",
+          "code_list_id": "2.16.840.1.113883.3.666.5.307",
+          "type": "encounters",
+          "id": "EncounterInpatient_EncounterPerformed_2f356da9_9e4f_442a_9232_4a10ae95334c_source",
+          "start_date": 1339406100000,
+          "end_date": 1339661700000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "3FD13096-2C8F-40B5-9297-B714E8DE9133",
+          "cms_id": "CMS32v7",
+          "criteria_id": "160eb4f4767dk",
+          "codes": {
+            "SNOMED-CT": [
+              "183452005"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5aeb77ccb848463d625b5d51"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "id": "MeasurePeriod",
+          "start_date": 0,
+          "end_date": 0,
+          "references": null
+        }
+      ],
+      "is_shared": null,
+      "origin_data": [
+
+      ],
+      "test_id": null,
+      "medical_record_number": "a383f8861def778cbcb41cb8db2830b3a11316b90a849cc1b2591ce8d5f7c8d3",
+      "medical_record_assigner": "Bonnie",
+      "description": null,
+      "description_category": null,
+      "insurance_providers": "[]"
+    },
+    "qdmVersion": "5.4"
+  }
+}

--- a/spec/javascripts/fixtures/json/patients/CMS32v7/Visits 2 Excl_2 ED.json
+++ b/spec/javascripts/fixtures/json/patients/CMS32v7/Visits 2 Excl_2 ED.json
@@ -1,0 +1,464 @@
+{
+  "_id": "5a5940ba942c6d0c717eeece",
+  "bundleId": "5a57e977942c6d1e61d32f14",
+  "expectedValues": [
+    {
+      "measure_id": "3FD13096-2C8F-40B5-9297-B714E8DE9133",
+      "population_index": 0,
+      "IPP": 2,
+      "MSRPOPL": 2,
+      "MSRPOPLEX": 2,
+      "OBSERV_UNIT": " mins",
+      "OBSERV": [
+        15,
+        25
+      ]
+    },
+    {
+      "measure_id": "3FD13096-2C8F-40B5-9297-B714E8DE9133",
+      "population_index": 1,
+      "STRAT": 2,
+      "IPP": 2,
+      "MSRPOPL": 2,
+      "MSRPOPLEX": 2,
+      "OBSERV_UNIT": " mins",
+      "OBSERV": [
+        15,
+        25
+      ]
+    },
+    {
+      "measure_id": "3FD13096-2C8F-40B5-9297-B714E8DE9133",
+      "population_index": 2,
+      "STRAT": 0,
+      "IPP": 0,
+      "MSRPOPL": 0,
+      "MSRPOPLEX": 0,
+      "OBSERV_UNIT": " mins"
+    },
+    {
+      "measure_id": "3FD13096-2C8F-40B5-9297-B714E8DE9133",
+      "population_index": 3,
+      "STRAT": 0,
+      "IPP": 0,
+      "MSRPOPL": 0,
+      "MSRPOPLEX": 0,
+      "OBSERV_UNIT": " mins"
+    }
+  ],
+  "familyName": "2 ED",
+  "givenNames": [
+    "Visits 2 Excl"
+  ],
+  "notes": "",
+  "qdmPatient": {
+    "_id": "5c88013dd7c8ac4c3e10667b",
+    "birthDatetime": "1994-01-01T08:00:00.000+00:00",
+    "dataElements": [
+      {
+        "_id": "5c88013dd7c8ac4c3e10667c",
+        "admissionSource": null,
+        "authorDatetime": "2012-06-10T05:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "4525004"
+          }
+        ],
+        "description": "Encounter, Performed: Emergency Department Visit",
+        "diagnoses": [
+          {
+            "code": "10278007",
+            "codeSystem": "SNOMED-CT",
+            "version": null,
+            "descriptor": "Psychiatric/Mental Health Diagnosis"
+          }
+        ],
+        "dischargeDisposition": {
+          "code": "371828006",
+          "codeSystem": "SNOMED-CT",
+          "descriptor": "Patient deceased during stay (discharge status = dead) (finding)",
+          "codeSystemOid": null,
+          "version": null
+        },
+        "facilityLocations": [
+
+        ],
+        "hqmfOid": "2.16.840.1.113883.3.560.1.79",
+        "id": {
+          "_id": "5c88013dd7c8ac4c3e10667d",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5aeb77cdb848463d625b5d52"
+        },
+        "lengthOfStay": {
+          "value": 0,
+          "unit": "days"
+        },
+        "negationRationale": null,
+        "principalDiagnosis": {
+          "code": "10278007",
+          "codeSystem": "SNOMED-CT",
+          "descriptor": "Psychiatric/Mental Health Diagnosis",
+          "codeSystemOid": null,
+          "version": null
+        },
+        "qdmCategory": "encounter",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "relevantPeriod": {
+          "low": "2012-06-10T05:00:00.000+00:00",
+          "high": "2012-06-10T05:25:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "_type": "QDM::EncounterPerformed"
+      },
+      {
+        "_id": "5c88013dd7c8ac4c3e10667e",
+        "admissionSource": null,
+        "authorDatetime": "2012-06-10T09:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "4525004"
+          }
+        ],
+        "description": "Encounter, Performed: Emergency Department Visit",
+        "diagnoses": [
+          {
+            "code": "10278007",
+            "codeSystem": "SNOMED-CT",
+            "version": null,
+            "descriptor": "Psychiatric/Mental Health Diagnosis"
+          }
+        ],
+        "dischargeDisposition": {
+          "code": "371828006",
+          "codeSystem": "SNOMED-CT",
+          "descriptor": "Patient deceased during stay (discharge status = dead) (finding)",
+          "codeSystemOid": null,
+          "version": null
+        },
+        "facilityLocations": [
+
+        ],
+        "hqmfOid": "2.16.840.1.113883.3.560.1.79",
+        "id": {
+          "_id": "5c88013dd7c8ac4c3e10667f",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5aeb77cdb848463d625b5d54"
+        },
+        "lengthOfStay": {
+          "value": 0,
+          "unit": "days"
+        },
+        "negationRationale": null,
+        "principalDiagnosis": {
+          "code": "10278007",
+          "codeSystem": "SNOMED-CT",
+          "descriptor": "Psychiatric/Mental Health Diagnosis",
+          "codeSystemOid": null,
+          "version": null
+        },
+        "qdmCategory": "encounter",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "relevantPeriod": {
+          "low": "2012-06-10T09:00:00.000+00:00",
+          "high": "2012-06-10T09:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "_type": "QDM::EncounterPerformed"
+      },
+      {
+        "_id": "5c88013dd7c8ac4c3e106680",
+        "admissionSource": null,
+        "authorDatetime": "2012-06-11T09:15:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "183452005"
+          }
+        ],
+        "description": "Encounter, Performed: Encounter Inpatient",
+        "diagnoses": [
+
+        ],
+        "dischargeDisposition": null,
+        "facilityLocations": [
+
+        ],
+        "hqmfOid": "2.16.840.1.113883.3.560.1.79",
+        "id": {
+          "_id": "5c88013dd7c8ac4c3e106681",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5aeb77cdb848463d625b5d56"
+        },
+        "lengthOfStay": {
+          "value": 3,
+          "unit": "days"
+        },
+        "negationRationale": null,
+        "principalDiagnosis": null,
+        "qdmCategory": "encounter",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "relevantPeriod": {
+          "low": "2012-06-11T09:15:00.000+00:00",
+          "high": "2012-06-14T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "_type": "QDM::EncounterPerformed"
+      },
+      {
+        "_id": "5c88013dd7c8ac4c3e106676",
+        "birthDatetime": "1994-01-01T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "code": "21112-8",
+            "codeSystem": "LOINC",
+            "descriptor": null,
+            "codeSystemOid": null,
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.54",
+        "id": {
+          "_id": "5c88013dd7c8ac4c3e106682",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013dd7c8ac4c3e106676"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "birthdate",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicBirthdate"
+      },
+      {
+        "_id": "5c88013dd7c8ac4c3e106677",
+        "dataElementCodes": [
+          {
+            "code": "2186-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "Not Hispanic or Latino",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.56",
+        "id": {
+          "_id": "5c88013dd7c8ac4c3e106683",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013dd7c8ac4c3e106677"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "ethnicity",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicEthnicity"
+      },
+      {
+        "_id": "5c88013dd7c8ac4c3e106678",
+        "dataElementCodes": [
+          {
+            "code": "1002-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "American Indian or Alaska Native",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.59",
+        "id": {
+          "_id": "5c88013dd7c8ac4c3e106684",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013dd7c8ac4c3e106678"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "race",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicRace"
+      },
+      {
+        "_id": "5c88013dd7c8ac4c3e106679",
+        "dataElementCodes": [
+          {
+            "code": "M",
+            "codeSystem": "AdministrativeGender",
+            "descriptor": "M",
+            "codeSystemOid": "2.16.840.1.113883.5.1",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.55",
+        "id": {
+          "_id": "5c88013dd7c8ac4c3e106685",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013dd7c8ac4c3e106679"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "gender",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicSex"
+      }
+    ],
+    "extendedData": {
+      "type": null,
+      "measure_ids": [
+        "3FD13096-2C8F-40B5-9297-B714E8DE9133",
+        null
+      ],
+      "source_data_criteria": [
+        {
+          "negation": false,
+          "definition": "encounter",
+          "status": "performed",
+          "title": "EmergencyDepartmentVisit",
+          "description": "Encounter, Performed: Emergency Department Visit",
+          "code_list_id": "2.16.840.1.113883.3.117.1.7.1.292",
+          "type": "encounters",
+          "id": "EmergencyDepartmentVisit_EncounterPerformed_e9dfea5a_0011_42cc_b048_3a8748c1c4b0_source",
+          "start_date": 1339304400000,
+          "end_date": 1339305900000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+            "PRINCIPAL_DIAGNOSIS": {
+              "type": "CD",
+              "code_list_id": "2.16.840.1.113883.3.117.1.7.1.299",
+              "field_title": "Principal Diagnosis",
+              "title": "Psychiatric/Mental Health Patient"
+            },
+            "DISCHARGE_STATUS": {
+              "type": "CD",
+              "code_list_id": "30e1af73-5672-4e74-ab09-dab8b4aac67f",
+              "field_title": "Discharge Disposition",
+              "title": "Patient deceased during stay (discharge status = dead) (finding)"
+            }
+          },
+          "hqmf_set_id": "3FD13096-2C8F-40B5-9297-B714E8DE9133",
+          "cms_id": "CMS32v7",
+          "criteria_id": "160eb4e203aVV",
+          "codes": {
+            "SNOMED-CT": [
+              "4525004"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5aeb77cdb848463d625b5d52"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "encounter",
+          "status": "performed",
+          "title": "EmergencyDepartmentVisit",
+          "description": "Encounter, Performed: Emergency Department Visit",
+          "code_list_id": "2.16.840.1.113883.3.117.1.7.1.292",
+          "type": "encounters",
+          "id": "EmergencyDepartmentVisit_EncounterPerformed_e9dfea5a_0011_42cc_b048_3a8748c1c4b0_source",
+          "start_date": 1339318800000,
+          "end_date": 1339319700000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+            "DISCHARGE_STATUS": {
+              "type": "CD",
+              "code_list_id": "30e1af73-5672-4e74-ab09-dab8b4aac67f",
+              "field_title": "Discharge Disposition",
+              "title": "Patient deceased during stay (discharge status = dead) (finding)"
+            },
+            "PRINCIPAL_DIAGNOSIS": {
+              "type": "CD",
+              "code_list_id": "2.16.840.1.113883.3.117.1.7.1.299",
+              "field_title": "Principal Diagnosis",
+              "title": "Psychiatric/Mental Health Patient"
+            }
+          },
+          "hqmf_set_id": "3FD13096-2C8F-40B5-9297-B714E8DE9133",
+          "cms_id": "CMS32v7",
+          "criteria_id": "160ec970f24Bn",
+          "codes": {
+            "SNOMED-CT": [
+              "4525004"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5aeb77cdb848463d625b5d54"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "encounter",
+          "status": "performed",
+          "title": "EncounterInpatient",
+          "description": "Encounter, Performed: Encounter Inpatient",
+          "code_list_id": "2.16.840.1.113883.3.666.5.307",
+          "type": "encounters",
+          "id": "EncounterInpatient_EncounterPerformed_2f356da9_9e4f_442a_9232_4a10ae95334c_source",
+          "start_date": 1339406100000,
+          "end_date": 1339661700000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "3FD13096-2C8F-40B5-9297-B714E8DE9133",
+          "cms_id": "CMS32v7",
+          "criteria_id": "160eb4f4767dk",
+          "codes": {
+            "SNOMED-CT": [
+              "183452005"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5aeb77cdb848463d625b5d56"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "id": "MeasurePeriod",
+          "start_date": 0,
+          "end_date": 0,
+          "references": null
+        }
+      ],
+      "is_shared": null,
+      "origin_data": [
+
+      ],
+      "test_id": null,
+      "medical_record_number": "f9eccf228da7e4bc5f5d35593a8226c9e9a00ce8993e522f0054d0be91b705d6",
+      "medical_record_assigner": "Bonnie",
+      "description": null,
+      "description_category": null,
+      "insurance_providers": "[]"
+    },
+    "qdmVersion": "5.4"
+  }
+}

--- a/spec/javascripts/fixtures/json/patients/CMS32v7/Visits_2 ED.json
+++ b/spec/javascripts/fixtures/json/patients/CMS32v7/Visits_2 ED.json
@@ -1,0 +1,440 @@
+{
+  "_id": "5a593d66942c6d0773593d97",
+  "bundleId": "5a57e977942c6d1e61d32f14",
+  "expectedValues": [
+    {
+      "measure_id": "3FD13096-2C8F-40B5-9297-B714E8DE9133",
+      "population_index": 0,
+      "IPP": 2,
+      "MSRPOPL": 2,
+      "MSRPOPLEX": 0,
+      "OBSERV_UNIT": " mins",
+      "OBSERV": [
+        15,
+        25
+      ]
+    },
+    {
+      "measure_id": "3FD13096-2C8F-40B5-9297-B714E8DE9133",
+      "population_index": 1,
+      "STRAT": 2,
+      "IPP": 2,
+      "MSRPOPL": 2,
+      "MSRPOPLEX": 0,
+      "OBSERV_UNIT": " mins",
+      "OBSERV": [
+        15,
+        25
+      ]
+    },
+    {
+      "measure_id": "3FD13096-2C8F-40B5-9297-B714E8DE9133",
+      "population_index": 2,
+      "STRAT": 0,
+      "IPP": 0,
+      "MSRPOPL": 0,
+      "MSRPOPLEX": 0,
+      "OBSERV_UNIT": " mins"
+    },
+    {
+      "measure_id": "3FD13096-2C8F-40B5-9297-B714E8DE9133",
+      "population_index": 3,
+      "STRAT": 0,
+      "IPP": 0,
+      "MSRPOPL": 0,
+      "MSRPOPLEX": 0,
+      "OBSERV_UNIT": " mins"
+    }
+  ],
+  "familyName": "2 ED",
+  "givenNames": [
+    "Visits"
+  ],
+  "notes": "",
+  "qdmPatient": {
+    "_id": "5c88013dd7c8ac4c3e10665b",
+    "birthDatetime": "1994-01-01T08:00:00.000+00:00",
+    "dataElements": [
+      {
+        "_id": "5c88013dd7c8ac4c3e10665c",
+        "admissionSource": null,
+        "authorDatetime": "2012-06-10T05:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "4525004"
+          }
+        ],
+        "description": "Encounter, Performed: Emergency Department Visit",
+        "diagnoses": [
+          {
+            "code": "10278007",
+            "codeSystem": "SNOMED-CT",
+            "version": null,
+            "descriptor": "Psychiatric/Mental Health Diagnosis"
+          }
+        ],
+        "dischargeDisposition": null,
+        "facilityLocations": [
+
+        ],
+        "hqmfOid": "2.16.840.1.113883.3.560.1.79",
+        "id": {
+          "_id": "5c88013dd7c8ac4c3e10665d",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5aeb77ccb848463d625b5d48"
+        },
+        "lengthOfStay": {
+          "value": 0,
+          "unit": "days"
+        },
+        "negationRationale": null,
+        "principalDiagnosis": {
+          "code": "10278007",
+          "codeSystem": "SNOMED-CT",
+          "descriptor": "Psychiatric/Mental Health Diagnosis",
+          "codeSystemOid": null,
+          "version": null
+        },
+        "qdmCategory": "encounter",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "relevantPeriod": {
+          "low": "2012-06-10T05:00:00.000+00:00",
+          "high": "2012-06-10T05:25:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "_type": "QDM::EncounterPerformed"
+      },
+      {
+        "_id": "5c88013dd7c8ac4c3e10665e",
+        "admissionSource": null,
+        "authorDatetime": "2012-06-10T09:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "4525004"
+          }
+        ],
+        "description": "Encounter, Performed: Emergency Department Visit",
+        "diagnoses": [
+          {
+            "code": "10278007",
+            "codeSystem": "SNOMED-CT",
+            "version": null,
+            "descriptor": "Psychiatric/Mental Health Diagnosis"
+          }
+        ],
+        "dischargeDisposition": null,
+        "facilityLocations": [
+
+        ],
+        "hqmfOid": "2.16.840.1.113883.3.560.1.79",
+        "id": {
+          "_id": "5c88013dd7c8ac4c3e10665f",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5aeb77ccb848463d625b5d4a"
+        },
+        "lengthOfStay": {
+          "value": 0,
+          "unit": "days"
+        },
+        "negationRationale": null,
+        "principalDiagnosis": {
+          "code": "10278007",
+          "codeSystem": "SNOMED-CT",
+          "descriptor": "Psychiatric/Mental Health Diagnosis",
+          "codeSystemOid": null,
+          "version": null
+        },
+        "qdmCategory": "encounter",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "relevantPeriod": {
+          "low": "2012-06-10T09:00:00.000+00:00",
+          "high": "2012-06-10T09:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "_type": "QDM::EncounterPerformed"
+      },
+      {
+        "_id": "5c88013dd7c8ac4c3e106660",
+        "admissionSource": null,
+        "authorDatetime": "2012-06-11T09:15:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "183452005"
+          }
+        ],
+        "description": "Encounter, Performed: Encounter Inpatient",
+        "diagnoses": [
+
+        ],
+        "dischargeDisposition": null,
+        "facilityLocations": [
+
+        ],
+        "hqmfOid": "2.16.840.1.113883.3.560.1.79",
+        "id": {
+          "_id": "5c88013dd7c8ac4c3e106661",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5aeb77ccb848463d625b5d4c"
+        },
+        "lengthOfStay": {
+          "value": 3,
+          "unit": "days"
+        },
+        "negationRationale": null,
+        "principalDiagnosis": null,
+        "qdmCategory": "encounter",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "relevantPeriod": {
+          "low": "2012-06-11T09:15:00.000+00:00",
+          "high": "2012-06-14T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "_type": "QDM::EncounterPerformed"
+      },
+      {
+        "_id": "5c88013dd7c8ac4c3e106656",
+        "birthDatetime": "1994-01-01T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "code": "21112-8",
+            "codeSystem": "LOINC",
+            "descriptor": null,
+            "codeSystemOid": null,
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.54",
+        "id": {
+          "_id": "5c88013dd7c8ac4c3e106662",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013dd7c8ac4c3e106656"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "birthdate",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicBirthdate"
+      },
+      {
+        "_id": "5c88013dd7c8ac4c3e106657",
+        "dataElementCodes": [
+          {
+            "code": "2186-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "Not Hispanic or Latino",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.56",
+        "id": {
+          "_id": "5c88013dd7c8ac4c3e106663",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013dd7c8ac4c3e106657"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "ethnicity",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicEthnicity"
+      },
+      {
+        "_id": "5c88013dd7c8ac4c3e106658",
+        "dataElementCodes": [
+          {
+            "code": "1002-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "American Indian or Alaska Native",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.59",
+        "id": {
+          "_id": "5c88013dd7c8ac4c3e106664",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013dd7c8ac4c3e106658"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "race",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicRace"
+      },
+      {
+        "_id": "5c88013dd7c8ac4c3e106659",
+        "dataElementCodes": [
+          {
+            "code": "M",
+            "codeSystem": "AdministrativeGender",
+            "descriptor": "M",
+            "codeSystemOid": "2.16.840.1.113883.5.1",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.55",
+        "id": {
+          "_id": "5c88013dd7c8ac4c3e106665",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013dd7c8ac4c3e106659"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "gender",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicSex"
+      }
+    ],
+    "extendedData": {
+      "type": null,
+      "measure_ids": [
+        "3FD13096-2C8F-40B5-9297-B714E8DE9133",
+        null
+      ],
+      "source_data_criteria": [
+        {
+          "negation": false,
+          "definition": "encounter",
+          "status": "performed",
+          "title": "EmergencyDepartmentVisit",
+          "description": "Encounter, Performed: Emergency Department Visit",
+          "code_list_id": "2.16.840.1.113883.3.117.1.7.1.292",
+          "type": "encounters",
+          "id": "EmergencyDepartmentVisit_EncounterPerformed_e9dfea5a_0011_42cc_b048_3a8748c1c4b0_source",
+          "start_date": 1339304400000,
+          "end_date": 1339305900000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+            "PRINCIPAL_DIAGNOSIS": {
+              "type": "CD",
+              "code_list_id": "2.16.840.1.113883.3.117.1.7.1.299",
+              "field_title": "Principal Diagnosis",
+              "title": "Psychiatric/Mental Health Patient"
+            }
+          },
+          "hqmf_set_id": "3FD13096-2C8F-40B5-9297-B714E8DE9133",
+          "cms_id": "CMS32v7",
+          "criteria_id": "160eb4e203aVV",
+          "codes": {
+            "SNOMED-CT": [
+              "4525004"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5aeb77ccb848463d625b5d48"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "encounter",
+          "status": "performed",
+          "title": "EmergencyDepartmentVisit",
+          "description": "Encounter, Performed: Emergency Department Visit",
+          "code_list_id": "2.16.840.1.113883.3.117.1.7.1.292",
+          "type": "encounters",
+          "id": "EmergencyDepartmentVisit_EncounterPerformed_e9dfea5a_0011_42cc_b048_3a8748c1c4b0_source",
+          "start_date": 1339318800000,
+          "end_date": 1339319700000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+            "PRINCIPAL_DIAGNOSIS": {
+              "type": "CD",
+              "code_list_id": "2.16.840.1.113883.3.117.1.7.1.299",
+              "field_title": "Principal Diagnosis",
+              "title": "Psychiatric/Mental Health Patient"
+            }
+          },
+          "hqmf_set_id": "3FD13096-2C8F-40B5-9297-B714E8DE9133",
+          "cms_id": "CMS32v7",
+          "criteria_id": "160ec970f24Bn",
+          "codes": {
+            "SNOMED-CT": [
+              "4525004"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5aeb77ccb848463d625b5d4a"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "encounter",
+          "status": "performed",
+          "title": "EncounterInpatient",
+          "description": "Encounter, Performed: Encounter Inpatient",
+          "code_list_id": "2.16.840.1.113883.3.666.5.307",
+          "type": "encounters",
+          "id": "EncounterInpatient_EncounterPerformed_2f356da9_9e4f_442a_9232_4a10ae95334c_source",
+          "start_date": 1339406100000,
+          "end_date": 1339661700000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "3FD13096-2C8F-40B5-9297-B714E8DE9133",
+          "cms_id": "CMS32v7",
+          "criteria_id": "160eb4f4767dk",
+          "codes": {
+            "SNOMED-CT": [
+              "183452005"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5aeb77ccb848463d625b5d4c"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "id": "MeasurePeriod",
+          "start_date": 0,
+          "end_date": 0,
+          "references": null
+        }
+      ],
+      "is_shared": null,
+      "origin_data": [
+
+      ],
+      "test_id": null,
+      "medical_record_number": "612454107a524e3f58c27db45630314da51689f4f33965288175657a991416b5",
+      "medical_record_assigner": "Bonnie",
+      "description": null,
+      "description_category": null,
+      "insurance_providers": "[]"
+    },
+    "qdmVersion": "5.4"
+  }
+}

--- a/spec/javascripts/fixtures/json/patients/CMS460v0/MethadoneLessThan90MME_NUMERFail.json
+++ b/spec/javascripts/fixtures/json/patients/CMS460v0/MethadoneLessThan90MME_NUMERFail.json
@@ -1,0 +1,323 @@
+{
+  "_id": "5b9ff2fcb8484609a984561f",
+  "bundleId": "5a57e977942c6d1e61d32f14",
+  "expectedValues": [
+    {
+      "measure_id": "442EDEF2-7347-4080-988F-16C9D1998803",
+      "population_index": 0,
+      "IPP": 1,
+      "DENOM": 1,
+      "DENEX": 0,
+      "NUMER": 0
+    }
+  ],
+  "familyName": "NUMERFail",
+  "givenNames": [
+    "MethadoneLessThan90MME"
+  ],
+  "notes": "methadone 40 mg oral tab does not exceed 90 MME (total daily dose is half a tablet (20 mg) which is 80 MME). Case does not meet NUMER criteria since MME is less than 90.",
+  "qdmPatient": {
+    "_id": "5c880142d7c8ac4c3e106745",
+    "birthDatetime": "1958-05-14T08:00:00.000+00:00",
+    "dataElements": [
+      {
+        "_id": "5c880142d7c8ac4c3e106746",
+        "admissionSource": null,
+        "authorDatetime": "2012-05-04T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "17436001"
+          },
+          {
+            "codeSystem": "CPT",
+            "code": "99241"
+          }
+        ],
+        "description": "Encounter, Performed: Outpatient Consultation",
+        "diagnoses": [
+
+        ],
+        "dischargeDisposition": null,
+        "facilityLocations": [
+
+        ],
+        "hqmfOid": "2.16.840.1.113883.3.560.1.79",
+        "id": {
+          "_id": "5c880142d7c8ac4c3e106747",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5b9ff2fcb8484609a9845620"
+        },
+        "lengthOfStay": {
+          "value": 0,
+          "unit": "days"
+        },
+        "negationRationale": null,
+        "principalDiagnosis": null,
+        "qdmCategory": "encounter",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "relevantPeriod": {
+          "low": "2012-05-04T08:00:00.000+00:00",
+          "high": "2012-05-04T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "_type": "QDM::EncounterPerformed"
+      },
+      {
+        "_id": "5c880142d7c8ac4c3e106748",
+        "authorDatetime": "2012-05-04T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "RxNorm",
+            "code": "864978"
+          }
+        ],
+        "daysSupplied": null,
+        "description": "Medication, Order: Opioid Medications",
+        "dosage": {
+          "value": 20,
+          "unit": "mg"
+        },
+        "frequency": {
+          "code": "229797004",
+          "codeSystem": "SNOMED-CT",
+          "descriptor": "Once daily (qualifier value)",
+          "codeSystemOid": null,
+          "version": null
+        },
+        "hqmfOid": "2.16.840.1.113883.3.560.1.17",
+        "id": {
+          "_id": "5c880142d7c8ac4c3e106749",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5b9ff2fcb8484609a9845621"
+        },
+        "negationRationale": null,
+        "prescriberId": null,
+        "qdmCategory": "medication",
+        "qdmStatus": "order",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "refills": null,
+        "relevantPeriod": {
+          "low": "2012-05-04T08:00:00.000+00:00",
+          "high": "2012-09-03T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "route": null,
+        "setting": null,
+        "supply": null,
+        "_type": "QDM::MedicationOrder"
+      },
+      {
+        "_id": "5c880142d7c8ac4c3e106740",
+        "birthDatetime": "1958-05-14T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "code": "21112-8",
+            "codeSystem": "LOINC",
+            "descriptor": null,
+            "codeSystemOid": null,
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.54",
+        "id": {
+          "_id": "5c880142d7c8ac4c3e10674a",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880142d7c8ac4c3e106740"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "birthdate",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicBirthdate"
+      },
+      {
+        "_id": "5c880142d7c8ac4c3e106741",
+        "dataElementCodes": [
+          {
+            "code": "2186-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "Not Hispanic or Latino",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.56",
+        "id": {
+          "_id": "5c880142d7c8ac4c3e10674b",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880142d7c8ac4c3e106741"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "ethnicity",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicEthnicity"
+      },
+      {
+        "_id": "5c880142d7c8ac4c3e106742",
+        "dataElementCodes": [
+          {
+            "code": "1002-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "American Indian or Alaska Native",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.59",
+        "id": {
+          "_id": "5c880142d7c8ac4c3e10674c",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880142d7c8ac4c3e106742"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "race",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicRace"
+      },
+      {
+        "_id": "5c880142d7c8ac4c3e106743",
+        "dataElementCodes": [
+          {
+            "code": "M",
+            "codeSystem": "AdministrativeGender",
+            "descriptor": "M",
+            "codeSystemOid": "2.16.840.1.113883.5.1",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.55",
+        "id": {
+          "_id": "5c880142d7c8ac4c3e10674d",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880142d7c8ac4c3e106743"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "gender",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicSex"
+      }
+    ],
+    "extendedData": {
+      "type": null,
+      "measure_ids": [
+        "442EDEF2-7347-4080-988F-16C9D1998803",
+        null
+      ],
+      "source_data_criteria": [
+        {
+          "negation": false,
+          "definition": "encounter",
+          "status": "performed",
+          "title": "OutpatientConsultation",
+          "description": "Encounter, Performed: Outpatient Consultation",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.101.12.1008",
+          "type": "encounters",
+          "id": "OutpatientConsultation_EncounterPerformed_48dc260e_53e9_4934_91fc_958ce91f1008_source",
+          "start_date": 1336118400000,
+          "end_date": 1336119300000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "442EDEF2-7347-4080-988F-16C9D1998803",
+          "cms_id": "CMS460v0",
+          "criteria_id": "165e8cb9dc6mt",
+          "codes": {
+            "SNOMED-CT": [
+              "17436001"
+            ],
+            "CPT": [
+              "99241"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5b9ff2fcb8484609a9845620"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "medication",
+          "status": "ordered",
+          "title": "OpioidMedications",
+          "description": "Medication, Order: Opioid Medications",
+          "code_list_id": "2.16.840.1.113883.3.3157.1004.26",
+          "type": "medications",
+          "id": "OpioidMedications_MedicationOrder_9fa72c11_9e0b_481f_a2bb_5ac13e6ddd90_source",
+          "start_date": 1336118400000,
+          "end_date": 1346660100000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+            "FREQUENCY": {
+              "type": "CD",
+              "code_list_id": "drc-e6b5e12d54357f2eff60055d5aa19fbe4c458e863b9a4bb551a5ba5b3c8ca1c5",
+              "field_title": "Frequency",
+              "title": "Once daily (qualifier value)"
+            },
+            "DOSE": {
+              "type": "PQ",
+              "code_list_id": "",
+              "field_title": "Dosage",
+              "value": "20",
+              "unit": "mg"
+            }
+          },
+          "hqmf_set_id": "442EDEF2-7347-4080-988F-16C9D1998803",
+          "cms_id": "CMS460v0",
+          "criteria_id": "165e8cbce30A9",
+          "codes": {
+            "RxNorm": [
+              "864978"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5b9ff2fcb8484609a9845621"
+          },
+          "code_source": "USER_DEFINED"
+        },
+        {
+          "id": "MeasurePeriod",
+          "start_date": 0,
+          "end_date": 0,
+          "references": null
+        }
+      ],
+      "is_shared": null,
+      "origin_data": [
+
+      ],
+      "test_id": null,
+      "medical_record_number": "db7212399f648c5126c4f02acb51e1ecb64b4c24252752a1d730c7341861aa7d",
+      "medical_record_assigner": "Bonnie",
+      "description": null,
+      "description_category": null,
+      "insurance_providers": "[{\"codes\":{\"SOP\":[\"349\"]},\"description\":null,\"end_time\":null,\"financial_responsibility_type\":{\"code\":\"SELF\",\"codeSystem\":\"HL7 Relationship Code\"},\"health_record_field\":null,\"member_id\":\"1234567890\",\"mood_code\":\"EVN\",\"name\":\"Other\",\"negationInd\":null,\"negationReason\":null,\"oid\":null,\"payer\":{\"name\":\"Other\"},\"reason\":null,\"relationship\":null,\"specifics\":null,\"start_time\":1199145600,\"status_code\":null,\"time\":null,\"type\":\"OT\"}]"
+    },
+    "qdmVersion": "5.4"
+  }
+}

--- a/spec/javascripts/fixtures/json/patients/CMS460v0/Opioid_Test.json
+++ b/spec/javascripts/fixtures/json/patients/CMS460v0/Opioid_Test.json
@@ -1,0 +1,340 @@
+{
+  "_id": "5af346c3b848465f42b0acf3",
+  "bundleId": "5a57e977942c6d1e61d32f14",
+  "expectedValues": [
+    {
+      "measure_id": "442EDEF2-7347-4080-988F-16C9D1998803",
+      "population_index": 0,
+      "IPP": 1,
+      "DENOM": 1,
+      "DENEX": 0,
+      "NUMER": 0
+    }
+  ],
+  "familyName": "Test",
+  "givenNames": [
+    "Opioid"
+  ],
+  "notes": "",
+  "qdmPatient": {
+    "_id": "5c880142d7c8ac4c3e106737",
+    "birthDatetime": "1980-06-10T08:00:00.000+00:00",
+    "dataElements": [
+      {
+        "_id": "5c880142d7c8ac4c3e106738",
+        "admissionSource": null,
+        "authorDatetime": "2012-05-09T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "17436001"
+          },
+          {
+            "codeSystem": "CPT",
+            "code": "99241"
+          }
+        ],
+        "description": "Encounter, Performed: Outpatient Consultation",
+        "diagnoses": [
+
+        ],
+        "dischargeDisposition": null,
+        "facilityLocations": [
+
+        ],
+        "hqmfOid": "2.16.840.1.113883.3.560.1.79",
+        "id": {
+          "_id": "5c880142d7c8ac4c3e106739",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5b2a7bfeb8484678da8c686c"
+        },
+        "lengthOfStay": {
+          "value": 0,
+          "unit": "days"
+        },
+        "negationRationale": null,
+        "principalDiagnosis": null,
+        "qdmCategory": "encounter",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "relevantPeriod": {
+          "low": "2012-05-09T08:00:00.000+00:00",
+          "high": "2012-05-09T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "_type": "QDM::EncounterPerformed"
+      },
+      {
+        "_id": "5c880142d7c8ac4c3e10673a",
+        "authorDatetime": "2012-05-09T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "RxNorm",
+            "code": "1053647"
+          }
+        ],
+        "daysSupplied": null,
+        "description": "Medication, Order: Opioid Medications",
+        "dosage": {
+          "value": 0.5,
+          "unit": "mg"
+        },
+        "frequency": {
+          "code": "229799001",
+          "codeSystem": "SNOMED-CT",
+          "descriptor": "Twice a day (qualifier value)",
+          "codeSystemOid": null,
+          "version": null
+        },
+        "hqmfOid": "2.16.840.1.113883.3.560.1.17",
+        "id": {
+          "_id": "5c880142d7c8ac4c3e10673b",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5b2a7bfeb8484678da8c686d"
+        },
+        "negationRationale": null,
+        "prescriberId": null,
+        "qdmCategory": "medication",
+        "qdmStatus": "order",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "refills": 2,
+        "relevantPeriod": {
+          "low": "2012-05-09T08:00:00.000+00:00",
+          "high": "2012-12-28T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "route": null,
+        "setting": null,
+        "supply": {
+          "value": 120,
+          "unit": ""
+        },
+        "_type": "QDM::MedicationOrder"
+      },
+      {
+        "_id": "5c880142d7c8ac4c3e106732",
+        "birthDatetime": "1980-06-10T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "code": "21112-8",
+            "codeSystem": "LOINC",
+            "descriptor": null,
+            "codeSystemOid": null,
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.54",
+        "id": {
+          "_id": "5c880142d7c8ac4c3e10673c",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880142d7c8ac4c3e106732"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "birthdate",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicBirthdate"
+      },
+      {
+        "_id": "5c880142d7c8ac4c3e106733",
+        "dataElementCodes": [
+          {
+            "code": "2186-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "Not Hispanic or Latino",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.56",
+        "id": {
+          "_id": "5c880142d7c8ac4c3e10673d",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880142d7c8ac4c3e106733"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "ethnicity",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicEthnicity"
+      },
+      {
+        "_id": "5c880142d7c8ac4c3e106734",
+        "dataElementCodes": [
+          {
+            "code": "1002-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "American Indian or Alaska Native",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.59",
+        "id": {
+          "_id": "5c880142d7c8ac4c3e10673e",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880142d7c8ac4c3e106734"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "race",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicRace"
+      },
+      {
+        "_id": "5c880142d7c8ac4c3e106735",
+        "dataElementCodes": [
+          {
+            "code": "M",
+            "codeSystem": "AdministrativeGender",
+            "descriptor": "M",
+            "codeSystemOid": "2.16.840.1.113883.5.1",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.55",
+        "id": {
+          "_id": "5c880142d7c8ac4c3e10673f",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880142d7c8ac4c3e106735"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "gender",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicSex"
+      }
+    ],
+    "extendedData": {
+      "type": null,
+      "measure_ids": [
+        "442EDEF2-7347-4080-988F-16C9D1998803",
+        null
+      ],
+      "source_data_criteria": [
+        {
+          "negation": false,
+          "definition": "encounter",
+          "status": "performed",
+          "title": "OutpatientConsultation",
+          "description": "Encounter, Performed: Outpatient Consultation",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.101.12.1008",
+          "type": "encounters",
+          "id": "OutpatientConsultation_EncounterPerformed_48dc260e_53e9_4934_91fc_958ce91f1008_source",
+          "start_date": 1336550400000,
+          "end_date": 1336551300000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "442EDEF2-7347-4080-988F-16C9D1998803",
+          "cms_id": "CMS460v0",
+          "criteria_id": "1634649dc54ED",
+          "codes": {
+            "SNOMED-CT": [
+              "17436001"
+            ],
+            "CPT": [
+              "99241"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5b2a7bfeb8484678da8c686c"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "medication",
+          "status": "ordered",
+          "title": "OpioidMedications",
+          "description": "Medication, Order: Opioid Medications",
+          "code_list_id": "2.16.840.1.113762.1.4.1111.144",
+          "type": "medications",
+          "id": "OpioidMedications_MedicationOrder_9fa72c11_9e0b_481f_a2bb_5ac13e6ddd90_source",
+          "start_date": 1336550400000,
+          "end_date": 1356682500000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+            "DOSE": {
+              "type": "PQ",
+              "value": "0.5",
+              "unit": "mg",
+              "field_title": "Dosage"
+            },
+            "FREQUENCY": {
+              "type": "CD",
+              "code_list_id": "drc-5d724671c39b58f85c450e49e712099c7c7ddc12096bd8b026a451dc75735b45",
+              "field_title": "Frequency",
+              "title": "Twice a day (qualifier value)"
+            },
+            "SUPPLY": {
+              "type": "PQ",
+              "code_list_id": "",
+              "field_title": "Supply",
+              "value": "120",
+              "unit": ""
+            },
+            "REFILLS": {
+              "type": "PQ",
+              "code_list_id": "",
+              "field_title": "Refills",
+              "value": "2",
+              "unit": ""
+            }
+          },
+          "hqmf_set_id": "442EDEF2-7347-4080-988F-16C9D1998803",
+          "cms_id": "CMS460v0",
+          "criteria_id": "163464a0518ET",
+          "codes": {
+            "RxNorm": [
+              "1053647"
+            ]
+          },
+          "fulfillments": null,
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5b2a7bfeb8484678da8c686d"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "id": "MeasurePeriod",
+          "start_date": 0,
+          "end_date": 0,
+          "references": null
+        }
+      ],
+      "is_shared": null,
+      "origin_data": [
+
+      ],
+      "test_id": null,
+      "medical_record_number": "5c9bee7e9c8628990b49657d9314673e61f3c211d838a8ae7d4ec8042c6966b6",
+      "medical_record_assigner": "Bonnie",
+      "description": null,
+      "description_category": null,
+      "insurance_providers": "[]"
+    },
+    "qdmVersion": "5.4"
+  }
+}

--- a/spec/javascripts/fixtures/json/patients/CMS529v0/Pass_IPP/DENOM/NUMER.json
+++ b/spec/javascripts/fixtures/json/patients/CMS529v0/Pass_IPP/DENOM/NUMER.json
@@ -1,0 +1,273 @@
+{
+  "_id": "5b05a7f8b84846736b81b847",
+  "bundleId": "5a57e977942c6d1e61d32f14",
+  "expectedValues": [
+    {
+      "measure_id": "FA75DE85-A934-45D7-A2F7-C700A756078B",
+      "population_index": 0,
+      "IPP": 1,
+      "DENOM": 1,
+      "NUMER": 1
+    }
+  ],
+  "familyName": "IPP/DENOM/NUMER",
+  "givenNames": [
+    "Pass"
+  ],
+  "notes": "",
+  "qdmPatient": {
+    "_id": "5c880142d7c8ac4c3e106729",
+    "birthDatetime": "1930-05-01T08:00:00.000+00:00",
+    "dataElements": [
+      {
+        "_id": "5c880142d7c8ac4c3e10672a",
+        "authorDatetime": "2012-05-22T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "Source of Payment Typology",
+            "code": "1"
+          }
+        ],
+        "description": "Patient Characteristic: Payer",
+        "hqmfOid": "2.16.840.1.113883.3.560.1.1001",
+        "id": {
+          "_id": "5c880142d7c8ac4c3e10672b",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5b05a7f8b84846736b81b848"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristic"
+      },
+      {
+        "_id": "5c880142d7c8ac4c3e10672c",
+        "admissionSource": null,
+        "authorDatetime": "2012-05-22T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "112689000"
+          }
+        ],
+        "description": "Encounter, Performed: Acute care hospital Inpatient Encounter",
+        "diagnoses": [
+
+        ],
+        "dischargeDisposition": null,
+        "facilityLocations": [
+
+        ],
+        "hqmfOid": "2.16.840.1.113883.3.560.1.79",
+        "id": {
+          "_id": "5c880142d7c8ac4c3e10672d",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5b05a7f8b84846736b81b849"
+        },
+        "lengthOfStay": {
+          "value": 0,
+          "unit": "days"
+        },
+        "negationRationale": null,
+        "principalDiagnosis": null,
+        "qdmCategory": "encounter",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "relevantPeriod": {
+          "low": "2012-05-22T08:00:00.000+00:00",
+          "high": "2012-05-22T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "_type": "QDM::EncounterPerformed"
+      },
+      {
+        "_id": "5c880142d7c8ac4c3e106724",
+        "birthDatetime": "1930-05-01T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "code": "21112-8",
+            "codeSystem": "LOINC",
+            "descriptor": null,
+            "codeSystemOid": null,
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.54",
+        "id": {
+          "_id": "5c880142d7c8ac4c3e10672e",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880142d7c8ac4c3e106724"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "birthdate",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicBirthdate"
+      },
+      {
+        "_id": "5c880142d7c8ac4c3e106725",
+        "dataElementCodes": [
+          {
+            "code": "2186-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "Not Hispanic or Latino",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.56",
+        "id": {
+          "_id": "5c880142d7c8ac4c3e10672f",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880142d7c8ac4c3e106725"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "ethnicity",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicEthnicity"
+      },
+      {
+        "_id": "5c880142d7c8ac4c3e106726",
+        "dataElementCodes": [
+          {
+            "code": "1002-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "American Indian or Alaska Native",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.59",
+        "id": {
+          "_id": "5c880142d7c8ac4c3e106730",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880142d7c8ac4c3e106726"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "race",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicRace"
+      },
+      {
+        "_id": "5c880142d7c8ac4c3e106727",
+        "dataElementCodes": [
+          {
+            "code": "M",
+            "codeSystem": "AdministrativeGender",
+            "descriptor": "M",
+            "codeSystemOid": "2.16.840.1.113883.5.1",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.55",
+        "id": {
+          "_id": "5c880142d7c8ac4c3e106731",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880142d7c8ac4c3e106727"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "gender",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicSex"
+      }
+    ],
+    "extendedData": {
+      "type": null,
+      "measure_ids": [
+        "FA75DE85-A934-45D7-A2F7-C700A756078B",
+        null
+      ],
+      "source_data_criteria": [
+        {
+          "negation": false,
+          "definition": "patient_characteristic",
+          "title": "Payer",
+          "description": "Patient Characteristic: Payer",
+          "code_list_id": "2.16.840.1.114222.4.11.3591",
+          "type": "characteristic",
+          "id": "Payer_PatientCharacteristic_41dc8804_cc7b_413d_9a39_e815347fcb46_source",
+          "start_date": 1337673600000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "FA75DE85-A934-45D7-A2F7-C700A756078B",
+          "cms_id": "CMS529v0",
+          "criteria_id": "1638e17af2fnT",
+          "codes": {
+            "Source of Payment Typology": [
+              "1"
+            ]
+          },
+          "coded_entry_id": {
+            "$oid": "5b05a7f8b84846736b81b848"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "encounter",
+          "status": "performed",
+          "title": "AcutecarehospitalInpatientEncounter",
+          "description": "Encounter, Performed: Acute care hospital Inpatient Encounter",
+          "code_list_id": "2.16.840.1.113883.3.666.5.2289",
+          "type": "encounters",
+          "id": "AcutecarehospitalInpatientEncounter_EncounterPerformed_cb0e4615_4bf7_47ca_8f0a_6f68ce9643a4_source",
+          "start_date": 1337673600000,
+          "end_date": 1337674500000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "FA75DE85-A934-45D7-A2F7-C700A756078B",
+          "cms_id": "CMS529v0",
+          "criteria_id": "1638e17d6c4fh",
+          "codes": {
+            "SNOMED-CT": [
+              "112689000"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5b05a7f8b84846736b81b849"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "id": "MeasurePeriod",
+          "start_date": 0,
+          "end_date": 0,
+          "references": null
+        }
+      ],
+      "is_shared": null,
+      "origin_data": [
+
+      ],
+      "test_id": null,
+      "medical_record_number": "d0db3db3f32ea2ea554b57e86370635d4c4ae1cfaa247d44e1fe2797320f1cb1",
+      "medical_record_assigner": "Bonnie",
+      "description": null,
+      "description_category": null,
+      "insurance_providers": "[{\"codes\":{\"SOP\":[\"349\"]},\"description\":null,\"end_time\":null,\"financial_responsibility_type\":{\"code\":\"SELF\",\"codeSystem\":\"HL7 Relationship Code\"},\"health_record_field\":null,\"member_id\":\"1234567890\",\"mood_code\":\"EVN\",\"name\":\"Other\",\"negationInd\":null,\"negationReason\":null,\"oid\":null,\"payer\":{\"name\":\"Other\"},\"reason\":null,\"relationship\":null,\"specifics\":null,\"start_time\":1199145600,\"status_code\":null,\"time\":null,\"type\":\"OT\"}]"
+    },
+    "qdmVersion": "5.4"
+  }
+}

--- a/spec/javascripts/fixtures/json/patients/CMS52v7/Element_Direct Reference Code.json
+++ b/spec/javascripts/fixtures/json/patients/CMS52v7/Element_Direct Reference Code.json
@@ -1,0 +1,553 @@
+{
+  "_id": "5ac279c4b848462af8fef319",
+  "bundleId": "5a57e977942c6d1e61d32f14",
+  "expectedValues": [
+    {
+      "measure_id": "1CDD20DE-5DE9-4759-8A93-31F1F8BAAAA2",
+      "population_index": 0,
+      "IPP": 1,
+      "DENOM": 1,
+      "DENEX": 0,
+      "NUMER": 0,
+      "DENEXCEP": 0
+    },
+    {
+      "measure_id": "1CDD20DE-5DE9-4759-8A93-31F1F8BAAAA2",
+      "population_index": 1,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0,
+      "DENEXCEP": 0
+    },
+    {
+      "measure_id": "1CDD20DE-5DE9-4759-8A93-31F1F8BAAAA2",
+      "population_index": 2,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    }
+  ],
+  "familyName": "Direct Reference Code",
+  "givenNames": [
+    "Element"
+  ],
+  "notes": "",
+  "qdmPatient": {
+    "_id": "5c880140d7c8ac4c3e1066f1",
+    "birthDatetime": "1970-01-01T08:00:00.000+00:00",
+    "dataElements": [
+      {
+        "_id": "5c880140d7c8ac4c3e1066f2",
+        "anatomicalLocationSite": null,
+        "authorDatetime": "2012-03-30T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "ICD-9-CM",
+            "code": "042"
+          },
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "111880001"
+          },
+          {
+            "codeSystem": "ICD-10-CM",
+            "code": "B20"
+          }
+        ],
+        "description": "Diagnosis: HIV 1",
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.110",
+        "id": {
+          "_id": "5c880140d7c8ac4c3e1066f3",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5aeb77e6b848463d625b667e"
+        },
+        "prevalencePeriod": {
+          "low": "2012-03-30T08:00:00.000+00:00",
+          "high": "2012-03-30T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "qdmCategory": "condition",
+        "qdmVersion": "5.4",
+        "qrdaOid": "2.16.840.1.113883.10.20.24.3.135",
+        "severity": null,
+        "_type": "QDM::Diagnosis"
+      },
+      {
+        "_id": "5c880140d7c8ac4c3e1066f4",
+        "admissionSource": null,
+        "authorDatetime": "2012-03-30T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "185463005"
+          },
+          {
+            "codeSystem": "CPT",
+            "code": "99201"
+          }
+        ],
+        "description": "Encounter, Performed: Office Visit",
+        "diagnoses": [
+
+        ],
+        "dischargeDisposition": null,
+        "facilityLocations": [
+
+        ],
+        "hqmfOid": "2.16.840.1.113883.3.560.1.79",
+        "id": {
+          "_id": "5c880140d7c8ac4c3e1066f5",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5aeb77e6b848463d625b667f"
+        },
+        "lengthOfStay": {
+          "value": 0,
+          "unit": "days"
+        },
+        "negationRationale": null,
+        "principalDiagnosis": null,
+        "qdmCategory": "encounter",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "relevantPeriod": {
+          "low": "2012-03-30T08:00:00.000+00:00",
+          "high": "2012-03-30T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "_type": "QDM::EncounterPerformed"
+      },
+      {
+        "_id": "5c880140d7c8ac4c3e1066f6",
+        "admissionSource": null,
+        "authorDatetime": "2012-07-30T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "185463005"
+          },
+          {
+            "codeSystem": "CPT",
+            "code": "99201"
+          }
+        ],
+        "description": "Encounter, Performed: Office Visit",
+        "diagnoses": [
+
+        ],
+        "dischargeDisposition": null,
+        "facilityLocations": [
+
+        ],
+        "hqmfOid": "2.16.840.1.113883.3.560.1.79",
+        "id": {
+          "_id": "5c880140d7c8ac4c3e1066f7",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5aeb77e6b848463d625b6680"
+        },
+        "lengthOfStay": {
+          "value": 0,
+          "unit": "days"
+        },
+        "negationRationale": null,
+        "principalDiagnosis": null,
+        "qdmCategory": "encounter",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "relevantPeriod": {
+          "low": "2012-07-30T08:00:00.000+00:00",
+          "high": "2012-07-30T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "_type": "QDM::EncounterPerformed"
+      },
+      {
+        "_id": "5c880140d7c8ac4c3e1066f8",
+        "authorDatetime": "2012-03-30T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "RxNorm",
+            "code": "105337"
+          }
+        ],
+        "daysSupplied": null,
+        "description": "Medication, Order: Dapsone 100 MG / Pyrimethamine 12.5 MG Oral Tablet",
+        "dosage": null,
+        "frequency": null,
+        "hqmfOid": "2.16.840.1.113883.3.560.1.17",
+        "id": {
+          "_id": "5c880140d7c8ac4c3e1066f9",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5aeb77e6b848463d625b6681"
+        },
+        "negationRationale": null,
+        "prescriberId": null,
+        "qdmCategory": "medication",
+        "qdmStatus": "order",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "refills": null,
+        "relevantPeriod": {
+          "low": "2012-03-30T08:00:00.000+00:00",
+          "high": "2012-03-30T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "route": null,
+        "setting": null,
+        "supply": null,
+        "_type": "QDM::MedicationOrder"
+      },
+      {
+        "_id": "5c880140d7c8ac4c3e1066fa",
+        "authorDatetime": "2012-03-30T08:00:00.000+00:00",
+        "components": [
+
+        ],
+        "dataElementCodes": [
+          {
+            "codeSystem": "LOINC",
+            "code": "24467-3"
+          }
+        ],
+        "description": "Laboratory Test, Performed: CD4+ Count",
+        "hqmfOid": "2.16.840.1.113883.3.560.1.5",
+        "id": {
+          "_id": "5c880140d7c8ac4c3e1066fb",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5aeb77e6b848463d625b6682"
+        },
+        "method": null,
+        "negationRationale": null,
+        "qdmCategory": "laboratory_test",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "referenceRange": null,
+        "relevantPeriod": {
+          "low": "2012-03-30T08:00:00.000+00:00",
+          "high": "2012-03-30T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "result": {
+          "unit": "/mm3",
+          "value": 199
+        },
+        "resultDatetime": null,
+        "status": null,
+        "_type": "QDM::LaboratoryTestPerformed"
+      },
+      {
+        "_id": "5c880140d7c8ac4c3e1066ec",
+        "birthDatetime": "1970-01-01T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "code": "21112-8",
+            "codeSystem": "LOINC",
+            "descriptor": null,
+            "codeSystemOid": null,
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.54",
+        "id": {
+          "_id": "5c880140d7c8ac4c3e1066fc",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880140d7c8ac4c3e1066ec"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "birthdate",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicBirthdate"
+      },
+      {
+        "_id": "5c880140d7c8ac4c3e1066ed",
+        "dataElementCodes": [
+          {
+            "code": "2186-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "Not Hispanic or Latino",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.56",
+        "id": {
+          "_id": "5c880140d7c8ac4c3e1066fd",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880140d7c8ac4c3e1066ed"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "ethnicity",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicEthnicity"
+      },
+      {
+        "_id": "5c880140d7c8ac4c3e1066ee",
+        "dataElementCodes": [
+          {
+            "code": "1002-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "American Indian or Alaska Native",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.59",
+        "id": {
+          "_id": "5c880140d7c8ac4c3e1066fe",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880140d7c8ac4c3e1066ee"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "race",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicRace"
+      },
+      {
+        "_id": "5c880140d7c8ac4c3e1066ef",
+        "dataElementCodes": [
+          {
+            "code": "M",
+            "codeSystem": "AdministrativeGender",
+            "descriptor": "M",
+            "codeSystemOid": "2.16.840.1.113883.5.1",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.55",
+        "id": {
+          "_id": "5c880140d7c8ac4c3e1066ff",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880140d7c8ac4c3e1066ef"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "gender",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicSex"
+      }
+    ],
+    "extendedData": {
+      "type": null,
+      "measure_ids": [
+        "1CDD20DE-5DE9-4759-8A93-31F1F8BAAAA2",
+        null
+      ],
+      "source_data_criteria": [
+        {
+          "negation": false,
+          "definition": "medication",
+          "status": "ordered",
+          "title": "Medication, Order: Medication, Order",
+          "description": "Medication, Order: Dapsone 100 MG / Pyrimethamine 12.5 MG Oral Tablet",
+          "code_list_id": "drc-e7bcd5fe05acffa0b0210240916ebdd5cb263ec9e30c7f943a055e4f406b38c4",
+          "type": "medications",
+          "id": "prefix_105337_MedicationOrder_0EC8DFB2_C7B5_4C69_92A3_F517CCD2FF8C_source",
+          "start_date": 1333094400000,
+          "end_date": 1333095300000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "1CDD20DE-5DE9-4759-8A93-31F1F8BAAAA2",
+          "cms_id": "CMS52v7",
+          "criteria_id": "16287aa2af4G0",
+          "codes": {
+            "RxNorm": [
+              "105337"
+            ]
+          },
+          "fulfillments": null,
+          "administrations_value": "",
+          "frequency_value": "",
+          "frequency_unit": "min",
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5aeb77e6b848463d625b6681"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "diagnosis",
+          "title": "HIV1",
+          "description": "Diagnosis: HIV 1",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.120.12.1004",
+          "type": "conditions",
+          "id": "HIV1_Diagnosis_abf5cb1c_6014_4c16_9991_f0af2322bf3d_source",
+          "start_date": 1333094400000,
+          "end_date": 1333095300000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "1CDD20DE-5DE9-4759-8A93-31F1F8BAAAA2",
+          "cms_id": "CMS52v7",
+          "criteria_id": "16287aa7788lA",
+          "codes": {
+            "ICD-9-CM": [
+              "042"
+            ],
+            "SNOMED-CT": [
+              "111880001"
+            ],
+            "ICD-10-CM": [
+              "B20"
+            ]
+          },
+          "coded_entry_id": {
+            "$oid": "5aeb77e6b848463d625b667e"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "encounter",
+          "status": "performed",
+          "title": "OfficeVisit",
+          "description": "Encounter, Performed: Office Visit",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.101.12.1001",
+          "type": "encounters",
+          "id": "OfficeVisit_EncounterPerformed_53ac9eca_bdc8_4a25_bb93_f88e7282c0b0_source",
+          "start_date": 1333094400000,
+          "end_date": 1333095300000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "1CDD20DE-5DE9-4759-8A93-31F1F8BAAAA2",
+          "cms_id": "CMS52v7",
+          "criteria_id": "16287aaa0ecs1",
+          "codes": {
+            "SNOMED-CT": [
+              "185463005"
+            ],
+            "CPT": [
+              "99201"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5aeb77e6b848463d625b667f"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "laboratory_test",
+          "status": "performed",
+          "title": "CD4+Count",
+          "description": "Laboratory Test, Performed: CD4+ Count",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.121.12.1004",
+          "type": "laboratory_tests",
+          "id": "CD4_Count_LaboratoryTestPerformed_fe396d84_5c2c_448e_84b9_e6c4b7064c0d_source",
+          "start_date": 1333094400000,
+          "end_date": 1333095300000,
+          "value": [
+            {
+              "type": "PQ",
+              "type_cmp": "CD",
+              "value": "199",
+              "unit": "/mm3"
+            }
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "1CDD20DE-5DE9-4759-8A93-31F1F8BAAAA2",
+          "cms_id": "CMS52v7",
+          "criteria_id": "16287aae234Db",
+          "codes": {
+            "LOINC": [
+              "24467-3"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5aeb77e6b848463d625b6682"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "encounter",
+          "status": "performed",
+          "title": "OfficeVisit",
+          "description": "Encounter, Performed: Office Visit",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.101.12.1001",
+          "type": "encounters",
+          "id": "OfficeVisit_EncounterPerformed_53ac9eca_bdc8_4a25_bb93_f88e7282c0b0_source",
+          "start_date": 1343635200000,
+          "end_date": 1343636100000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "1CDD20DE-5DE9-4759-8A93-31F1F8BAAAA2",
+          "cms_id": "CMS52v7",
+          "criteria_id": "16287ab2336Cq",
+          "codes": {
+            "SNOMED-CT": [
+              "185463005"
+            ],
+            "CPT": [
+              "99201"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5aeb77e6b848463d625b6680"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "id": "MeasurePeriod",
+          "start_date": 0,
+          "end_date": 0,
+          "references": null
+        }
+      ],
+      "is_shared": null,
+      "origin_data": [
+
+      ],
+      "test_id": null,
+      "medical_record_number": "7368f43d63c27db2e2516cc8cc97fdf89a58a9ed2318ca3ecc90fb0656657f6a",
+      "medical_record_assigner": "Bonnie",
+      "description": null,
+      "description_category": null,
+      "insurance_providers": "[]"
+    },
+    "qdmVersion": "5.4"
+  }
+}

--- a/spec/javascripts/fixtures/json/patients/CMS53v7/PCIat60min_NUMERPass.json
+++ b/spec/javascripts/fixtures/json/patients/CMS53v7/PCIat60min_NUMERPass.json
@@ -1,0 +1,496 @@
+{
+  "_id": "5b758aa7b8484609983b84a6",
+  "bundleId": "5a57e977942c6d1e61d32f14",
+  "expectedValues": [
+    {
+      "measure_id": "84B9D0B5-0CAF-4E41-B345-3492A23C2E9F",
+      "population_index": 0,
+      "IPP": 1,
+      "DENOM": 1,
+      "DENEX": 0,
+      "NUMER": 1,
+      "DENEXCEP": 0
+    }
+  ],
+  "familyName": "NUMERPass",
+  "givenNames": [
+    "PCIat60min"
+  ],
+  "notes": "Correct age, enc., MP, ECG, PCI done at 60 minutes of arrival ",
+  "qdmPatient": {
+    "_id": "5c880145d7c8ac4c3e1067b5",
+    "birthDatetime": "1955-11-24T08:00:00.000+00:00",
+    "dataElements": [
+      {
+        "_id": "5c880145d7c8ac4c3e1067b6",
+        "admissionSource": null,
+        "authorDatetime": "2012-11-12T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "183452005"
+          }
+        ],
+        "description": "Encounter, Performed: Encounter Inpatient",
+        "diagnoses": [
+          {
+            "code": "10273003",
+            "codeSystem": "SNOMED-CT",
+            "version": null,
+            "descriptor": "Acute or Evolving MI"
+          }
+        ],
+        "dischargeDisposition": null,
+        "facilityLocations": [
+          {
+            "_id": {
+              "$oid": "5c880145d7c8ac4c3e1067af"
+            },
+            "dataElementCodes": [
+
+            ],
+            "description": null,
+            "_type": "QDM::FacilityLocation",
+            "code": {
+              "code": "183452005",
+              "codeSystem": "SNOMED-CT",
+              "descriptor": "Encounter Inpatient",
+              "codeSystemOid": null,
+              "version": null,
+              "_type": "QDM::Code"
+            },
+            "locationPeriod": {
+              "low": "2012-11-12T08:00:00.000+00:00",
+              "high": null,
+              "lowClosed": true,
+              "highClosed": true,
+              "_type": "QDM::Interval"
+            },
+            "qdmVersion": "5.4"
+          }
+        ],
+        "hqmfOid": "2.16.840.1.113883.3.560.1.79",
+        "id": {
+          "_id": "5c880145d7c8ac4c3e1067b7",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5b758aa7b8484609983b84a7"
+        },
+        "lengthOfStay": {
+          "value": 0,
+          "unit": "days"
+        },
+        "negationRationale": null,
+        "principalDiagnosis": {
+          "code": "10273003",
+          "codeSystem": "SNOMED-CT",
+          "descriptor": "Acute or Evolving MI",
+          "codeSystemOid": null,
+          "version": null
+        },
+        "qdmCategory": "encounter",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "relevantPeriod": {
+          "low": "2012-11-12T08:00:00.000+00:00",
+          "high": "2012-11-12T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "_type": "QDM::EncounterPerformed"
+      },
+      {
+        "_id": "5c880145d7c8ac4c3e1067b8",
+        "authorDatetime": "2012-11-12T09:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "RxNorm",
+            "code": "1804799"
+          }
+        ],
+        "description": "Medication, Administered: Fibrinolytic Therapy",
+        "dosage": null,
+        "frequency": null,
+        "hqmfOid": "2.16.840.1.113883.3.560.1.14",
+        "id": {
+          "_id": "5c880145d7c8ac4c3e1067b9",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5b758aa7b8484609983b84aa"
+        },
+        "negationRationale": null,
+        "qdmCategory": "medication",
+        "qdmStatus": "administered",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "relevantPeriod": {
+          "low": "2012-11-12T09:00:00.000+00:00",
+          "high": "2012-11-12T09:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "route": null,
+        "_type": "QDM::MedicationAdministered"
+      },
+      {
+        "_id": "5c880145d7c8ac4c3e1067ba",
+        "authorDatetime": "2012-11-12T08:00:00.000+00:00",
+        "components": [
+
+        ],
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "164847006"
+          }
+        ],
+        "description": "Diagnostic Study, Performed: Electrocardiogram (ECG)",
+        "facilityLocation": null,
+        "hqmfOid": "2.16.840.1.113883.3.560.1.3",
+        "id": {
+          "_id": "5c880145d7c8ac4c3e1067bb",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5b758aa7b8484609983b84a8"
+        },
+        "method": null,
+        "negationRationale": null,
+        "qdmCategory": "diagnostic_study",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "relevantPeriod": {
+          "low": "2012-11-12T08:00:00.000+00:00",
+          "high": "2012-11-12T08:30:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "result": null,
+        "resultDatetime": null,
+        "status": null,
+        "_type": "QDM::DiagnosticStudyPerformed"
+      },
+      {
+        "_id": "5c880145d7c8ac4c3e1067bc",
+        "anatomicalLocationSite": null,
+        "authorDatetime": "2012-11-12T09:00:00.000+00:00",
+        "components": [
+
+        ],
+        "dataElementCodes": [
+          {
+            "codeSystem": "ICD-10-PCS",
+            "code": "0270346"
+          },
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "11101003"
+          }
+        ],
+        "description": "Procedure, Performed: PCI",
+        "hqmfOid": "2.16.840.1.113883.3.560.1.6",
+        "id": {
+          "_id": "5c880145d7c8ac4c3e1067bd",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5b758aa7b8484609983b84a9"
+        },
+        "incisionDatetime": null,
+        "method": null,
+        "negationRationale": null,
+        "ordinality": null,
+        "qdmCategory": "procedure",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "relevantPeriod": {
+          "low": "2012-11-12T09:00:00.000+00:00",
+          "high": "2012-11-12T09:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "result": null,
+        "status": null,
+        "_type": "QDM::ProcedurePerformed"
+      },
+      {
+        "_id": "5c880145d7c8ac4c3e1067b0",
+        "birthDatetime": "1955-11-24T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "code": "21112-8",
+            "codeSystem": "LOINC",
+            "descriptor": null,
+            "codeSystemOid": null,
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.54",
+        "id": {
+          "_id": "5c880145d7c8ac4c3e1067be",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880145d7c8ac4c3e1067b0"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "birthdate",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicBirthdate"
+      },
+      {
+        "_id": "5c880145d7c8ac4c3e1067b1",
+        "dataElementCodes": [
+          {
+            "code": "2186-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "Not Hispanic or Latino",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.56",
+        "id": {
+          "_id": "5c880145d7c8ac4c3e1067bf",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880145d7c8ac4c3e1067b1"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "ethnicity",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicEthnicity"
+      },
+      {
+        "_id": "5c880145d7c8ac4c3e1067b2",
+        "dataElementCodes": [
+          {
+            "code": "1002-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "American Indian or Alaska Native",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.59",
+        "id": {
+          "_id": "5c880145d7c8ac4c3e1067c0",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880145d7c8ac4c3e1067b2"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "race",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicRace"
+      },
+      {
+        "_id": "5c880145d7c8ac4c3e1067b3",
+        "dataElementCodes": [
+          {
+            "code": "M",
+            "codeSystem": "AdministrativeGender",
+            "descriptor": "M",
+            "codeSystemOid": "2.16.840.1.113883.5.1",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.55",
+        "id": {
+          "_id": "5c880145d7c8ac4c3e1067c1",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880145d7c8ac4c3e1067b3"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "gender",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicSex"
+      }
+    ],
+    "extendedData": {
+      "type": null,
+      "measure_ids": [
+        "84B9D0B5-0CAF-4E41-B345-3492A23C2E9F",
+        null
+      ],
+      "source_data_criteria": [
+        {
+          "negation": false,
+          "definition": "encounter",
+          "status": "performed",
+          "title": "EncounterInpatient",
+          "description": "Encounter, Performed: Encounter Inpatient",
+          "code_list_id": "2.16.840.1.113883.3.666.5.307",
+          "type": "encounters",
+          "id": "EncounterInpatient_EncounterPerformed_8ee8cc7d_b1d8_4e88_b02c_6be2f448bbd7_source",
+          "start_date": 1352707200000,
+          "end_date": 1352708100000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+            "PRINCIPAL_DIAGNOSIS": {
+              "type": "CD",
+              "code_list_id": "2.16.840.1.113883.3.666.5.3022",
+              "field_title": "Principal Diagnosis",
+              "title": "Acute or Evolving MI"
+            },
+            "FACILITY_LOCATION": {
+              "type": "COL",
+              "values": [
+                {
+                  "type": "FAC",
+                  "key": "FACILITY_LOCATION",
+                  "code_list_id": "2.16.840.1.113883.3.666.5.307",
+                  "field_title": "Facility Location",
+                  "start_date": "11/12/2012",
+                  "start_time": "8:00 AM",
+                  "end_date": "",
+                  "end_time": "8:00 AM",
+                  "value": 1352707200000,
+                  "locationPeriodLow": "11/12/2012 8:00 AM",
+                  "title": "Encounter Inpatient"
+                }
+              ]
+            }
+          },
+          "hqmf_set_id": "84B9D0B5-0CAF-4E41-B345-3492A23C2E9F",
+          "cms_id": "CMS53v7",
+          "criteria_id": "16543231611VC",
+          "codes": {
+            "SNOMED-CT": [
+              "183452005"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5b758aa7b8484609983b84a7"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "diagnostic_study",
+          "status": "performed",
+          "title": "Electrocardiogram(ECG)",
+          "description": "Diagnostic Study, Performed: Electrocardiogram (ECG)",
+          "code_list_id": "2.16.840.1.113883.3.666.5.735",
+          "type": "diagnostic_studies",
+          "id": "Electrocardiogram_ECG__DiagnosticStudyPerformed_fce36416_5e59_44e2_991d_78fc3f716dd8_source",
+          "start_date": 1352707200000,
+          "end_date": 1352709000000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "84B9D0B5-0CAF-4E41-B345-3492A23C2E9F",
+          "cms_id": "CMS53v7",
+          "criteria_id": "1654324cea7uz",
+          "codes": {
+            "SNOMED-CT": [
+              "164847006"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5b758aa7b8484609983b84a8"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "procedure",
+          "status": "performed",
+          "title": "PCI",
+          "description": "Procedure, Performed: PCI",
+          "code_list_id": "2.16.840.1.113762.1.4.1045.67",
+          "type": "procedures",
+          "id": "PCI_ProcedurePerformed_2f2d2de7_89fd_47a3_8060_527a9c5dcabb_source",
+          "start_date": 1352710800000,
+          "end_date": 1352711700000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "84B9D0B5-0CAF-4E41-B345-3492A23C2E9F",
+          "cms_id": "CMS53v7",
+          "criteria_id": "16543253e0338",
+          "codes": {
+            "ICD-10-PCS": [
+              "0270346"
+            ],
+            "SNOMED-CT": [
+              "11101003"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5b758aa7b8484609983b84a9"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "medication",
+          "status": "administered",
+          "title": "FibrinolyticTherapy",
+          "description": "Medication, Administered: Fibrinolytic Therapy",
+          "code_list_id": "2.16.840.1.113883.3.666.5.736",
+          "type": "medications",
+          "id": "FibrinolyticTherapy_MedicationAdministered_9cc94634_2acc_4c2f_89c4_b7bdad109448_source",
+          "start_date": 1352710800000,
+          "end_date": 1352711700000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "84B9D0B5-0CAF-4E41-B345-3492A23C2E9F",
+          "cms_id": "CMS53v7",
+          "criteria_id": "16543259103M9",
+          "codes": {
+            "RxNorm": [
+              "1804799"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5b758aa7b8484609983b84aa"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "id": "MeasurePeriod",
+          "start_date": 0,
+          "end_date": 0,
+          "references": null
+        }
+      ],
+      "is_shared": null,
+      "origin_data": [
+
+      ],
+      "test_id": null,
+      "medical_record_number": "04a1acfa4c0b99f5ce00e36ccadc7691af7cd2bf7d03944ff31634daed2f2f82",
+      "medical_record_assigner": "Bonnie",
+      "description": null,
+      "description_category": null,
+      "insurance_providers": "[{\"codes\":{\"SOP\":[\"349\"]},\"description\":null,\"end_time\":null,\"financial_responsibility_type\":{\"code\":\"SELF\",\"codeSystem\":\"HL7 Relationship Code\"},\"health_record_field\":null,\"member_id\":\"1234567890\",\"mood_code\":\"EVN\",\"name\":\"Other\",\"negationInd\":null,\"negationReason\":null,\"oid\":null,\"payer\":{\"name\":\"Other\"},\"reason\":null,\"relationship\":null,\"specifics\":null,\"start_time\":1199145600,\"status_code\":null,\"time\":null,\"type\":\"OT\"}]"
+    },
+    "qdmVersion": "5.4"
+  }
+}

--- a/spec/javascripts/fixtures/json/patients/CMS722v0/Patient With Code_Test.json
+++ b/spec/javascripts/fixtures/json/patients/CMS722v0/Patient With Code_Test.json
@@ -1,0 +1,370 @@
+{
+  "_id": "5abe36f0b848462862fdcae8",
+  "bundleId": "5a57e977942c6d1e61d32f14",
+  "expectedValues": [
+    {
+      "measure_id": "189C1035-C86E-419B-A034-AE55FA4C04F9",
+      "population_index": 0,
+      "IPP": 1,
+      "DENOM": 1,
+      "DENEX": 0,
+      "NUMER": 0
+    }
+  ],
+  "familyName": "Test",
+  "givenNames": [
+    "Patient With Code"
+  ],
+  "notes": "",
+  "qdmPatient": {
+    "_id": "5c880140d7c8ac4c3e1066d7",
+    "birthDatetime": "1970-01-01T08:00:00.000+00:00",
+    "dataElements": [
+      {
+        "_id": "5c880140d7c8ac4c3e1066d8",
+        "anatomicalLocationSite": null,
+        "authorDatetime": "2012-03-22T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "17561000119102"
+          },
+          {
+            "codeSystem": "ICD-10-CM",
+            "code": "Z38.00"
+          }
+        ],
+        "description": "Diagnosis: Live Birth Newborn Born in Hospital",
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.110",
+        "id": {
+          "_id": "5c880140d7c8ac4c3e1066d9",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5aeb77f7b848463d625b71e4"
+        },
+        "prevalencePeriod": {
+          "low": "2012-03-22T08:00:00.000+00:00",
+          "high": "2012-03-22T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "qdmCategory": "condition",
+        "qdmVersion": "5.4",
+        "qrdaOid": "2.16.840.1.113883.10.20.24.3.135",
+        "severity": null,
+        "_type": "QDM::Diagnosis"
+      },
+      {
+        "_id": "5c880140d7c8ac4c3e1066da",
+        "admissionSource": null,
+        "authorDatetime": "2012-03-22T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "183452005"
+          }
+        ],
+        "description": "Encounter, Performed: Encounter Inpatient",
+        "diagnoses": [
+
+        ],
+        "dischargeDisposition": null,
+        "facilityLocations": [
+
+        ],
+        "hqmfOid": "2.16.840.1.113883.3.560.1.79",
+        "id": {
+          "_id": "5c880140d7c8ac4c3e1066db",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5aeb77f7b848463d625b71e5"
+        },
+        "lengthOfStay": {
+          "value": 0,
+          "unit": "days"
+        },
+        "negationRationale": null,
+        "principalDiagnosis": null,
+        "qdmCategory": "encounter",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "relevantPeriod": {
+          "low": "2012-03-22T08:00:00.000+00:00",
+          "high": "2012-03-22T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "_type": "QDM::EncounterPerformed"
+      },
+      {
+        "_id": "5c880140d7c8ac4c3e1066dc",
+        "authorDatetime": "2012-03-22T08:00:00.000+00:00",
+        "components": [
+
+        ],
+        "dataElementCodes": [
+          {
+            "codeSystem": "LOINC",
+            "code": "54109-4"
+          }
+        ],
+        "description": "Diagnostic Study, Performed: Newborn Hearing Screen Right",
+        "facilityLocation": null,
+        "hqmfOid": "2.16.840.1.113883.3.560.1.3",
+        "id": {
+          "_id": "5c880140d7c8ac4c3e1066dd",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5aeb77f7b848463d625b71e6"
+        },
+        "method": null,
+        "negationRationale": null,
+        "qdmCategory": "diagnostic_study",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "relevantPeriod": {
+          "low": "2012-03-22T08:00:00.000+00:00",
+          "high": "2012-03-22T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "result": {
+          "code": "164059009",
+          "codeSystem": "SNOMED-CT",
+          "version": null,
+          "descriptor": "Pass Or Refer"
+        },
+        "resultDatetime": null,
+        "status": null,
+        "_type": "QDM::DiagnosticStudyPerformed"
+      },
+      {
+        "_id": "5c880140d7c8ac4c3e1066d2",
+        "birthDatetime": "1970-01-01T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "code": "21112-8",
+            "codeSystem": "LOINC",
+            "descriptor": null,
+            "codeSystemOid": null,
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.54",
+        "id": {
+          "_id": "5c880140d7c8ac4c3e1066de",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880140d7c8ac4c3e1066d2"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "birthdate",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicBirthdate"
+      },
+      {
+        "_id": "5c880140d7c8ac4c3e1066d3",
+        "dataElementCodes": [
+          {
+            "code": "2186-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "Not Hispanic or Latino",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.56",
+        "id": {
+          "_id": "5c880140d7c8ac4c3e1066df",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880140d7c8ac4c3e1066d3"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "ethnicity",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicEthnicity"
+      },
+      {
+        "_id": "5c880140d7c8ac4c3e1066d4",
+        "dataElementCodes": [
+          {
+            "code": "1002-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "American Indian or Alaska Native",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.59",
+        "id": {
+          "_id": "5c880140d7c8ac4c3e1066e0",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880140d7c8ac4c3e1066d4"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "race",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicRace"
+      },
+      {
+        "_id": "5c880140d7c8ac4c3e1066d5",
+        "dataElementCodes": [
+          {
+            "code": "M",
+            "codeSystem": "AdministrativeGender",
+            "descriptor": "M",
+            "codeSystemOid": "2.16.840.1.113883.5.1",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.55",
+        "id": {
+          "_id": "5c880140d7c8ac4c3e1066e1",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880140d7c8ac4c3e1066d5"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "gender",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicSex"
+      }
+    ],
+    "extendedData": {
+      "type": null,
+      "measure_ids": [
+        "189C1035-C86E-419B-A034-AE55FA4C04F9",
+        null
+      ],
+      "source_data_criteria": [
+        {
+          "negation": false,
+          "definition": "diagnostic_study",
+          "status": "performed",
+          "title": "Newborn Hearing Screen Right",
+          "description": "Diagnostic Study, Performed: Newborn Hearing Screen Right",
+          "code_list_id": "2.16.840.1.114222.4.1.214079.1.1.4",
+          "type": "diagnostic_studies",
+          "id": "NewbornHearingScreenRight_DiagnosticStudyPerformed_4d13fe89_db63_4397_9080_4168c8c8d26c_source",
+          "start_date": 1332403200000,
+          "end_date": 1332404100000,
+          "value": [
+            {
+              "type": "CD",
+              "type_cmp": "CD",
+              "code_list_id": "2.16.840.1.114222.4.1.214079.1.1.6",
+              "title": "Pass Or Refer"
+            }
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "189C1035-C86E-419B-A034-AE55FA4C04F9",
+          "cms_id": "CMS722v0",
+          "criteria_id": "1624e31e6618u",
+          "codes": {
+            "LOINC": [
+              "54109-4"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5aeb77f7b848463d625b71e6"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "encounter",
+          "status": "performed",
+          "title": "Encounter Inpatient",
+          "description": "Encounter, Performed: Encounter Inpatient",
+          "code_list_id": "2.16.840.1.113883.3.666.5.307",
+          "type": "encounters",
+          "id": "EncounterInpatient_EncounterPerformed_7b37876d_70f3_4879_a168_6dd822107f1c_source",
+          "start_date": 1332403200000,
+          "end_date": 1332404100000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "189C1035-C86E-419B-A034-AE55FA4C04F9",
+          "cms_id": "CMS722v0",
+          "criteria_id": "1624e3236f27z",
+          "codes": {
+            "SNOMED-CT": [
+              "183452005"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5aeb77f7b848463d625b71e5"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "diagnosis",
+          "title": "Live Birth Newborn Born in Hospital",
+          "description": "Diagnosis: Live Birth Newborn Born in Hospital",
+          "code_list_id": "2.16.840.1.113762.1.4.1046.6",
+          "type": "conditions",
+          "id": "LiveBirthNewbornBorninHospital_Diagnosis_d7f4c89d_3a0d_4426_80d8_ca1a5b92df24_source",
+          "start_date": 1332403200000,
+          "end_date": 1332404100000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "189C1035-C86E-419B-A034-AE55FA4C04F9",
+          "cms_id": "CMS722v0",
+          "criteria_id": "1624e32724a3o",
+          "codes": {
+            "SNOMED-CT": [
+              "17561000119102"
+            ],
+            "ICD-10-CM": [
+              "Z38.00"
+            ]
+          },
+          "coded_entry_id": {
+            "$oid": "5aeb77f7b848463d625b71e4"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "id": "MeasurePeriod",
+          "start_date": 0,
+          "end_date": 0,
+          "references": null
+        }
+      ],
+      "is_shared": null,
+      "origin_data": [
+
+      ],
+      "test_id": null,
+      "medical_record_number": "2fa973962474da8dfe89cbb7144fb11f2333f421eec112156776303cbedc2e64",
+      "medical_record_assigner": "Bonnie",
+      "description": null,
+      "description_category": null,
+      "insurance_providers": "[]"
+    },
+    "qdmVersion": "5.4"
+  }
+}

--- a/spec/javascripts/fixtures/json/patients/CMS722v0/Patient_Test.json
+++ b/spec/javascripts/fixtures/json/patients/CMS722v0/Patient_Test.json
@@ -1,0 +1,360 @@
+{
+  "_id": "5ab3c32db8484626ce364ebe",
+  "bundleId": "5a57e977942c6d1e61d32f14",
+  "expectedValues": [
+    {
+      "measure_id": "189C1035-C86E-419B-A034-AE55FA4C04F9",
+      "population_index": 0,
+      "IPP": 1,
+      "DENOM": 1,
+      "DENEX": 0,
+      "NUMER": 0
+    }
+  ],
+  "familyName": "Test",
+  "givenNames": [
+    "Patient"
+  ],
+  "notes": "",
+  "qdmPatient": {
+    "_id": "5c88013fd7c8ac4c3e1066c7",
+    "birthDatetime": "1970-01-01T08:00:00.000+00:00",
+    "dataElements": [
+      {
+        "_id": "5c88013fd7c8ac4c3e1066c8",
+        "anatomicalLocationSite": null,
+        "authorDatetime": "2012-03-22T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "17561000119102"
+          },
+          {
+            "codeSystem": "ICD-10-CM",
+            "code": "Z38.00"
+          }
+        ],
+        "description": "Diagnosis: Live Birth Newborn Born in Hospital",
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.110",
+        "id": {
+          "_id": "5c88013fd7c8ac4c3e1066c9",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5aeb77f2b848463d625b6dbe"
+        },
+        "prevalencePeriod": {
+          "low": "2012-03-22T08:00:00.000+00:00",
+          "high": "2012-03-22T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "qdmCategory": "condition",
+        "qdmVersion": "5.4",
+        "qrdaOid": "2.16.840.1.113883.10.20.24.3.135",
+        "severity": null,
+        "_type": "QDM::Diagnosis"
+      },
+      {
+        "_id": "5c88013fd7c8ac4c3e1066ca",
+        "admissionSource": null,
+        "authorDatetime": "2012-03-22T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "183452005"
+          }
+        ],
+        "description": "Encounter, Performed: Encounter Inpatient",
+        "diagnoses": [
+
+        ],
+        "dischargeDisposition": null,
+        "facilityLocations": [
+
+        ],
+        "hqmfOid": "2.16.840.1.113883.3.560.1.79",
+        "id": {
+          "_id": "5c88013fd7c8ac4c3e1066cb",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5aeb77f2b848463d625b6dbf"
+        },
+        "lengthOfStay": {
+          "value": 0,
+          "unit": "days"
+        },
+        "negationRationale": null,
+        "principalDiagnosis": null,
+        "qdmCategory": "encounter",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "relevantPeriod": {
+          "low": "2012-03-22T08:00:00.000+00:00",
+          "high": "2012-03-22T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "_type": "QDM::EncounterPerformed"
+      },
+      {
+        "_id": "5c88013fd7c8ac4c3e1066cc",
+        "authorDatetime": "2012-03-22T08:00:00.000+00:00",
+        "components": [
+
+        ],
+        "dataElementCodes": [
+          {
+            "codeSystem": "LOINC",
+            "code": "54109-4"
+          }
+        ],
+        "description": "Diagnostic Study, Performed: Newborn Hearing Screen Right",
+        "facilityLocation": null,
+        "hqmfOid": "2.16.840.1.113883.3.560.1.3",
+        "id": {
+          "_id": "5c88013fd7c8ac4c3e1066cd",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5aeb77f2b848463d625b6dc0"
+        },
+        "method": null,
+        "negationRationale": null,
+        "qdmCategory": "diagnostic_study",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "relevantPeriod": {
+          "low": "2012-03-22T08:00:00.000+00:00",
+          "high": "2012-03-22T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "result": null,
+        "resultDatetime": null,
+        "status": null,
+        "_type": "QDM::DiagnosticStudyPerformed"
+      },
+      {
+        "_id": "5c88013fd7c8ac4c3e1066c2",
+        "birthDatetime": "1970-01-01T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "code": "21112-8",
+            "codeSystem": "LOINC",
+            "descriptor": null,
+            "codeSystemOid": null,
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.54",
+        "id": {
+          "_id": "5c88013fd7c8ac4c3e1066ce",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013fd7c8ac4c3e1066c2"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "birthdate",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicBirthdate"
+      },
+      {
+        "_id": "5c88013fd7c8ac4c3e1066c3",
+        "dataElementCodes": [
+          {
+            "code": "2186-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "Not Hispanic or Latino",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.56",
+        "id": {
+          "_id": "5c88013fd7c8ac4c3e1066cf",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013fd7c8ac4c3e1066c3"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "ethnicity",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicEthnicity"
+      },
+      {
+        "_id": "5c88013fd7c8ac4c3e1066c4",
+        "dataElementCodes": [
+          {
+            "code": "1002-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "American Indian or Alaska Native",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.59",
+        "id": {
+          "_id": "5c88013fd7c8ac4c3e1066d0",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013fd7c8ac4c3e1066c4"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "race",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicRace"
+      },
+      {
+        "_id": "5c88013fd7c8ac4c3e1066c5",
+        "dataElementCodes": [
+          {
+            "code": "M",
+            "codeSystem": "AdministrativeGender",
+            "descriptor": "M",
+            "codeSystemOid": "2.16.840.1.113883.5.1",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.55",
+        "id": {
+          "_id": "5c88013fd7c8ac4c3e1066d1",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013fd7c8ac4c3e1066c5"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "gender",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicSex"
+      }
+    ],
+    "extendedData": {
+      "type": null,
+      "measure_ids": [
+        "189C1035-C86E-419B-A034-AE55FA4C04F9",
+        null
+      ],
+      "source_data_criteria": [
+        {
+          "negation": false,
+          "definition": "diagnostic_study",
+          "status": "performed",
+          "title": "Newborn Hearing Screen Right",
+          "description": "Diagnostic Study, Performed: Newborn Hearing Screen Right",
+          "code_list_id": "2.16.840.1.114222.4.1.214079.1.1.4",
+          "type": "diagnostic_studies",
+          "id": "NewbornHearingScreenRight_DiagnosticStudyPerformed_4d13fe89_db63_4397_9080_4168c8c8d26c_source",
+          "start_date": 1332403200000,
+          "end_date": 1332404100000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "189C1035-C86E-419B-A034-AE55FA4C04F9",
+          "cms_id": "CMS722v0",
+          "criteria_id": "1624e31e6618u",
+          "codes": {
+            "LOINC": [
+              "54109-4"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5aeb77f2b848463d625b6dc0"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "encounter",
+          "status": "performed",
+          "title": "Encounter Inpatient",
+          "description": "Encounter, Performed: Encounter Inpatient",
+          "code_list_id": "2.16.840.1.113883.3.666.5.307",
+          "type": "encounters",
+          "id": "EncounterInpatient_EncounterPerformed_7b37876d_70f3_4879_a168_6dd822107f1c_source",
+          "start_date": 1332403200000,
+          "end_date": 1332404100000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "189C1035-C86E-419B-A034-AE55FA4C04F9",
+          "cms_id": "CMS722v0",
+          "criteria_id": "1624e3236f27z",
+          "codes": {
+            "SNOMED-CT": [
+              "183452005"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5aeb77f2b848463d625b6dbf"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "diagnosis",
+          "title": "Live Birth Newborn Born in Hospital",
+          "description": "Diagnosis: Live Birth Newborn Born in Hospital",
+          "code_list_id": "2.16.840.1.113762.1.4.1046.6",
+          "type": "conditions",
+          "id": "LiveBirthNewbornBorninHospital_Diagnosis_d7f4c89d_3a0d_4426_80d8_ca1a5b92df24_source",
+          "start_date": 1332403200000,
+          "end_date": 1332404100000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "189C1035-C86E-419B-A034-AE55FA4C04F9",
+          "cms_id": "CMS722v0",
+          "criteria_id": "1624e32724a3o",
+          "codes": {
+            "SNOMED-CT": [
+              "17561000119102"
+            ],
+            "ICD-10-CM": [
+              "Z38.00"
+            ]
+          },
+          "coded_entry_id": {
+            "$oid": "5aeb77f2b848463d625b6dbe"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "id": "MeasurePeriod",
+          "start_date": 0,
+          "end_date": 0,
+          "references": null
+        }
+      ],
+      "is_shared": null,
+      "origin_data": [
+
+      ],
+      "test_id": null,
+      "medical_record_number": "5ebc5fc9b1b269147bfb156f278ec48504ee98f9949659eadf256f9c955c9bdf",
+      "medical_record_assigner": "Bonnie",
+      "description": null,
+      "description_category": null,
+      "insurance_providers": "[]"
+    },
+    "qdmVersion": "5.4"
+  }
+}

--- a/spec/javascripts/fixtures/json/patients/CMS759v1/Numer_PASS.json
+++ b/spec/javascripts/fixtures/json/patients/CMS759v1/Numer_PASS.json
@@ -1,0 +1,280 @@
+{
+  "_id": "5aa98404b8484606bc493901",
+  "bundleId": "5a57e977942c6d1e61d32f14",
+  "expectedValues": [
+    {
+      "measure_id": "36C5FDB4-EC16-4B75-96B4-CCBC9C7B0473",
+      "population_index": 0,
+      "IPP": 1,
+      "DENOM": 1,
+      "NUMER": 1
+    }
+  ],
+  "familyName": "PASS",
+  "givenNames": [
+    "Numer"
+  ],
+  "notes": "",
+  "qdmPatient": {
+    "_id": "5c88013fd7c8ac4c3e1066b9",
+    "birthDatetime": "1990-01-01T08:00:00.000+00:00",
+    "dataElements": [
+      {
+        "_id": "5c88013fd7c8ac4c3e1066ba",
+        "dataElementCodes": [
+          {
+            "codeSystem": "Source of Payment Typology",
+            "code": "121"
+          }
+        ],
+        "description": "Patient Characteristic Payer: Medicare Fee For Service",
+        "hqmfOid": "2.16.840.1.113883.3.560.1.405",
+        "id": {
+          "_id": "5c88013fd7c8ac4c3e1066bb",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5aeb7736b848463d625b2155"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "payer",
+        "qdmVersion": "5.4",
+        "relevantPeriod": {
+          "low": "2012-03-14T08:00:00.000+00:00",
+          "high": "2012-03-14T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "_type": "QDM::PatientCharacteristicPayer"
+      },
+      {
+        "_id": "5c88013fd7c8ac4c3e1066bc",
+        "admissionSource": null,
+        "authorDatetime": "2012-03-14T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "10378005"
+          }
+        ],
+        "description": "Encounter, Performed: Inpatient Encounter",
+        "diagnoses": [
+
+        ],
+        "dischargeDisposition": null,
+        "facilityLocations": [
+
+        ],
+        "hqmfOid": "2.16.840.1.113883.3.560.1.79",
+        "id": {
+          "_id": "5c88013fd7c8ac4c3e1066bd",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5aeb7736b848463d625b2156"
+        },
+        "lengthOfStay": {
+          "value": 0,
+          "unit": "days"
+        },
+        "negationRationale": null,
+        "principalDiagnosis": null,
+        "qdmCategory": "encounter",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "relevantPeriod": {
+          "low": "2012-03-14T08:00:00.000+00:00",
+          "high": "2012-03-14T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "_type": "QDM::EncounterPerformed"
+      },
+      {
+        "_id": "5c88013fd7c8ac4c3e1066b4",
+        "birthDatetime": "1990-01-01T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "code": "21112-8",
+            "codeSystem": "LOINC",
+            "descriptor": null,
+            "codeSystemOid": null,
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.54",
+        "id": {
+          "_id": "5c88013fd7c8ac4c3e1066be",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013fd7c8ac4c3e1066b4"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "birthdate",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicBirthdate"
+      },
+      {
+        "_id": "5c88013fd7c8ac4c3e1066b5",
+        "dataElementCodes": [
+          {
+            "code": "2186-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "Not Hispanic or Latino",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.56",
+        "id": {
+          "_id": "5c88013fd7c8ac4c3e1066bf",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013fd7c8ac4c3e1066b5"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "ethnicity",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicEthnicity"
+      },
+      {
+        "_id": "5c88013fd7c8ac4c3e1066b6",
+        "dataElementCodes": [
+          {
+            "code": "1002-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "American Indian or Alaska Native",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.59",
+        "id": {
+          "_id": "5c88013fd7c8ac4c3e1066c0",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013fd7c8ac4c3e1066b6"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "race",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicRace"
+      },
+      {
+        "_id": "5c88013fd7c8ac4c3e1066b7",
+        "dataElementCodes": [
+          {
+            "code": "M",
+            "codeSystem": "AdministrativeGender",
+            "descriptor": "M",
+            "codeSystemOid": "2.16.840.1.113883.5.1",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.55",
+        "id": {
+          "_id": "5c88013fd7c8ac4c3e1066c1",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013fd7c8ac4c3e1066b7"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "gender",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicSex"
+      }
+    ],
+    "extendedData": {
+      "type": null,
+      "measure_ids": [
+        "36C5FDB4-EC16-4B75-96B4-CCBC9C7B0473",
+        null
+      ],
+      "source_data_criteria": [
+        {
+          "negation": false,
+          "definition": "patient_characteristic_payer",
+          "title": "MedicareFeeForService",
+          "description": "Patient Characteristic Payer: Medicare Fee For Service",
+          "code_list_id": "2.16.840.1.113883.3.1240.15.2.4008",
+          "type": "characteristic",
+          "id": "MedicareFeeForService_PatientCharacteristicPayer_fd63ab29_79e4_44c1_80df_e02bd05a5667_source",
+          "start_date": 1331712000000,
+          "end_date": 1331712900000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "36C5FDB4-EC16-4B75-96B4-CCBC9C7B0473",
+          "cms_id": "CMSv0",
+          "criteria_id": "162262ac4f6Rz",
+          "codes": {
+            "Source of Payment Typology": [
+              "121"
+            ]
+          },
+          "coded_entry_id": {
+            "$oid": "5aeb7736b848463d625b2155"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "encounter",
+          "status": "performed",
+          "title": "InpatientEncounter",
+          "description": "Encounter, Performed: Inpatient Encounter",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.101.12.1060",
+          "type": "encounters",
+          "id": "InpatientEncounter_EncounterPerformed_a6c66e3c_da7d_4104_836a_c6c427fecb16_source",
+          "start_date": 1331712000000,
+          "end_date": 1331712900000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "36C5FDB4-EC16-4B75-96B4-CCBC9C7B0473",
+          "cms_id": "CMSv0",
+          "criteria_id": "162262ad454gq",
+          "codes": {
+            "SNOMED-CT": [
+              "10378005"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5aeb7736b848463d625b2156"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "id": "MeasurePeriod",
+          "start_date": 0,
+          "end_date": 0,
+          "references": null
+        }
+      ],
+      "is_shared": null,
+      "origin_data": [
+
+      ],
+      "test_id": null,
+      "medical_record_number": "c5ae9f803996dfda65278dfe2a79d91ee397bf3e2e09dccf9c2b3a82b2f0a36f",
+      "medical_record_assigner": "Bonnie",
+      "description": null,
+      "description_category": null,
+      "insurance_providers": "[]"
+    },
+    "qdmVersion": "5.4"
+  }
+}

--- a/spec/javascripts/fixtures/json/patients/CMS760v0/Correct_Timezone.json
+++ b/spec/javascripts/fixtures/json/patients/CMS760v0/Correct_Timezone.json
@@ -1,0 +1,151 @@
+{
+  "_id": "5abe84fcb8484660706240db",
+  "bundleId": "5a57e977942c6d1e61d32f14",
+  "expectedValues": [
+    {
+      "measure_id": "065C9002-603F-46A3-BA0F-E2A9F1732DC3",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "NUMER": 0
+    }
+  ],
+  "familyName": "Timezone",
+  "givenNames": [
+    "Correct"
+  ],
+  "notes": "",
+  "qdmPatient": {
+    "_id": "5c880140d7c8ac4c3e1066e7",
+    "birthDatetime": "2012-12-31T04:00:00.000+00:00",
+    "dataElements": [
+      {
+        "_id": "5c880140d7c8ac4c3e1066e2",
+        "birthDatetime": "2012-12-31T04:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "code": "21112-8",
+            "codeSystem": "LOINC",
+            "descriptor": null,
+            "codeSystemOid": null,
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.54",
+        "id": {
+          "_id": "5c880140d7c8ac4c3e1066e8",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880140d7c8ac4c3e1066e2"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "birthdate",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicBirthdate"
+      },
+      {
+        "_id": "5c880140d7c8ac4c3e1066e3",
+        "dataElementCodes": [
+          {
+            "code": "2186-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "Not Hispanic or Latino",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.56",
+        "id": {
+          "_id": "5c880140d7c8ac4c3e1066e9",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880140d7c8ac4c3e1066e3"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "ethnicity",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicEthnicity"
+      },
+      {
+        "_id": "5c880140d7c8ac4c3e1066e4",
+        "dataElementCodes": [
+          {
+            "code": "1002-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "American Indian or Alaska Native",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.59",
+        "id": {
+          "_id": "5c880140d7c8ac4c3e1066ea",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880140d7c8ac4c3e1066e4"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "race",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicRace"
+      },
+      {
+        "_id": "5c880140d7c8ac4c3e1066e5",
+        "dataElementCodes": [
+          {
+            "code": "M",
+            "codeSystem": "AdministrativeGender",
+            "descriptor": "M",
+            "codeSystemOid": "2.16.840.1.113883.5.1",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.55",
+        "id": {
+          "_id": "5c880140d7c8ac4c3e1066eb",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880140d7c8ac4c3e1066e5"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "gender",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicSex"
+      }
+    ],
+    "extendedData": {
+      "type": null,
+      "measure_ids": [
+        "065C9002-603F-46A3-BA0F-E2A9F1732DC3",
+        null
+      ],
+      "source_data_criteria": [
+        {
+          "id": "MeasurePeriod",
+          "start_date": 0,
+          "end_date": 0,
+          "references": null
+        }
+      ],
+      "is_shared": null,
+      "origin_data": [
+
+      ],
+      "test_id": null,
+      "medical_record_number": "04171102a010e3607b1e639d7648062de6fddbf3d7f7291288b13c587b191c6c",
+      "medical_record_assigner": "Bonnie",
+      "description": null,
+      "description_category": null,
+      "insurance_providers": "[]"
+    },
+    "qdmVersion": "5.4"
+  }
+}

--- a/spec/javascripts/fixtures/json/patients/CMS761v0/No_Participation.json
+++ b/spec/javascripts/fixtures/json/patients/CMS761v0/No_Participation.json
@@ -1,0 +1,224 @@
+{
+  "_id": "5ad08c06b8484651bb40d494",
+  "bundleId": "5a57e977942c6d1e61d32f14",
+  "expectedValues": [
+    {
+      "measure_id": "8C942F13-6EAA-4A8E-BB4F-3B3BF7311C1F",
+      "population_index": 0,
+      "IPP": 1,
+      "DENOM": 1,
+      "NUMER": 0
+    }
+  ],
+  "familyName": "Participation",
+  "givenNames": [
+    "No"
+  ],
+  "notes": "",
+  "qdmPatient": {
+    "_id": "5c880141d7c8ac4c3e106705",
+    "birthDatetime": "1970-01-01T08:00:00.000+00:00",
+    "dataElements": [
+      {
+        "_id": "5c880141d7c8ac4c3e106706",
+        "admissionSource": null,
+        "authorDatetime": "2012-04-13T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "10378005"
+          }
+        ],
+        "description": "Encounter, Performed: Inpatient Encounter",
+        "diagnoses": [
+
+        ],
+        "dischargeDisposition": null,
+        "facilityLocations": [
+
+        ],
+        "hqmfOid": "2.16.840.1.113883.3.560.1.79",
+        "id": {
+          "_id": "5c880141d7c8ac4c3e106707",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5aec6eb6b848463f1229da32"
+        },
+        "lengthOfStay": {
+          "value": 0,
+          "unit": "days"
+        },
+        "negationRationale": null,
+        "principalDiagnosis": null,
+        "qdmCategory": "encounter",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "relevantPeriod": {
+          "low": "2012-04-13T08:00:00.000+00:00",
+          "high": "2012-04-13T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "_type": "QDM::EncounterPerformed"
+      },
+      {
+        "_id": "5c880141d7c8ac4c3e106700",
+        "birthDatetime": "1970-01-01T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "code": "21112-8",
+            "codeSystem": "LOINC",
+            "descriptor": null,
+            "codeSystemOid": null,
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.54",
+        "id": {
+          "_id": "5c880141d7c8ac4c3e106708",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880141d7c8ac4c3e106700"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "birthdate",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicBirthdate"
+      },
+      {
+        "_id": "5c880141d7c8ac4c3e106701",
+        "dataElementCodes": [
+          {
+            "code": "2186-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "Not Hispanic or Latino",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.56",
+        "id": {
+          "_id": "5c880141d7c8ac4c3e106709",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880141d7c8ac4c3e106701"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "ethnicity",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicEthnicity"
+      },
+      {
+        "_id": "5c880141d7c8ac4c3e106702",
+        "dataElementCodes": [
+          {
+            "code": "1002-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "American Indian or Alaska Native",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.59",
+        "id": {
+          "_id": "5c880141d7c8ac4c3e10670a",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880141d7c8ac4c3e106702"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "race",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicRace"
+      },
+      {
+        "_id": "5c880141d7c8ac4c3e106703",
+        "dataElementCodes": [
+          {
+            "code": "F",
+            "codeSystem": "AdministrativeGender",
+            "descriptor": "F",
+            "codeSystemOid": "2.16.840.1.113883.5.1",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.55",
+        "id": {
+          "_id": "5c880141d7c8ac4c3e10670b",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880141d7c8ac4c3e106703"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "gender",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicSex"
+      }
+    ],
+    "extendedData": {
+      "type": null,
+      "measure_ids": [
+        "8C942F13-6EAA-4A8E-BB4F-3B3BF7311C1F",
+        null
+      ],
+      "source_data_criteria": [
+        {
+          "negation": false,
+          "definition": "encounter",
+          "status": "performed",
+          "title": "InpatientEncounter",
+          "description": "Encounter, Performed: Inpatient Encounter",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.101.12.1060",
+          "type": "encounters",
+          "id": "InpatientEncounter_EncounterPerformed_a6c66e3c_da7d_4104_836a_c6c427fecb16_source",
+          "start_date": 1334304000000,
+          "end_date": 1334304900000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "8C942F13-6EAA-4A8E-BB4F-3B3BF7311C1F",
+          "cms_id": "CMS761v0",
+          "criteria_id": "162bea28d6fHa",
+          "codes": {
+            "SNOMED-CT": [
+              "10378005"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5aec6eb6b848463f1229da32"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "id": "MeasurePeriod",
+          "start_date": 0,
+          "end_date": 0,
+          "references": null
+        }
+      ],
+      "is_shared": null,
+      "origin_data": [
+
+      ],
+      "test_id": null,
+      "medical_record_number": "c693ab2e8cecaee09a5bd9076bd465210afbb38187fe2abcdb40fcc2d0263d56",
+      "medical_record_assigner": "Bonnie",
+      "description": null,
+      "description_category": null,
+      "insurance_providers": "[{\"codes\":{\"SOP\":[\"349\"]},\"description\":null,\"end_time\":null,\"financial_responsibility_type\":{\"code\":\"SELF\",\"codeSystem\":\"HL7 Relationship Code\"},\"health_record_field\":null,\"member_id\":\"1234567890\",\"mood_code\":\"EVN\",\"name\":\"Other\",\"negationInd\":null,\"negationReason\":null,\"oid\":null,\"payer\":{\"name\":\"Other\"},\"reason\":null,\"relationship\":null,\"specifics\":null,\"start_time\":1199145600,\"status_code\":null,\"time\":null,\"type\":\"OT\"}]"
+    },
+    "qdmVersion": "5.4"
+  }
+}

--- a/spec/javascripts/fixtures/json/patients/CMS761v0/With_Participation.json
+++ b/spec/javascripts/fixtures/json/patients/CMS761v0/With_Participation.json
@@ -1,0 +1,279 @@
+{
+  "_id": "5aec6e07b848463f1229da20",
+  "bundleId": "5a57e977942c6d1e61d32f14",
+  "expectedValues": [
+    {
+      "measure_id": "8C942F13-6EAA-4A8E-BB4F-3B3BF7311C1F",
+      "population_index": 0,
+      "IPP": 1,
+      "DENOM": 1,
+      "NUMER": 1
+    }
+  ],
+  "familyName": "Participation",
+  "givenNames": [
+    "With"
+  ],
+  "notes": "",
+  "qdmPatient": {
+    "_id": "5c880141d7c8ac4c3e106711",
+    "birthDatetime": "1970-01-01T08:00:00.000+00:00",
+    "dataElements": [
+      {
+        "_id": "5c880141d7c8ac4c3e106712",
+        "admissionSource": null,
+        "authorDatetime": "2012-04-13T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "10378005"
+          }
+        ],
+        "description": "Encounter, Performed: Inpatient Encounter",
+        "diagnoses": [
+
+        ],
+        "dischargeDisposition": null,
+        "facilityLocations": [
+
+        ],
+        "hqmfOid": "2.16.840.1.113883.3.560.1.79",
+        "id": {
+          "_id": "5c880141d7c8ac4c3e106713",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5aec6eafb848463f1229da2a"
+        },
+        "lengthOfStay": {
+          "value": 0,
+          "unit": "days"
+        },
+        "negationRationale": null,
+        "principalDiagnosis": null,
+        "qdmCategory": "encounter",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "relevantPeriod": {
+          "low": "2012-04-13T08:00:00.000+00:00",
+          "high": "2012-04-13T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "_type": "QDM::EncounterPerformed"
+      },
+      {
+        "_id": "5c880141d7c8ac4c3e106714",
+        "dataElementCodes": [
+          {
+            "codeSystem": "Source of Payment Typology",
+            "code": "3"
+          }
+        ],
+        "description": "Participation: Insurance Coverage Type",
+        "hqmfOid": null,
+        "id": {
+          "_id": "5c880141d7c8ac4c3e106715",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5aec6eafb848463f1229da2b"
+        },
+        "participationPeriod": {
+          "low": "2012-05-04T08:00:00.000+00:00",
+          "high": "2012-05-04T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "qdmCategory": "participation",
+        "qdmVersion": "5.4",
+        "_type": "QDM::Participation"
+      },
+      {
+        "_id": "5c880141d7c8ac4c3e10670c",
+        "birthDatetime": "1970-01-01T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "code": "21112-8",
+            "codeSystem": "LOINC",
+            "descriptor": null,
+            "codeSystemOid": null,
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.54",
+        "id": {
+          "_id": "5c880141d7c8ac4c3e106716",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880141d7c8ac4c3e10670c"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "birthdate",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicBirthdate"
+      },
+      {
+        "_id": "5c880141d7c8ac4c3e10670d",
+        "dataElementCodes": [
+          {
+            "code": "2186-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "Not Hispanic or Latino",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.56",
+        "id": {
+          "_id": "5c880141d7c8ac4c3e106717",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880141d7c8ac4c3e10670d"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "ethnicity",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicEthnicity"
+      },
+      {
+        "_id": "5c880141d7c8ac4c3e10670e",
+        "dataElementCodes": [
+          {
+            "code": "1002-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "American Indian or Alaska Native",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.59",
+        "id": {
+          "_id": "5c880141d7c8ac4c3e106718",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880141d7c8ac4c3e10670e"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "race",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicRace"
+      },
+      {
+        "_id": "5c880141d7c8ac4c3e10670f",
+        "dataElementCodes": [
+          {
+            "code": "F",
+            "codeSystem": "AdministrativeGender",
+            "descriptor": "F",
+            "codeSystemOid": "2.16.840.1.113883.5.1",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.55",
+        "id": {
+          "_id": "5c880141d7c8ac4c3e106719",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880141d7c8ac4c3e10670f"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "gender",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicSex"
+      }
+    ],
+    "extendedData": {
+      "type": null,
+      "measure_ids": [
+        "8C942F13-6EAA-4A8E-BB4F-3B3BF7311C1F",
+        null
+      ],
+      "source_data_criteria": [
+        {
+          "negation": false,
+          "definition": "encounter",
+          "status": "performed",
+          "title": "InpatientEncounter",
+          "description": "Encounter, Performed: Inpatient Encounter",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.101.12.1060",
+          "type": "encounters",
+          "id": "InpatientEncounter_EncounterPerformed_a6c66e3c_da7d_4104_836a_c6c427fecb16_source",
+          "start_date": 1334304000000,
+          "end_date": 1334304900000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "8C942F13-6EAA-4A8E-BB4F-3B3BF7311C1F",
+          "cms_id": "CMS761v0",
+          "criteria_id": "162bea28d6fHa",
+          "codes": {
+            "SNOMED-CT": [
+              "10378005"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5aec6eafb848463f1229da2a"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "participation",
+          "title": "InsuranceCoverageTypeFPAR",
+          "description": "Participation: Insurance Coverage Type",
+          "code_list_id": "2.16.840.1.113762.1.4.1166.29",
+          "type": "participations",
+          "id": "InsuranceCoverageTypeFPAR_Participation_29fbfb89_3cf5_433f_96bd_fb24fb1896f8_source",
+          "start_date": 1336118400000,
+          "end_date": 1336119300000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "8C942F13-6EAA-4A8E-BB4F-3B3BF7311C1F",
+          "cms_id": "CMS761v0",
+          "criteria_id": "1632b8dea99Yg",
+          "codes": {
+            "Source of Payment Typology": [
+              "3"
+            ]
+          },
+          "coded_entry_id": {
+            "$oid": "5aec6eafb848463f1229da2b"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "id": "MeasurePeriod",
+          "start_date": 0,
+          "end_date": 0,
+          "references": null
+        }
+      ],
+      "is_shared": null,
+      "origin_data": [
+
+      ],
+      "test_id": null,
+      "medical_record_number": "22b755900bfa2cd1996b37f5a25fb5e2d08a118c48ededa2b486adffa6fd0a5e",
+      "medical_record_assigner": "Bonnie",
+      "description": null,
+      "description_category": null,
+      "insurance_providers": "[{\"codes\":{\"SOP\":[\"349\"]},\"description\":null,\"end_time\":null,\"financial_responsibility_type\":{\"code\":\"SELF\",\"codeSystem\":\"HL7 Relationship Code\"},\"health_record_field\":null,\"member_id\":\"1234567890\",\"mood_code\":\"EVN\",\"name\":\"Other\",\"negationInd\":null,\"negationReason\":null,\"oid\":null,\"payer\":{\"name\":\"Other\"},\"reason\":null,\"relationship\":null,\"specifics\":null,\"start_time\":1199145600,\"status_code\":null,\"time\":null,\"type\":\"OT\"}]"
+    },
+    "qdmVersion": "5.4"
+  }
+}

--- a/spec/javascripts/fixtures/json/patients/CMS878v0/Test_NoNumerator.json
+++ b/spec/javascripts/fixtures/json/patients/CMS878v0/Test_NoNumerator.json
@@ -1,0 +1,216 @@
+{
+  "_id": "5b61b47fb848461e81031467",
+  "bundleId": "5a57e977942c6d1e61d32f14",
+  "expectedValues": [
+    {
+      "measure_id": "50901F2E-3715-462B-87C1-2AD9B9B1CDE7",
+      "population_index": 0,
+      "IPP": 1,
+      "DENOM": 1,
+      "NUMER": 0
+    }
+  ],
+  "familyName": "NoNumerator",
+  "givenNames": [
+    "Test"
+  ],
+  "notes": "",
+  "qdmPatient": {
+    "_id": "5c880144d7c8ac4c3e10677f",
+    "birthDatetime": "1976-07-04T05:23:00.000+00:00",
+    "dataElements": [
+      {
+        "_id": "5c880144d7c8ac4c3e106780",
+        "authorDatetime": "2012-07-30T08:00:00.000+00:00",
+        "components": [
+
+        ],
+        "dataElementCodes": [
+          {
+            "codeSystem": "LOINC",
+            "code": "72166-2"
+          }
+        ],
+        "description": "Assessment, Performed: Tobacco Use Status",
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.117",
+        "id": {
+          "_id": "5c880144d7c8ac4c3e106781",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5b61b47fb848461e81031468"
+        },
+        "method": null,
+        "negationRationale": null,
+        "qdmCategory": "assessment",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "result": "44367-05-28T08:00:00.000+00:00",
+        "_type": "QDM::AssessmentPerformed"
+      },
+      {
+        "_id": "5c880144d7c8ac4c3e10677a",
+        "birthDatetime": "1976-07-04T05:23:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "code": "21112-8",
+            "codeSystem": "LOINC",
+            "descriptor": null,
+            "codeSystemOid": null,
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.54",
+        "id": {
+          "_id": "5c880144d7c8ac4c3e106782",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880144d7c8ac4c3e10677a"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "birthdate",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicBirthdate"
+      },
+      {
+        "_id": "5c880144d7c8ac4c3e10677b",
+        "dataElementCodes": [
+          {
+            "code": "2186-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "Not Hispanic or Latino",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.56",
+        "id": {
+          "_id": "5c880144d7c8ac4c3e106783",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880144d7c8ac4c3e10677b"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "ethnicity",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicEthnicity"
+      },
+      {
+        "_id": "5c880144d7c8ac4c3e10677c",
+        "dataElementCodes": [
+          {
+            "code": "2106-3",
+            "codeSystem": "CDC Race",
+            "descriptor": "White",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.59",
+        "id": {
+          "_id": "5c880144d7c8ac4c3e106784",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880144d7c8ac4c3e10677c"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "race",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicRace"
+      },
+      {
+        "_id": "5c880144d7c8ac4c3e10677d",
+        "dataElementCodes": [
+          {
+            "code": "F",
+            "codeSystem": "AdministrativeGender",
+            "descriptor": "F",
+            "codeSystemOid": "2.16.840.1.113883.5.1",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.55",
+        "id": {
+          "_id": "5c880144d7c8ac4c3e106785",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880144d7c8ac4c3e10677d"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "gender",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicSex"
+      }
+    ],
+    "extendedData": {
+      "type": null,
+      "measure_ids": [
+        "50901F2E-3715-462B-87C1-2AD9B9B1CDE7",
+        null
+      ],
+      "source_data_criteria": [
+        {
+          "negation": false,
+          "definition": "assessment",
+          "status": "performed",
+          "title": "TobaccoUseStatus",
+          "description": "Assessment, Performed: Tobacco Use Status",
+          "code_list_id": "2.16.840.1.113762.1.4.1110.27",
+          "type": "assessments",
+          "id": "TobaccoUseStatus_AssessmentPerformed_de11e623_3d10_4076_a28d_4430d015a1f1_source",
+          "start_date": 1343635200000,
+          "value": [
+            {
+              "type": "TS",
+              "type_cmp": "CD",
+              "start_date": "05/25/2012",
+              "start_time": "8:00 AM",
+              "value": 1337932800000
+            }
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "50901F2E-3715-462B-87C1-2AD9B9B1CDE7",
+          "cms_id": "CMS878v0",
+          "criteria_id": "164f5a88e6b64",
+          "codes": {
+            "LOINC": [
+              "72166-2"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5b61b47fb848461e81031468"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "id": "MeasurePeriod",
+          "start_date": 0,
+          "end_date": 0,
+          "references": null
+        }
+      ],
+      "is_shared": null,
+      "origin_data": [
+
+      ],
+      "test_id": null,
+      "medical_record_number": "b2860a5756c502304c581b0f48a4f646995c8dc72f49c7b45c3520b016cfaac3",
+      "medical_record_assigner": "Bonnie",
+      "description": null,
+      "description_category": null,
+      "insurance_providers": "[{\"codes\":{\"SOP\":[\"349\"]},\"description\":null,\"end_time\":null,\"financial_responsibility_type\":{\"code\":\"SELF\",\"codeSystem\":\"HL7 Relationship Code\"},\"health_record_field\":null,\"member_id\":\"1234567890\",\"mood_code\":\"EVN\",\"name\":\"Other\",\"negationInd\":null,\"negationReason\":null,\"oid\":null,\"payer\":{\"name\":\"Other\"},\"reason\":null,\"relationship\":null,\"specifics\":null,\"start_time\":1199145600,\"status_code\":null,\"time\":null,\"type\":\"OT\"}]"
+    },
+    "qdmVersion": "5.4"
+  }
+}

--- a/spec/javascripts/fixtures/json/patients/CMS878v0/Test_Numerator.json
+++ b/spec/javascripts/fixtures/json/patients/CMS878v0/Test_Numerator.json
@@ -1,0 +1,216 @@
+{
+  "_id": "5b61b4d5b84846662484a5b7",
+  "bundleId": "5a57e977942c6d1e61d32f14",
+  "expectedValues": [
+    {
+      "measure_id": "50901F2E-3715-462B-87C1-2AD9B9B1CDE7",
+      "population_index": 0,
+      "IPP": 1,
+      "DENOM": 1,
+      "NUMER": 1
+    }
+  ],
+  "familyName": "Numerator",
+  "givenNames": [
+    "Test"
+  ],
+  "notes": "",
+  "qdmPatient": {
+    "_id": "5c880144d7c8ac4c3e10678b",
+    "birthDatetime": "1987-03-04T12:55:00.000+00:00",
+    "dataElements": [
+      {
+        "_id": "5c880144d7c8ac4c3e10678c",
+        "authorDatetime": "2012-07-30T08:00:00.000+00:00",
+        "components": [
+
+        ],
+        "dataElementCodes": [
+          {
+            "codeSystem": "LOINC",
+            "code": "72166-2"
+          }
+        ],
+        "description": "Assessment, Performed: Tobacco Use Status",
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.117",
+        "id": {
+          "_id": "5c880144d7c8ac4c3e10678d",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5b61b4d5b84846662484a5b8"
+        },
+        "method": null,
+        "negationRationale": null,
+        "qdmCategory": "assessment",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "result": "44468-09-14T08:00:00.000+00:00",
+        "_type": "QDM::AssessmentPerformed"
+      },
+      {
+        "_id": "5c880144d7c8ac4c3e106786",
+        "birthDatetime": "1987-03-04T12:55:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "code": "21112-8",
+            "codeSystem": "LOINC",
+            "descriptor": null,
+            "codeSystemOid": null,
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.54",
+        "id": {
+          "_id": "5c880144d7c8ac4c3e10678e",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880144d7c8ac4c3e106786"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "birthdate",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicBirthdate"
+      },
+      {
+        "_id": "5c880144d7c8ac4c3e106787",
+        "dataElementCodes": [
+          {
+            "code": "2186-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "Not Hispanic or Latino",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.56",
+        "id": {
+          "_id": "5c880144d7c8ac4c3e10678f",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880144d7c8ac4c3e106787"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "ethnicity",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicEthnicity"
+      },
+      {
+        "_id": "5c880144d7c8ac4c3e106788",
+        "dataElementCodes": [
+          {
+            "code": "2054-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "Black or African American",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.59",
+        "id": {
+          "_id": "5c880144d7c8ac4c3e106790",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880144d7c8ac4c3e106788"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "race",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicRace"
+      },
+      {
+        "_id": "5c880144d7c8ac4c3e106789",
+        "dataElementCodes": [
+          {
+            "code": "M",
+            "codeSystem": "AdministrativeGender",
+            "descriptor": "M",
+            "codeSystemOid": "2.16.840.1.113883.5.1",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.55",
+        "id": {
+          "_id": "5c880144d7c8ac4c3e106791",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880144d7c8ac4c3e106789"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "gender",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicSex"
+      }
+    ],
+    "extendedData": {
+      "type": null,
+      "measure_ids": [
+        "50901F2E-3715-462B-87C1-2AD9B9B1CDE7",
+        null
+      ],
+      "source_data_criteria": [
+        {
+          "negation": false,
+          "definition": "assessment",
+          "status": "performed",
+          "title": "TobaccoUseStatus",
+          "description": "Assessment, Performed: Tobacco Use Status",
+          "code_list_id": "2.16.840.1.113762.1.4.1110.27",
+          "type": "assessments",
+          "id": "TobaccoUseStatus_AssessmentPerformed_de11e623_3d10_4076_a28d_4430d015a1f1_source",
+          "start_date": 1343635200000,
+          "value": [
+            {
+              "type": "TS",
+              "type_cmp": "CD",
+              "start_date": "07/01/2012",
+              "start_time": "8:00 AM",
+              "value": 1341129600000
+            }
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "50901F2E-3715-462B-87C1-2AD9B9B1CDE7",
+          "cms_id": "CMS878v0",
+          "criteria_id": "164f5a88e6b64",
+          "codes": {
+            "LOINC": [
+              "72166-2"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5b61b4d5b84846662484a5b8"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "id": "MeasurePeriod",
+          "start_date": 0,
+          "end_date": 0,
+          "references": null
+        }
+      ],
+      "is_shared": null,
+      "origin_data": [
+
+      ],
+      "test_id": null,
+      "medical_record_number": "812ef3ac9a6a82749eb010e6750878d88de799903b269b1e87e7c44226c04238",
+      "medical_record_assigner": "Bonnie",
+      "description": null,
+      "description_category": null,
+      "insurance_providers": "[{\"codes\":{\"SOP\":[\"349\"]},\"description\":null,\"end_time\":null,\"financial_responsibility_type\":{\"code\":\"SELF\",\"codeSystem\":\"HL7 Relationship Code\"},\"health_record_field\":null,\"member_id\":\"1234567890\",\"mood_code\":\"EVN\",\"name\":\"Other\",\"negationInd\":null,\"negationReason\":null,\"oid\":null,\"payer\":{\"name\":\"Other\"},\"reason\":null,\"relationship\":null,\"specifics\":null,\"start_time\":1199145600,\"status_code\":null,\"time\":null,\"type\":\"OT\"}]"
+    },
+    "qdmVersion": "5.4"
+  }
+}

--- a/spec/javascripts/fixtures/json/patients/CMS879v0/Test_NoNumerator.json
+++ b/spec/javascripts/fixtures/json/patients/CMS879v0/Test_NoNumerator.json
@@ -1,0 +1,388 @@
+{
+  "_id": "5b61b638b84846662484a6c1",
+  "bundleId": "5a57e977942c6d1e61d32f14",
+  "expectedValues": [
+    {
+      "measure_id": "D5355200-50C1-4A79-8983-8617B93FE6C1",
+      "population_index": 0,
+      "IPP": 1,
+      "DENOM": 1,
+      "NUMER": 0
+    }
+  ],
+  "familyName": "NoNumerator",
+  "givenNames": [
+    "Test"
+  ],
+  "notes": "",
+  "qdmPatient": {
+    "_id": "5c880143d7c8ac4c3e10675f",
+    "birthDatetime": "1940-01-01T08:00:00.000+00:00",
+    "dataElements": [
+      {
+        "_id": "5c880143d7c8ac4c3e106760",
+        "authorDatetime": "2012-07-31T08:00:00.000+00:00",
+        "components": [
+
+        ],
+        "dataElementCodes": [
+          {
+            "codeSystem": "LOINC",
+            "code": "24320-4"
+          }
+        ],
+        "description": "Assessment, Performed: Laboratory Tests for Hypertension",
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.117",
+        "id": {
+          "_id": "5c880143d7c8ac4c3e106761",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5b61b638b84846662484a6c2"
+        },
+        "method": null,
+        "negationRationale": null,
+        "qdmCategory": "assessment",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "result": "44307-03-04T08:00:00.000+00:00",
+        "_type": "QDM::AssessmentPerformed"
+      },
+      {
+        "_id": "5c880143d7c8ac4c3e106762",
+        "authorDatetime": "2012-07-31T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "RxNorm",
+            "code": "200031"
+          }
+        ],
+        "daysSupplied": null,
+        "description": "Medication, Ordered: Beta Blocker Therapy for LVSD",
+        "dosage": null,
+        "frequency": null,
+        "hqmfOid": "2.16.840.1.113883.3.560.1.78",
+        "id": {
+          "_id": "5c880143d7c8ac4c3e106763",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5b61b638b84846662484a6c3"
+        },
+        "negationRationale": {
+          "code": "105480006",
+          "codeSystem": "SNOMED-CT",
+          "descriptor": null,
+          "codeSystemOid": null,
+          "version": null
+        },
+        "prescriberId": null,
+        "qdmCategory": "medication",
+        "qdmStatus": "order",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "refills": null,
+        "relevantPeriod": {
+          "low": "2012-07-31T08:00:00.000+00:00",
+          "high": "9999-12-31T23:59:59.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "route": null,
+        "setting": null,
+        "supply": null,
+        "_type": "QDM::MedicationOrder"
+      },
+      {
+        "_id": "5c880143d7c8ac4c3e106764",
+        "authorDatetime": "2012-07-31T08:00:00.000+00:00",
+        "components": [
+          {
+            "result": "43510-06-10T08:00:00+00:00",
+            "code": {
+              "code": "200031",
+              "codeSystem": "RxNorm",
+              "version": null,
+              "descriptor": null
+            }
+          }
+        ],
+        "dataElementCodes": [
+          {
+            "codeSystem": "LOINC",
+            "code": "24320-4"
+          }
+        ],
+        "description": "Laboratory Test, Performed: Laboratory Tests for Hypertension",
+        "hqmfOid": "2.16.840.1.113883.3.560.1.5",
+        "id": {
+          "_id": "5c880143d7c8ac4c3e106765",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5b61b638b84846662484a6c4"
+        },
+        "method": null,
+        "negationRationale": null,
+        "qdmCategory": "laboratory_test",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "referenceRange": null,
+        "relevantPeriod": {
+          "low": "2012-07-31T08:00:00.000+00:00",
+          "high": "2012-07-31T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "result": null,
+        "resultDatetime": null,
+        "status": null,
+        "_type": "QDM::LaboratoryTestPerformed"
+      },
+      {
+        "_id": "5c880143d7c8ac4c3e10675a",
+        "birthDatetime": "1940-01-01T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "code": "21112-8",
+            "codeSystem": "LOINC",
+            "descriptor": null,
+            "codeSystemOid": null,
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.54",
+        "id": {
+          "_id": "5c880143d7c8ac4c3e106766",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880143d7c8ac4c3e10675a"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "birthdate",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicBirthdate"
+      },
+      {
+        "_id": "5c880143d7c8ac4c3e10675b",
+        "dataElementCodes": [
+          {
+            "code": "2186-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "Not Hispanic or Latino",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.56",
+        "id": {
+          "_id": "5c880143d7c8ac4c3e106767",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880143d7c8ac4c3e10675b"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "ethnicity",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicEthnicity"
+      },
+      {
+        "_id": "5c880143d7c8ac4c3e10675c",
+        "dataElementCodes": [
+          {
+            "code": "1002-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "American Indian or Alaska Native",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.59",
+        "id": {
+          "_id": "5c880143d7c8ac4c3e106768",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880143d7c8ac4c3e10675c"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "race",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicRace"
+      },
+      {
+        "_id": "5c880143d7c8ac4c3e10675d",
+        "dataElementCodes": [
+          {
+            "code": "M",
+            "codeSystem": "AdministrativeGender",
+            "descriptor": "M",
+            "codeSystemOid": "2.16.840.1.113883.5.1",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.55",
+        "id": {
+          "_id": "5c880143d7c8ac4c3e106769",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880143d7c8ac4c3e10675d"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "gender",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicSex"
+      }
+    ],
+    "extendedData": {
+      "type": null,
+      "measure_ids": [
+        "D5355200-50C1-4A79-8983-8617B93FE6C1",
+        null
+      ],
+      "source_data_criteria": [
+        {
+          "negation": false,
+          "definition": "assessment",
+          "status": "performed",
+          "title": "LaboratoryTestsforHypertension",
+          "description": "Assessment, Performed: Laboratory Tests for Hypertension",
+          "code_list_id": "2.16.840.1.113883.3.600.1482",
+          "type": "assessments",
+          "id": "LaboratoryTestsforHypertension_AssessmentPerformed_7dd701f4_bcdb_4198_8958_6f1a1f79a7bc_source",
+          "start_date": 1343721600000,
+          "value": [
+            {
+              "type": "TS",
+              "type_cmp": "CD",
+              "start_date": "05/03/2012",
+              "start_time": "8:00 AM",
+              "value": 1336032000000
+            }
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "D5355200-50C1-4A79-8983-8617B93FE6C1",
+          "cms_id": "CMS879v0",
+          "criteria_id": "164f5ac39e4yh",
+          "codes": {
+            "LOINC": [
+              "24320-4"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5b61b638b84846662484a6c2"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": true,
+          "definition": "medication",
+          "status": "ordered",
+          "title": "BetaBlockerTherapyforLVSD",
+          "description": "Medication, Ordered: Beta Blocker Therapy for LVSD",
+          "code_list_id": "2.16.840.1.113883.3.526.3.1184",
+          "type": "medications",
+          "id": "Derived from BetaBlockerTherapyforLVSD_MedicationNotOrdered_802b51cf_5bf7_469e_a6ab_61619fae8a1a_source",
+          "start_date": 1343721600000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "D5355200-50C1-4A79-8983-8617B93FE6C1",
+          "cms_id": "CMS879v0",
+          "criteria_id": "164f5ad29adOC",
+          "codes": {
+            "RxNorm": [
+              "200031"
+            ]
+          },
+          "negation_code_list_id": "2.16.840.1.113883.3.600.791",
+          "coded_entry_id": {
+            "$oid": "5b61b638b84846662484a6c3"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "laboratory_test",
+          "status": "performed",
+          "title": "LaboratoryTestsforHypertension",
+          "description": "Laboratory Test, Performed: Laboratory Tests for Hypertension",
+          "code_list_id": "2.16.840.1.113883.3.600.1482",
+          "type": "laboratory_tests",
+          "id": "LaboratoryTestsforHypertension_LaboratoryTestPerformed_7dd701f4_bcdb_4198_8958_6f1a1f79a7bc_source",
+          "start_date": 1343721600000,
+          "end_date": 1343722500000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+            "COMPONENT": {
+              "type": "COL",
+              "values": [
+                {
+                  "type": "CMP",
+                  "type_cmp": "TS",
+                  "key": "COMPONENT",
+                  "code_list_id": "2.16.840.1.113883.3.526.3.1184",
+                  "field_title": "Component",
+                  "code_list_id_cmp": "",
+                  "referenceRangeLow_value": "",
+                  "referenceRangeLow_unit": "",
+                  "referenceRangeHigh_value": "",
+                  "referenceRangeHigh_unit": "",
+                  "title": "Beta Blocker Therapy for LVSD",
+                  "start_date": "07/17/2011",
+                  "start_time": "8:00 AM",
+                  "value": 1310889600000
+                }
+              ]
+            }
+          },
+          "hqmf_set_id": "D5355200-50C1-4A79-8983-8617B93FE6C1",
+          "cms_id": "CMS879v0",
+          "criteria_id": "164f5adab85Ec",
+          "codes": {
+            "LOINC": [
+              "24320-4"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5b61b638b84846662484a6c4"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "id": "MeasurePeriod",
+          "start_date": 0,
+          "end_date": 0,
+          "references": null
+        }
+      ],
+      "is_shared": null,
+      "origin_data": [
+
+      ],
+      "test_id": null,
+      "medical_record_number": "6f7fa9bdd5fc70b547408d8374fe5b66d446e9160acb57bc101f8ce353712056",
+      "medical_record_assigner": "Bonnie",
+      "description": null,
+      "description_category": null,
+      "insurance_providers": "[{\"codes\":{\"SOP\":[\"349\"]},\"description\":null,\"end_time\":null,\"financial_responsibility_type\":{\"code\":\"SELF\",\"codeSystem\":\"HL7 Relationship Code\"},\"health_record_field\":null,\"member_id\":\"1234567890\",\"mood_code\":\"EVN\",\"name\":\"Other\",\"negationInd\":null,\"negationReason\":null,\"oid\":null,\"payer\":{\"name\":\"Other\"},\"reason\":null,\"relationship\":null,\"specifics\":null,\"start_time\":1199145600,\"status_code\":null,\"time\":null,\"type\":\"OT\"}]"
+    },
+    "qdmVersion": "5.4"
+  }
+}

--- a/spec/javascripts/fixtures/json/patients/CMS879v0/Test_Numerator.json
+++ b/spec/javascripts/fixtures/json/patients/CMS879v0/Test_Numerator.json
@@ -1,0 +1,388 @@
+{
+  "_id": "5b61b693b84846662484a6e4",
+  "bundleId": "5a57e977942c6d1e61d32f14",
+  "expectedValues": [
+    {
+      "measure_id": "D5355200-50C1-4A79-8983-8617B93FE6C1",
+      "population_index": 0,
+      "IPP": 1,
+      "DENOM": 1,
+      "NUMER": 1
+    }
+  ],
+  "familyName": "Numerator",
+  "givenNames": [
+    "Test"
+  ],
+  "notes": "",
+  "qdmPatient": {
+    "_id": "5c880143d7c8ac4c3e10676f",
+    "birthDatetime": "1940-01-01T08:00:00.000+00:00",
+    "dataElements": [
+      {
+        "_id": "5c880143d7c8ac4c3e106770",
+        "authorDatetime": "2012-07-31T08:00:00.000+00:00",
+        "components": [
+
+        ],
+        "dataElementCodes": [
+          {
+            "codeSystem": "LOINC",
+            "code": "24320-4"
+          }
+        ],
+        "description": "Assessment, Performed: Laboratory Tests for Hypertension",
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.117",
+        "id": {
+          "_id": "5c880143d7c8ac4c3e106771",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5b61b693b84846662484a6e5"
+        },
+        "method": null,
+        "negationRationale": null,
+        "qdmCategory": "assessment",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "result": "44307-03-04T08:00:00.000+00:00",
+        "_type": "QDM::AssessmentPerformed"
+      },
+      {
+        "_id": "5c880143d7c8ac4c3e106772",
+        "authorDatetime": "2012-07-31T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "RxNorm",
+            "code": "200031"
+          }
+        ],
+        "daysSupplied": null,
+        "description": "Medication, Ordered: Beta Blocker Therapy for LVSD",
+        "dosage": null,
+        "frequency": null,
+        "hqmfOid": "2.16.840.1.113883.3.560.1.78",
+        "id": {
+          "_id": "5c880143d7c8ac4c3e106773",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5b61b693b84846662484a6e6"
+        },
+        "negationRationale": {
+          "code": "105480006",
+          "codeSystem": "SNOMED-CT",
+          "descriptor": null,
+          "codeSystemOid": null,
+          "version": null
+        },
+        "prescriberId": null,
+        "qdmCategory": "medication",
+        "qdmStatus": "order",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "refills": null,
+        "relevantPeriod": {
+          "low": "2012-07-31T08:00:00.000+00:00",
+          "high": "9999-12-31T23:59:59.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "route": null,
+        "setting": null,
+        "supply": null,
+        "_type": "QDM::MedicationOrder"
+      },
+      {
+        "_id": "5c880143d7c8ac4c3e106774",
+        "authorDatetime": "2012-07-31T08:00:00.000+00:00",
+        "components": [
+          {
+            "result": "44512-07-06T08:00:00+00:00",
+            "code": {
+              "code": "200031",
+              "codeSystem": "RxNorm",
+              "version": null,
+              "descriptor": null
+            }
+          }
+        ],
+        "dataElementCodes": [
+          {
+            "codeSystem": "LOINC",
+            "code": "24320-4"
+          }
+        ],
+        "description": "Laboratory Test, Performed: Laboratory Tests for Hypertension",
+        "hqmfOid": "2.16.840.1.113883.3.560.1.5",
+        "id": {
+          "_id": "5c880143d7c8ac4c3e106775",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5b61b693b84846662484a6e7"
+        },
+        "method": null,
+        "negationRationale": null,
+        "qdmCategory": "laboratory_test",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "referenceRange": null,
+        "relevantPeriod": {
+          "low": "2012-07-31T08:00:00.000+00:00",
+          "high": "2012-07-31T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "result": null,
+        "resultDatetime": null,
+        "status": null,
+        "_type": "QDM::LaboratoryTestPerformed"
+      },
+      {
+        "_id": "5c880143d7c8ac4c3e10676a",
+        "birthDatetime": "1940-01-01T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "code": "21112-8",
+            "codeSystem": "LOINC",
+            "descriptor": null,
+            "codeSystemOid": null,
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.54",
+        "id": {
+          "_id": "5c880143d7c8ac4c3e106776",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880143d7c8ac4c3e10676a"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "birthdate",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicBirthdate"
+      },
+      {
+        "_id": "5c880143d7c8ac4c3e10676b",
+        "dataElementCodes": [
+          {
+            "code": "2186-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "Not Hispanic or Latino",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.56",
+        "id": {
+          "_id": "5c880143d7c8ac4c3e106777",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880143d7c8ac4c3e10676b"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "ethnicity",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicEthnicity"
+      },
+      {
+        "_id": "5c880143d7c8ac4c3e10676c",
+        "dataElementCodes": [
+          {
+            "code": "1002-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "American Indian or Alaska Native",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.59",
+        "id": {
+          "_id": "5c880143d7c8ac4c3e106778",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880143d7c8ac4c3e10676c"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "race",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicRace"
+      },
+      {
+        "_id": "5c880143d7c8ac4c3e10676d",
+        "dataElementCodes": [
+          {
+            "code": "M",
+            "codeSystem": "AdministrativeGender",
+            "descriptor": "M",
+            "codeSystemOid": "2.16.840.1.113883.5.1",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.55",
+        "id": {
+          "_id": "5c880143d7c8ac4c3e106779",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880143d7c8ac4c3e10676d"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "gender",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicSex"
+      }
+    ],
+    "extendedData": {
+      "type": null,
+      "measure_ids": [
+        "D5355200-50C1-4A79-8983-8617B93FE6C1",
+        null
+      ],
+      "source_data_criteria": [
+        {
+          "negation": false,
+          "definition": "assessment",
+          "status": "performed",
+          "title": "LaboratoryTestsforHypertension",
+          "description": "Assessment, Performed: Laboratory Tests for Hypertension",
+          "code_list_id": "2.16.840.1.113883.3.600.1482",
+          "type": "assessments",
+          "id": "LaboratoryTestsforHypertension_AssessmentPerformed_7dd701f4_bcdb_4198_8958_6f1a1f79a7bc_source",
+          "start_date": 1343721600000,
+          "value": [
+            {
+              "type": "TS",
+              "type_cmp": "CD",
+              "start_date": "05/03/2012",
+              "start_time": "8:00 AM",
+              "value": 1336032000000
+            }
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "D5355200-50C1-4A79-8983-8617B93FE6C1",
+          "cms_id": "CMS879v0",
+          "criteria_id": "164f5ac39e4yh",
+          "codes": {
+            "LOINC": [
+              "24320-4"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5b61b693b84846662484a6e5"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": true,
+          "definition": "medication",
+          "status": "ordered",
+          "title": "BetaBlockerTherapyforLVSD",
+          "description": "Medication, Ordered: Beta Blocker Therapy for LVSD",
+          "code_list_id": "2.16.840.1.113883.3.526.3.1184",
+          "type": "medications",
+          "id": "Derived from BetaBlockerTherapyforLVSD_MedicationNotOrdered_802b51cf_5bf7_469e_a6ab_61619fae8a1a_source",
+          "start_date": 1343721600000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "D5355200-50C1-4A79-8983-8617B93FE6C1",
+          "cms_id": "CMS879v0",
+          "criteria_id": "164f5ad29adOC",
+          "codes": {
+            "RxNorm": [
+              "200031"
+            ]
+          },
+          "negation_code_list_id": "2.16.840.1.113883.3.600.791",
+          "coded_entry_id": {
+            "$oid": "5b61b693b84846662484a6e6"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "laboratory_test",
+          "status": "performed",
+          "title": "LaboratoryTestsforHypertension",
+          "description": "Laboratory Test, Performed: Laboratory Tests for Hypertension",
+          "code_list_id": "2.16.840.1.113883.3.600.1482",
+          "type": "laboratory_tests",
+          "id": "LaboratoryTestsforHypertension_LaboratoryTestPerformed_7dd701f4_bcdb_4198_8958_6f1a1f79a7bc_source",
+          "start_date": 1343721600000,
+          "end_date": 1343722500000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+            "COMPONENT": {
+              "type": "COL",
+              "values": [
+                {
+                  "type": "CMP",
+                  "type_cmp": "TS",
+                  "key": "COMPONENT",
+                  "code_list_id": "2.16.840.1.113883.3.526.3.1184",
+                  "field_title": "Component",
+                  "code_list_id_cmp": "",
+                  "referenceRangeLow_value": "",
+                  "referenceRangeLow_unit": "",
+                  "referenceRangeHigh_value": "",
+                  "referenceRangeHigh_unit": "",
+                  "title": "Beta Blocker Therapy for LVSD",
+                  "start_date": "07/17/2012",
+                  "start_time": "8:00 AM",
+                  "value": 1342512000000
+                }
+              ]
+            }
+          },
+          "hqmf_set_id": "D5355200-50C1-4A79-8983-8617B93FE6C1",
+          "cms_id": "CMS879v0",
+          "criteria_id": "164f5adab85Ec",
+          "codes": {
+            "LOINC": [
+              "24320-4"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5b61b693b84846662484a6e7"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "id": "MeasurePeriod",
+          "start_date": 0,
+          "end_date": 0,
+          "references": null
+        }
+      ],
+      "is_shared": null,
+      "origin_data": [
+
+      ],
+      "test_id": null,
+      "medical_record_number": "a5b1de56a574b5ad0b76cdfac071de678289832fc7518f1fa5540ebc5e235e15",
+      "medical_record_assigner": "Bonnie",
+      "description": null,
+      "description_category": null,
+      "insurance_providers": "[{\"codes\":{\"SOP\":[\"349\"]},\"description\":null,\"end_time\":null,\"financial_responsibility_type\":{\"code\":\"SELF\",\"codeSystem\":\"HL7 Relationship Code\"},\"health_record_field\":null,\"member_id\":\"1234567890\",\"mood_code\":\"EVN\",\"name\":\"Other\",\"negationInd\":null,\"negationReason\":null,\"oid\":null,\"payer\":{\"name\":\"Other\"},\"reason\":null,\"relationship\":null,\"specifics\":null,\"start_time\":1199145600,\"status_code\":null,\"time\":null,\"type\":\"OT\"}]"
+    },
+    "qdmVersion": "5.4"
+  }
+}

--- a/spec/javascripts/fixtures/json/patients/CMSv9999/Patient_Blank.json
+++ b/spec/javascripts/fixtures/json/patients/CMSv9999/Patient_Blank.json
@@ -1,0 +1,241 @@
+{
+  "_id": "5af5b02db848462db95f11f3",
+  "bundleId": "5a57e977942c6d1e61d32f14",
+  "expectedValues": [
+    {
+      "measure_id": "21C422D4-1658-478D-AEC2-B87B73638C41",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "21C422D4-1658-478D-AEC2-B87B73638C41",
+      "population_index": 1,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "21C422D4-1658-478D-AEC2-B87B73638C41",
+      "population_index": 2,
+      "STRAT": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "21C422D4-1658-478D-AEC2-B87B73638C41",
+      "population_index": 3,
+      "STRAT": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "21C422D4-1658-478D-AEC2-B87B73638C41",
+      "population_index": 4,
+      "STRAT": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "21C422D4-1658-478D-AEC2-B87B73638C41",
+      "population_index": 5,
+      "STRAT": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "21C422D4-1658-478D-AEC2-B87B73638C41",
+      "population_index": 6,
+      "STRAT": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "21C422D4-1658-478D-AEC2-B87B73638C41",
+      "population_index": 7,
+      "STRAT": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "21C422D4-1658-478D-AEC2-B87B73638C41",
+      "population_index": 8,
+      "STRAT": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "21C422D4-1658-478D-AEC2-B87B73638C41",
+      "population_index": 9,
+      "STRAT": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "21C422D4-1658-478D-AEC2-B87B73638C41",
+      "population_index": 10,
+      "STRAT": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    }
+  ],
+  "familyName": "Blank",
+  "givenNames": [
+    "Patient"
+  ],
+  "notes": "",
+  "qdmPatient": {
+    "_id": "5c880141d7c8ac4c3e10671f",
+    "birthDatetime": "1970-01-01T08:00:00.000+00:00",
+    "dataElements": [
+      {
+        "_id": "5c880141d7c8ac4c3e10671a",
+        "birthDatetime": "1970-01-01T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "code": "21112-8",
+            "codeSystem": "LOINC",
+            "descriptor": null,
+            "codeSystemOid": null,
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.54",
+        "id": {
+          "_id": "5c880141d7c8ac4c3e106720",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880141d7c8ac4c3e10671a"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "birthdate",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicBirthdate"
+      },
+      {
+        "_id": "5c880141d7c8ac4c3e10671b",
+        "dataElementCodes": [
+          {
+            "code": "2186-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "Not Hispanic or Latino",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.56",
+        "id": {
+          "_id": "5c880141d7c8ac4c3e106721",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880141d7c8ac4c3e10671b"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "ethnicity",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicEthnicity"
+      },
+      {
+        "_id": "5c880141d7c8ac4c3e10671c",
+        "dataElementCodes": [
+          {
+            "code": "1002-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "American Indian or Alaska Native",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.59",
+        "id": {
+          "_id": "5c880141d7c8ac4c3e106722",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880141d7c8ac4c3e10671c"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "race",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicRace"
+      },
+      {
+        "_id": "5c880141d7c8ac4c3e10671d",
+        "dataElementCodes": [
+          {
+            "code": "M",
+            "codeSystem": "AdministrativeGender",
+            "descriptor": "M",
+            "codeSystemOid": "2.16.840.1.113883.5.1",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.55",
+        "id": {
+          "_id": "5c880141d7c8ac4c3e106723",
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880141d7c8ac4c3e10671d"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "gender",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicSex"
+      }
+    ],
+    "extendedData": {
+      "type": null,
+      "measure_ids": [
+        "21C422D4-1658-478D-AEC2-B87B73638C41",
+        null
+      ],
+      "source_data_criteria": [
+        {
+          "id": "MeasurePeriod",
+          "start_date": 0,
+          "end_date": 0,
+          "references": null
+        }
+      ],
+      "is_shared": null,
+      "origin_data": [
+
+      ],
+      "test_id": null,
+      "medical_record_number": "e89dca90064c46158e292fbc8721b5a82c516421b206f91179e708dee8c8036a",
+      "medical_record_assigner": "Bonnie",
+      "description": null,
+      "description_category": null,
+      "insurance_providers": "[{\"codes\":{\"SOP\":[\"349\"]},\"description\":null,\"end_time\":null,\"financial_responsibility_type\":{\"code\":\"SELF\",\"codeSystem\":\"HL7 Relationship Code\"},\"health_record_field\":null,\"member_id\":\"1234567890\",\"mood_code\":\"EVN\",\"name\":\"Other\",\"negationInd\":null,\"negationReason\":null,\"oid\":null,\"payer\":{\"name\":\"Other\"},\"reason\":null,\"relationship\":null,\"specifics\":null,\"start_time\":1199145600,\"status_code\":null,\"time\":null,\"type\":\"OT\"}]"
+    },
+    "qdmVersion": "5.4"
+  }
+}

--- a/test/fixtures/patients/CMS108v7/108v7 Elements_108v7 Test.json
+++ b/test/fixtures/patients/CMS108v7/108v7 Elements_108v7 Test.json
@@ -1,0 +1,1046 @@
+{
+  "_id": {
+    "$oid": "5b6b2821b848461165a3e886"
+  },
+  "bundleId": "5a57e977942c6d1e61d32f14",
+  "expectedValues": [
+    {
+      "measure_id": "38B0B5EC-0F63-466F-8FE3-2CD20DDD1622",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    }
+  ],
+  "familyName": "108v7 Test",
+  "givenNames": [
+    "108v7 Elements"
+  ],
+  "notes": "",
+  "qdmPatient": {
+    "_id": {
+      "$oid": "5c880144d7c8ac4c3e106797"
+    },
+    "birthDatetime": "1970-01-01T08:00:00.000+00:00",
+    "dataElements": [
+      {
+        "_id": {
+          "$oid": "5c880144d7c8ac4c3e106798"
+        },
+        "authorDatetime": "2012-08-01T08:00:00.000+00:00",
+        "components": [
+          {
+            "result": {
+              "code": "0SP909Z",
+              "codeSystem": "ICD-10-PCS",
+              "version": null,
+              "descriptor": null
+            },
+            "code": {
+              "code": "112943005",
+              "codeSystem": "SNOMED-CT",
+              "version": null,
+              "descriptor": "Hip Replacement Surgery"
+            }
+          },
+          {
+            "result": {
+              "unit": "mg",
+              "value": 34
+            },
+            "code": {
+              "code": "1037045",
+              "codeSystem": "RxNorm",
+              "version": null,
+              "descriptor": null
+            }
+          },
+          {
+            "result": "44342-10-06T08:00:00+00:00",
+            "code": {
+              "code": "1736470",
+              "codeSystem": "RxNorm",
+              "version": null,
+              "descriptor": null
+            }
+          }
+        ],
+        "dataElementCodes": [
+          {
+            "codeSystem": "LOINC",
+            "code": "72136-5"
+          }
+        ],
+        "description": "Assessment, Performed: Risk for venous thromboembolism",
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.117",
+        "id": {
+          "_id": {
+            "$oid": "5c880144d7c8ac4c3e106799"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5b6c247cb848464add0870f6"
+        },
+        "method": {
+          "code": "008Q0ZZ",
+          "codeSystem": "ICD-10-PCS",
+          "descriptor": "General Surgery",
+          "codeSystemOid": null,
+          "version": null
+        },
+        "negationRationale": null,
+        "qdmCategory": "assessment",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "reason": {
+          "code": "133918004",
+          "codeSystem": "SNOMED-CT",
+          "descriptor": "Comfort Measures",
+          "codeSystemOid": null,
+          "version": null
+        },
+        "relatedTo": [
+          {
+            "_id": {
+              "$oid": "5c880144d7c8ac4c3e10679a"
+            },
+            "namingSystem": null,
+            "qdmVersion": "5.4",
+            "value": "5b6c247cb848464add0870ee"
+          }
+        ],
+        "result": "44422-02-28T08:00:00.000+00:00",
+        "_type": "QDM::AssessmentPerformed"
+      },
+      {
+        "_id": {
+          "$oid": "5c880144d7c8ac4c3e10679b"
+        },
+        "anatomicalLocationSite": null,
+        "authorDatetime": "2012-08-01T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "442023007"
+          }
+        ],
+        "description": "Device, Applied: Venous foot pumps (VFP)",
+        "hqmfOid": "2.16.840.1.113883.3.560.1.10",
+        "id": {
+          "_id": {
+            "$oid": "5c880144d7c8ac4c3e10679c"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5b6c247cb848464add0870ee"
+        },
+        "negationRationale": null,
+        "qdmCategory": "device",
+        "qdmStatus": "applied",
+        "qdmVersion": "5.4",
+        "reason": {
+          "code": "195155004",
+          "codeSystem": "SNOMED-CT",
+          "descriptor": "Hemorrhagic Stroke",
+          "codeSystemOid": null,
+          "version": null
+        },
+        "relevantPeriod": {
+          "low": "2012-08-01T08:00:00.000+00:00",
+          "high": "9999-12-31T23:59:59.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "_type": "QDM::DeviceApplied"
+      },
+      {
+        "_id": {
+          "$oid": "5c880144d7c8ac4c3e10679d"
+        },
+        "anatomicalLocationSite": null,
+        "authorDatetime": "2012-08-01T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "428411000124104"
+          }
+        ],
+        "description": "Device, Applied: Intermittent pneumatic compression devices (IPC)",
+        "hqmfOid": "2.16.840.1.113883.3.560.1.110",
+        "id": {
+          "_id": {
+            "$oid": "5c880144d7c8ac4c3e10679e"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5b6c247cb848464add0870ef"
+        },
+        "negationRationale": {
+          "code": "1037045",
+          "codeSystem": "RxNorm",
+          "descriptor": null,
+          "codeSystemOid": null,
+          "version": null
+        },
+        "qdmCategory": "device",
+        "qdmStatus": "applied",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "relevantPeriod": {
+          "low": "2012-08-01T08:00:00.000+00:00",
+          "high": "9999-12-31T23:59:59.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "_type": "QDM::DeviceApplied"
+      },
+      {
+        "_id": {
+          "$oid": "5c880144d7c8ac4c3e10679f"
+        },
+        "authorDatetime": "2012-08-01T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "442023007"
+          }
+        ],
+        "description": "Device, Ordered: Venous foot pumps (VFP)",
+        "hqmfOid": "2.16.840.1.113883.3.560.1.37",
+        "id": {
+          "_id": {
+            "$oid": "5c880144d7c8ac4c3e1067a0"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5b6c247cb848464add0870f0"
+        },
+        "negationRationale": null,
+        "qdmCategory": "device",
+        "qdmStatus": "order",
+        "qdmVersion": "5.4",
+        "reason": {
+          "code": "0SP909Z",
+          "codeSystem": "ICD-10-PCS",
+          "descriptor": "Hip Replacement Surgery",
+          "codeSystemOid": null,
+          "version": null
+        },
+        "_type": "QDM::DeviceOrder"
+      },
+      {
+        "_id": {
+          "$oid": "5c880144d7c8ac4c3e1067a1"
+        },
+        "authorDatetime": "2012-08-01T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "348681001"
+          }
+        ],
+        "description": "Device, Ordered: Graduated compression stockings (GCS)",
+        "hqmfOid": "2.16.840.1.113883.3.560.1.137",
+        "id": {
+          "_id": {
+            "$oid": "5c880144d7c8ac4c3e1067a2"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5b6c247cb848464add0870f1"
+        },
+        "negationRationale": {
+          "code": "195155004",
+          "codeSystem": "SNOMED-CT",
+          "descriptor": null,
+          "codeSystemOid": null,
+          "version": null
+        },
+        "qdmCategory": "device",
+        "qdmStatus": "order",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "_type": "QDM::DeviceOrder"
+      },
+      {
+        "_id": {
+          "$oid": "5c880144d7c8ac4c3e1067a3"
+        },
+        "authorDatetime": "2012-08-01T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "RxNorm",
+            "code": "1037045"
+          }
+        ],
+        "description": "Medication, Administered: Direct Thrombin Inhibitor",
+        "dosage": {
+          "value": 5,
+          "unit": "mg"
+        },
+        "frequency": {
+          "code": null,
+          "codeSystem": null,
+          "descriptor": null,
+          "codeSystemOid": null,
+          "version": null
+        },
+        "hqmfOid": "2.16.840.1.113883.3.560.1.14",
+        "id": {
+          "_id": {
+            "$oid": "5c880144d7c8ac4c3e1067a4"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5b6c247cb848464add0870f2"
+        },
+        "negationRationale": null,
+        "qdmCategory": "medication",
+        "qdmStatus": "administered",
+        "qdmVersion": "5.4",
+        "reason": {
+          "code": "4525004",
+          "codeSystem": "SNOMED-CT",
+          "descriptor": "Emergency Department Visit",
+          "codeSystemOid": null,
+          "version": null
+        },
+        "relevantPeriod": {
+          "low": "2012-08-01T08:00:00.000+00:00",
+          "high": "9999-12-31T23:59:59.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "route": {
+          "code": "418114005",
+          "codeSystem": "SNOMED-CT",
+          "descriptor": "Intravenous route",
+          "codeSystemOid": null,
+          "version": null
+        },
+        "_type": "QDM::MedicationAdministered"
+      },
+      {
+        "_id": {
+          "$oid": "5c880144d7c8ac4c3e1067a5"
+        },
+        "authorDatetime": "2012-08-01T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "RxNorm",
+            "code": "1361226"
+          }
+        ],
+        "description": "Medication, Administered: Low Dose Unfractionated Heparin for VTE Prophylaxis",
+        "dosage": null,
+        "frequency": null,
+        "hqmfOid": "2.16.840.1.113883.3.560.1.114",
+        "id": {
+          "_id": {
+            "$oid": "5c880144d7c8ac4c3e1067a6"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5b6c247cb848464add0870f3"
+        },
+        "negationRationale": {
+          "code": "861356",
+          "codeSystem": "RxNorm",
+          "descriptor": null,
+          "codeSystemOid": null,
+          "version": null
+        },
+        "qdmCategory": "medication",
+        "qdmStatus": "administered",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "relevantPeriod": {
+          "low": "2012-08-01T08:00:00.000+00:00",
+          "high": "9999-12-31T23:59:59.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "route": null,
+        "_type": "QDM::MedicationAdministered"
+      },
+      {
+        "_id": {
+          "$oid": "5c880144d7c8ac4c3e1067a7"
+        },
+        "authorDatetime": "2012-08-01T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "RxNorm",
+            "code": "1361226"
+          }
+        ],
+        "daysSupplied": null,
+        "description": "Medication, Ordered: Low Dose Unfractionated Heparin for VTE Prophylaxis",
+        "dosage": null,
+        "frequency": null,
+        "hqmfOid": "2.16.840.1.113883.3.560.1.78",
+        "id": {
+          "_id": {
+            "$oid": "5c880144d7c8ac4c3e1067a8"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5b6c247cb848464add0870f4"
+        },
+        "negationRationale": {
+          "code": "101421000119107",
+          "codeSystem": "SNOMED-CT",
+          "descriptor": null,
+          "codeSystemOid": null,
+          "version": null
+        },
+        "prescriberId": null,
+        "qdmCategory": "medication",
+        "qdmStatus": "order",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "refills": null,
+        "relevantPeriod": {
+          "low": "2012-08-01T08:00:00.000+00:00",
+          "high": "9999-12-31T23:59:59.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "route": null,
+        "setting": null,
+        "supply": null,
+        "_type": "QDM::MedicationOrder"
+      },
+      {
+        "_id": {
+          "$oid": "5c880144d7c8ac4c3e1067a9"
+        },
+        "authorDatetime": "2012-08-01T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "RxNorm",
+            "code": "855288"
+          }
+        ],
+        "daysSupplied": null,
+        "description": "Medication, Ordered: Warfarin",
+        "dosage": {
+          "value": 5,
+          "unit": "mg"
+        },
+        "frequency": {
+          "code": null,
+          "codeSystem": null,
+          "descriptor": null,
+          "codeSystemOid": null,
+          "version": null
+        },
+        "hqmfOid": "2.16.840.1.113883.3.560.1.17",
+        "id": {
+          "_id": {
+            "$oid": "5c880144d7c8ac4c3e1067aa"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5b6c247cb848464add0870f5"
+        },
+        "negationRationale": null,
+        "prescriberId": null,
+        "qdmCategory": "medication",
+        "qdmStatus": "order",
+        "qdmVersion": "5.4",
+        "reason": {
+          "code": "195080001",
+          "codeSystem": "SNOMED-CT",
+          "descriptor": "Atrial Fibrillation/Flutter",
+          "codeSystemOid": null,
+          "version": null
+        },
+        "refills": 9,
+        "relevantPeriod": {
+          "low": "2012-08-01T08:00:00.000+00:00",
+          "high": "9999-12-31T23:59:59.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "route": {
+          "code": "34206005",
+          "codeSystem": "SNOMED-CT",
+          "descriptor": "Subcutaneous route",
+          "codeSystemOid": null,
+          "version": null
+        },
+        "setting": null,
+        "supply": {
+          "value": 100,
+          "unit": "mg"
+        },
+        "_type": "QDM::MedicationOrder"
+      },
+      {
+        "_id": {
+          "$oid": "5c880144d7c8ac4c3e106792"
+        },
+        "birthDatetime": "1970-01-01T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "code": "21112-8",
+            "codeSystem": "LOINC",
+            "descriptor": null,
+            "codeSystemOid": null,
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.54",
+        "id": {
+          "_id": {
+            "$oid": "5c880144d7c8ac4c3e1067ab"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880144d7c8ac4c3e106792"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "birthdate",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicBirthdate"
+      },
+      {
+        "_id": {
+          "$oid": "5c880144d7c8ac4c3e106793"
+        },
+        "dataElementCodes": [
+          {
+            "code": "2186-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "Not Hispanic or Latino",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.56",
+        "id": {
+          "_id": {
+            "$oid": "5c880144d7c8ac4c3e1067ac"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880144d7c8ac4c3e106793"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "ethnicity",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicEthnicity"
+      },
+      {
+        "_id": {
+          "$oid": "5c880144d7c8ac4c3e106794"
+        },
+        "dataElementCodes": [
+          {
+            "code": "1002-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "American Indian or Alaska Native",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.59",
+        "id": {
+          "_id": {
+            "$oid": "5c880144d7c8ac4c3e1067ad"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880144d7c8ac4c3e106794"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "race",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicRace"
+      },
+      {
+        "_id": {
+          "$oid": "5c880144d7c8ac4c3e106795"
+        },
+        "dataElementCodes": [
+          {
+            "code": "M",
+            "codeSystem": "AdministrativeGender",
+            "descriptor": "M",
+            "codeSystemOid": "2.16.840.1.113883.5.1",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.55",
+        "id": {
+          "_id": {
+            "$oid": "5c880144d7c8ac4c3e1067ae"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880144d7c8ac4c3e106795"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "gender",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicSex"
+      }
+    ],
+    "extendedData": {
+      "type": null,
+      "measure_ids": [
+        "38B0B5EC-0F63-466F-8FE3-2CD20DDD1622",
+        null
+      ],
+      "source_data_criteria": [
+        {
+          "negation": false,
+          "definition": "assessment",
+          "status": "performed",
+          "title": "Assessment, Performed: Assessment, Performed",
+          "description": "Assessment, Performed: Risk for venous thromboembolism",
+          "code_list_id": "drc-522a38859e8337cb6214742610b449c149172dccc97f176b0b580b4d3f975004",
+          "type": "assessments",
+          "id": "prefix_72136_5_AssessmentPerformed_B7EF188A_B153_422B_8D67_C74436EAB826_source",
+          "start_date": 1343808000000,
+          "value": [
+            {
+              "type": "TS",
+              "type_cmp": "CD",
+              "start_date": "06/14/2012",
+              "start_time": "8:00 AM",
+              "value": 1339660800000
+            }
+          ],
+          "references": [
+            {
+              "reference_type": "Related To",
+              "reference_id": "1651a9359d3RB",
+              "type": "CD",
+              "description": "Device, Applied: Venous foot pumps (VFP)",
+              "start_date": "08/01/2012"
+            }
+          ],
+          "field_values": {
+            "REASON": {
+              "type": "CD",
+              "code_list_id": "1.3.6.1.4.1.33895.1.3.0.45",
+              "field_title": "Reason",
+              "title": "Comfort Measures"
+            },
+            "METHOD": {
+              "type": "CD",
+              "code_list_id": "2.16.840.1.113883.3.117.1.7.1.255",
+              "field_title": "Method",
+              "title": "General Surgery"
+            },
+            "COMPONENT": {
+              "type": "COL",
+              "values": [
+                {
+                  "type": "CMP",
+                  "key": "COMPONENT",
+                  "code_list_id": "2.16.840.1.113883.3.666.5.1743",
+                  "title_cmp": "Hip Replacement Surgery",
+                  "field_title": "Component",
+                  "type_cmp": "CD",
+                  "code_list_id_cmp": "2.16.840.1.113883.3.117.1.7.1.259",
+                  "title": "General or Neuraxial Anesthesia"
+                },
+                {
+                  "type": "CMP",
+                  "key": "COMPONENT",
+                  "code_list_id": "2.16.840.1.113883.3.117.1.7.1.205",
+                  "field_title": "Component",
+                  "type_cmp": "PQ",
+                  "code_list_id_cmp": "",
+                  "title": "Direct Thrombin Inhibitor",
+                  "value": "34",
+                  "unit": "mg"
+                },
+                {
+                  "type": "CMP",
+                  "key": "COMPONENT",
+                  "code_list_id": "2.16.840.1.113762.1.4.1045.41",
+                  "field_title": "Component",
+                  "type_cmp": "TS",
+                  "code_list_id_cmp": "",
+                  "title": "Glycoprotein IIb/IIIa Inhibitors",
+                  "start_date": "05/16/2012",
+                  "start_time": "8:00 AM",
+                  "value": 1337155200000
+                }
+              ],
+              "field_title": "Component"
+            }
+          },
+          "hqmf_set_id": "38B0B5EC-0F63-466F-8FE3-2CD20DDD1622",
+          "cms_id": "CMS108v7",
+          "criteria_id": "1651a91e4800A",
+          "codes": {
+            "LOINC": [
+              "72136-5"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5b6c247cb848464add0870f6"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "device",
+          "status": "applied",
+          "title": "Venousfootpumps(VFP)",
+          "description": "Device, Applied: Venous foot pumps (VFP)",
+          "code_list_id": "2.16.840.1.113883.3.117.1.7.1.230",
+          "type": "devices",
+          "id": "Venousfootpumps_VFP__DeviceApplied_40280381_3d27_5493_013d_4be146945c82_source",
+          "start_date": 1343808000000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+            "REASON": {
+              "type": "CD",
+              "code_list_id": "2.16.840.1.113883.3.117.1.7.1.212",
+              "field_title": "Reason",
+              "title": "Hemorrhagic Stroke"
+            }
+          },
+          "hqmf_set_id": "38B0B5EC-0F63-466F-8FE3-2CD20DDD1622",
+          "cms_id": "CMS108v7",
+          "criteria_id": "1651a9359d3RB",
+          "codes": {
+            "SNOMED-CT": [
+              "442023007"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5b6c247cb848464add0870ee"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": true,
+          "definition": "device",
+          "status": "applied",
+          "title": "Intermittentpneumaticcompressiondevices(IPC)",
+          "description": "Device, Applied: Intermittent pneumatic compression devices (IPC)",
+          "code_list_id": "2.16.840.1.113883.3.117.1.7.1.214",
+          "type": "devices",
+          "id": "Intermittentpneumaticcompressiondevices_IPC__DeviceApplied_40280381_3d27_5493_013d_4be146945c83_source",
+          "start_date": 1343808000000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "38B0B5EC-0F63-466F-8FE3-2CD20DDD1622",
+          "cms_id": "CMS108v7",
+          "criteria_id": "1651a948034mw",
+          "codes": {
+            "SNOMED-CT": [
+              "428411000124104"
+            ]
+          },
+          "negation_code_list_id": "2.16.840.1.113883.3.117.1.7.1.205",
+          "coded_entry_id": {
+            "$oid": "5b6c247cb848464add0870ef"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "medication",
+          "status": "administered",
+          "title": "DirectThrombinInhibitor",
+          "description": "Medication, Administered: Direct Thrombin Inhibitor",
+          "code_list_id": "2.16.840.1.113883.3.117.1.7.1.205",
+          "type": "medications",
+          "id": "DirectThrombinInhibitor_MedicationAdministered_40280381_3d27_5493_013d_4be146955c93_source",
+          "start_date": 1343808000000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+            "DOSE": {
+              "type": "PQ",
+              "code_list_id": "",
+              "field_title": "Dosage",
+              "value": "5",
+              "unit": "mg"
+            },
+            "FREQUENCY": {
+              "type": "PQ",
+              "code_list_id": "",
+              "field_title": "Frequency",
+              "value": "3",
+              "unit": "days"
+            },
+            "SUPPLY": {
+              "type": "PQ",
+              "code_list_id": "",
+              "field_title": "Supply",
+              "value": "100",
+              "unit": "mg"
+            },
+            "REASON": {
+              "type": "CD",
+              "code_list_id": "2.16.840.1.113883.3.117.1.7.1.292",
+              "field_title": "Reason",
+              "title": "Emergency Department Visit"
+            },
+            "ROUTE": {
+              "type": "CD",
+              "code_list_id": "2.16.840.1.113883.3.117.1.7.1.222",
+              "field_title": "Route",
+              "title": "Intravenous route"
+            }
+          },
+          "hqmf_set_id": "38B0B5EC-0F63-466F-8FE3-2CD20DDD1622",
+          "cms_id": "CMS108v7",
+          "criteria_id": "1651a97e18a0J",
+          "codes": {
+            "RxNorm": [
+              "1037045"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5b6c247cb848464add0870f2"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": true,
+          "definition": "medication",
+          "status": "administered",
+          "title": "LowDoseUnfractionatedHeparinforVTEProphylaxis",
+          "description": "Medication, Administered: Low Dose Unfractionated Heparin for VTE Prophylaxis",
+          "code_list_id": "2.16.840.1.113762.1.4.1045.39",
+          "type": "medications",
+          "id": "LowDoseUnfractionatedHeparinforVTEProphylaxis_MedicationAdministered_389f98c4_53d0_4562_bfae_02b74a2f8c26_source",
+          "start_date": 1343808000000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "38B0B5EC-0F63-466F-8FE3-2CD20DDD1622",
+          "cms_id": "CMS108v7",
+          "criteria_id": "1651a98e395QR",
+          "codes": {
+            "RxNorm": [
+              "1361226"
+            ]
+          },
+          "negation_code_list_id": "2.16.840.1.113883.3.117.1.7.1.211",
+          "coded_entry_id": {
+            "$oid": "5b6c247cb848464add0870f3"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": true,
+          "definition": "medication",
+          "status": "ordered",
+          "title": "LowDoseUnfractionatedHeparinforVTEProphylaxis",
+          "description": "Medication, Ordered: Low Dose Unfractionated Heparin for VTE Prophylaxis",
+          "code_list_id": "2.16.840.1.113762.1.4.1045.39",
+          "type": "medications",
+          "id": "Derived from LowDoseUnfractionatedHeparinforVTEProphylaxis_MedicationNotOrdered_389f98c4_53d0_4562_bfae_02b74a2f8c26_source",
+          "start_date": 1343808000000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "38B0B5EC-0F63-466F-8FE3-2CD20DDD1622",
+          "cms_id": "CMS108v7",
+          "criteria_id": "1651e6b65b5hH",
+          "codes": {
+            "RxNorm": [
+              "1361226"
+            ]
+          },
+          "negation_code_list_id": "2.16.840.1.113883.3.464.1003.105.12.1004",
+          "coded_entry_id": {
+            "$oid": "5b6c247cb848464add0870f4"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "device",
+          "status": "ordered",
+          "title": "Venousfootpumps(VFP)",
+          "description": "Device, Ordered: Venous foot pumps (VFP)",
+          "code_list_id": "2.16.840.1.113883.3.117.1.7.1.230",
+          "type": "devices",
+          "id": "Derived from Venousfootpumps_VFP__DeviceNotOrdered_40280381_3d27_5493_013d_4be146945c82_source",
+          "start_date": 1343808000000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+            "REASON": {
+              "type": "CD",
+              "code_list_id": "2.16.840.1.113883.3.117.1.7.1.259",
+              "field_title": "Reason",
+              "title": "Hip Replacement Surgery"
+            }
+          },
+          "hqmf_set_id": "38B0B5EC-0F63-466F-8FE3-2CD20DDD1622",
+          "cms_id": "CMS108v7",
+          "criteria_id": "1651e6bf4ddcQ",
+          "codes": {
+            "SNOMED-CT": [
+              "442023007"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5b6c247cb848464add0870f0"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": true,
+          "definition": "device",
+          "status": "ordered",
+          "title": "Graduatedcompressionstockings(GCS)",
+          "description": "Device, Ordered: Graduated compression stockings (GCS)",
+          "code_list_id": "2.16.840.1.113883.3.117.1.7.1.256",
+          "type": "devices",
+          "id": "Derived from Graduatedcompressionstockings_GCS__DeviceNotOrdered_40280381_3d27_5493_013d_4be146945c81_source",
+          "start_date": 1343808000000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "38B0B5EC-0F63-466F-8FE3-2CD20DDD1622",
+          "cms_id": "CMS108v7",
+          "criteria_id": "1651e6c69caJj",
+          "codes": {
+            "SNOMED-CT": [
+              "348681001"
+            ]
+          },
+          "negation_code_list_id": "2.16.840.1.113883.3.117.1.7.1.212",
+          "coded_entry_id": {
+            "$oid": "5b6c247cb848464add0870f1"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "medication",
+          "status": "ordered",
+          "title": "Warfarin",
+          "description": "Medication, Ordered: Warfarin",
+          "code_list_id": "2.16.840.1.113883.3.117.1.7.1.232",
+          "type": "medications",
+          "id": "Derived from Warfarin_MedicationNotOrdered_40280381_3d27_5493_013d_4be146955c95_source",
+          "start_date": 1343808000000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+            "DOSE": {
+              "type": "PQ",
+              "code_list_id": "",
+              "field_title": "Dosage",
+              "value": "5",
+              "unit": "mg"
+            },
+            "SUPPLY": {
+              "type": "PQ",
+              "code_list_id": "",
+              "field_title": "Supply",
+              "value": "100",
+              "unit": "mg"
+            },
+            "FREQUENCY": {
+              "type": "PQ",
+              "code_list_id": "",
+              "field_title": "Frequency",
+              "value": "1",
+              "unit": "day"
+            },
+            "REASON": {
+              "type": "CD",
+              "code_list_id": "2.16.840.1.113883.3.117.1.7.1.202",
+              "field_title": "Reason",
+              "title": "Atrial Fibrillation/Flutter"
+            },
+            "REFILLS": {
+              "type": "PQ",
+              "code_list_id": "",
+              "field_title": "Refills",
+              "value": "9",
+              "unit": ""
+            },
+            "ROUTE": {
+              "type": "CD",
+              "code_list_id": "2.16.840.1.113883.3.117.1.7.1.223",
+              "field_title": "Route",
+              "title": "Subcutaneous route"
+            }
+          },
+          "hqmf_set_id": "38B0B5EC-0F63-466F-8FE3-2CD20DDD1622",
+          "cms_id": "CMS108v7",
+          "criteria_id": "1651e6cc909wk",
+          "codes": {
+            "RxNorm": [
+              "855288"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5b6c247cb848464add0870f5"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "id": "MeasurePeriod",
+          "start_date": 0,
+          "end_date": 0,
+          "references": null
+        }
+      ],
+      "is_shared": null,
+      "origin_data": [
+
+      ],
+      "test_id": null,
+      "medical_record_number": "6f951a8be6a7afd11c1ef6d6b44a59eac8a9d0a0ab98c519c6edf957334df8a7",
+      "medical_record_assigner": "Bonnie",
+      "description": null,
+      "description_category": null,
+      "insurance_providers": "[{\"codes\":{\"SOP\":[\"349\"]},\"description\":null,\"end_time\":null,\"financial_responsibility_type\":{\"code\":\"SELF\",\"codeSystem\":\"HL7 Relationship Code\"},\"health_record_field\":null,\"member_id\":\"1234567890\",\"mood_code\":\"EVN\",\"name\":\"Other\",\"negationInd\":null,\"negationReason\":null,\"oid\":null,\"payer\":{\"name\":\"Other\"},\"reason\":null,\"relationship\":null,\"specifics\":null,\"start_time\":1199145600,\"status_code\":null,\"time\":null,\"type\":\"OT\"}]"
+    },
+    "qdmVersion": "5.4"
+  }
+}

--- a/test/fixtures/patients/CMS10v0/Test_DenexcepPass.json
+++ b/test/fixtures/patients/CMS10v0/Test_DenexcepPass.json
@@ -1,0 +1,342 @@
+{
+  "_id": {
+    "$oid": "5bfef1a9b848462b5596bd7b"
+  },
+  "bundleId": "5a57e977942c6d1e61d32f14",
+  "expectedValues": [
+    {
+      "measure_id": "442F4F7E-3C22-4641-9BEE-0E968CC38EF2",
+      "population_index": 0,
+      "IPP": 1,
+      "DENOM": 1,
+      "NUMER": 0,
+      "DENEXCEP": 1
+    }
+  ],
+  "familyName": "DenexcepPass",
+  "givenNames": [
+    "Test"
+  ],
+  "notes": "",
+  "qdmPatient": {
+    "_id": {
+      "$oid": "5c880146d7c8ac4c3e1067d3"
+    },
+    "birthDatetime": "1990-02-01T08:00:00.000+00:00",
+    "dataElements": [
+      {
+        "_id": {
+          "$oid": "5c880146d7c8ac4c3e1067d4"
+        },
+        "admissionSource": null,
+        "authorDatetime": "2012-07-18T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "10197000"
+          },
+          {
+            "codeSystem": "CPT",
+            "code": "59400"
+          },
+          {
+            "codeSystem": "HCPCS",
+            "code": "G0101"
+          }
+        ],
+        "description": "Encounter, Performed: Medications Encounter Code Set",
+        "diagnoses": [
+
+        ],
+        "dischargeDisposition": null,
+        "facilityLocations": [
+
+        ],
+        "hqmfOid": "2.16.840.1.113883.3.560.1.79",
+        "id": {
+          "_id": {
+            "$oid": "5c880146d7c8ac4c3e1067d5"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5bfef1a9b848462b5596bd7d"
+        },
+        "lengthOfStay": {
+          "value": 0,
+          "unit": "days"
+        },
+        "negationRationale": null,
+        "principalDiagnosis": null,
+        "qdmCategory": "encounter",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "relevantPeriod": {
+          "low": "2012-07-18T08:00:00.000+00:00",
+          "high": "2012-07-18T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "_type": "QDM::EncounterPerformed"
+      },
+      {
+        "_id": {
+          "$oid": "5c880146d7c8ac4c3e1067d6"
+        },
+        "anatomicalLocationSite": null,
+        "authorDatetime": "2012-07-18T08:00:00.000+00:00",
+        "components": [
+
+        ],
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "428191000124101"
+          }
+        ],
+        "description": "Procedure, Performed: Current Medications Documented SNMD",
+        "hqmfOid": "2.16.840.1.113883.3.560.1.106",
+        "id": {
+          "_id": {
+            "$oid": "5c880146d7c8ac4c3e1067d7"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5bfef1a9b848462b5596bd7c"
+        },
+        "incisionDatetime": null,
+        "method": null,
+        "negationRationale": {
+          "code": "183932001",
+          "codeSystem": "SNOMED-CT",
+          "descriptor": null,
+          "codeSystemOid": null,
+          "version": null
+        },
+        "ordinality": null,
+        "qdmCategory": "procedure",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "relevantPeriod": {
+          "low": "2012-07-18T08:00:00.000+00:00",
+          "high": "9999-12-31T23:59:59.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "result": null,
+        "status": null,
+        "_type": "QDM::ProcedurePerformed"
+      },
+      {
+        "_id": {
+          "$oid": "5c880146d7c8ac4c3e1067ce"
+        },
+        "birthDatetime": "1990-02-01T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "code": "21112-8",
+            "codeSystem": "LOINC",
+            "descriptor": null,
+            "codeSystemOid": null,
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.54",
+        "id": {
+          "_id": {
+            "$oid": "5c880146d7c8ac4c3e1067d8"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880146d7c8ac4c3e1067ce"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "birthdate",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicBirthdate"
+      },
+      {
+        "_id": {
+          "$oid": "5c880146d7c8ac4c3e1067cf"
+        },
+        "dataElementCodes": [
+          {
+            "code": "2186-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "Not Hispanic or Latino",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.56",
+        "id": {
+          "_id": {
+            "$oid": "5c880146d7c8ac4c3e1067d9"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880146d7c8ac4c3e1067cf"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "ethnicity",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicEthnicity"
+      },
+      {
+        "_id": {
+          "$oid": "5c880146d7c8ac4c3e1067d0"
+        },
+        "dataElementCodes": [
+          {
+            "code": "1002-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "American Indian or Alaska Native",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.59",
+        "id": {
+          "_id": {
+            "$oid": "5c880146d7c8ac4c3e1067da"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880146d7c8ac4c3e1067d0"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "race",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicRace"
+      },
+      {
+        "_id": {
+          "$oid": "5c880146d7c8ac4c3e1067d1"
+        },
+        "dataElementCodes": [
+          {
+            "code": "M",
+            "codeSystem": "AdministrativeGender",
+            "descriptor": "M",
+            "codeSystemOid": "2.16.840.1.113883.5.1",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.55",
+        "id": {
+          "_id": {
+            "$oid": "5c880146d7c8ac4c3e1067db"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880146d7c8ac4c3e1067d1"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "gender",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicSex"
+      }
+    ],
+    "extendedData": {
+      "type": null,
+      "measure_ids": [
+        "442F4F7E-3C22-4641-9BEE-0E968CC38EF2",
+        null
+      ],
+      "source_data_criteria": [
+        {
+          "negation": true,
+          "definition": "procedure",
+          "status": "performed",
+          "title": "Current Medications Documented SNMD",
+          "description": "Procedure, Performed: Current Medications Documented SNMD",
+          "code_list_id": "2.16.840.1.113883.3.600.1.462",
+          "type": "procedures",
+          "id": "CurrentMedicationsDocumentedSNMD_ProcedurePerformed_4851d807_b8b9_4e52_a1ce_a7c97a762502_source",
+          "start_date": 1342598400000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "442F4F7E-3C22-4641-9BEE-0E968CC38EF2",
+          "cms_id": "CMS10v0",
+          "criteria_id": "1675bde99deSL",
+          "codes": {
+            "SNOMED-CT": [
+              "428191000124101"
+            ]
+          },
+          "negation_code_list_id": "2.16.840.1.113883.3.600.1.1502",
+          "coded_entry_id": {
+            "$oid": "5bfef1a9b848462b5596bd7c"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "encounter",
+          "status": "performed",
+          "title": "Medications Encounter Code Set",
+          "description": "Encounter, Performed: Medications Encounter Code Set",
+          "code_list_id": "2.16.840.1.113883.3.600.1.1834",
+          "type": "encounters",
+          "id": "MedicationsEncounterCodeSet_EncounterPerformed_0a3e8996_7fcb_4ff8_be65_0739cba27409_source",
+          "start_date": 1342598400000,
+          "end_date": 1342599300000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "442F4F7E-3C22-4641-9BEE-0E968CC38EF2",
+          "cms_id": "CMS10v0",
+          "criteria_id": "1675bdf6c56Ib",
+          "codes": {
+            "SNOMED-CT": [
+              "10197000"
+            ],
+            "CPT": [
+              "59400"
+            ],
+            "HCPCS": [
+              "G0101"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5bfef1a9b848462b5596bd7d"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "id": "MeasurePeriod",
+          "start_date": 0,
+          "end_date": 0,
+          "references": null
+        }
+      ],
+      "is_shared": null,
+      "origin_data": [
+
+      ],
+      "test_id": null,
+      "medical_record_number": "3993742715f1bee6c424d5ac453467cf51c872781d2c86da04189ac08d03414f",
+      "medical_record_assigner": "Bonnie",
+      "description": null,
+      "description_category": null,
+      "insurance_providers": "[{\"codes\":{\"SOP\":[\"349\"]},\"description\":null,\"end_time\":null,\"financial_responsibility_type\":{\"code\":\"SELF\",\"codeSystem\":\"HL7 Relationship Code\"},\"health_record_field\":null,\"member_id\":\"1234567890\",\"mood_code\":\"EVN\",\"name\":\"Other\",\"negationInd\":null,\"negationReason\":null,\"oid\":null,\"payer\":{\"name\":\"Other\"},\"reason\":null,\"relationship\":null,\"specifics\":null,\"start_time\":1199145600,\"status_code\":null,\"time\":null,\"type\":\"OT\"}]"
+    },
+    "qdmVersion": "5.4"
+  }
+}

--- a/test/fixtures/patients/CMS10v0/Test_IppPass.json
+++ b/test/fixtures/patients/CMS10v0/Test_IppPass.json
@@ -1,0 +1,263 @@
+{
+  "_id": {
+    "$oid": "5bfef119b84846254735f78e"
+  },
+  "bundleId": "5a57e977942c6d1e61d32f14",
+  "expectedValues": [
+    {
+      "measure_id": "442F4F7E-3C22-4641-9BEE-0E968CC38EF2",
+      "population_index": 0,
+      "IPP": 1,
+      "DENOM": 1,
+      "NUMER": 0,
+      "DENEXCEP": 0
+    }
+  ],
+  "familyName": "IppPass",
+  "givenNames": [
+    "Test"
+  ],
+  "notes": "",
+  "qdmPatient": {
+    "_id": {
+      "$oid": "5c880145d7c8ac4c3e1067c7"
+    },
+    "birthDatetime": "1990-03-02T08:00:00.000+00:00",
+    "dataElements": [
+      {
+        "_id": {
+          "$oid": "5c880145d7c8ac4c3e1067c8"
+        },
+        "admissionSource": null,
+        "authorDatetime": "2012-07-12T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "10197000"
+          },
+          {
+            "codeSystem": "CPT",
+            "code": "59400"
+          },
+          {
+            "codeSystem": "HCPCS",
+            "code": "G0101"
+          }
+        ],
+        "description": "Encounter, Performed: Medications Encounter Code Set",
+        "diagnoses": [
+
+        ],
+        "dischargeDisposition": null,
+        "facilityLocations": [
+
+        ],
+        "hqmfOid": "2.16.840.1.113883.3.560.1.79",
+        "id": {
+          "_id": {
+            "$oid": "5c880145d7c8ac4c3e1067c9"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5bfef119b84846254735f78f"
+        },
+        "lengthOfStay": {
+          "value": 0,
+          "unit": "days"
+        },
+        "negationRationale": null,
+        "principalDiagnosis": null,
+        "qdmCategory": "encounter",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "relevantPeriod": {
+          "low": "2012-07-12T08:00:00.000+00:00",
+          "high": "2012-07-12T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "_type": "QDM::EncounterPerformed"
+      },
+      {
+        "_id": {
+          "$oid": "5c880145d7c8ac4c3e1067c2"
+        },
+        "birthDatetime": "1990-03-02T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "code": "21112-8",
+            "codeSystem": "LOINC",
+            "descriptor": null,
+            "codeSystemOid": null,
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.54",
+        "id": {
+          "_id": {
+            "$oid": "5c880145d7c8ac4c3e1067ca"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880145d7c8ac4c3e1067c2"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "birthdate",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicBirthdate"
+      },
+      {
+        "_id": {
+          "$oid": "5c880145d7c8ac4c3e1067c3"
+        },
+        "dataElementCodes": [
+          {
+            "code": "2186-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "Not Hispanic or Latino",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.56",
+        "id": {
+          "_id": {
+            "$oid": "5c880145d7c8ac4c3e1067cb"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880145d7c8ac4c3e1067c3"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "ethnicity",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicEthnicity"
+      },
+      {
+        "_id": {
+          "$oid": "5c880145d7c8ac4c3e1067c4"
+        },
+        "dataElementCodes": [
+          {
+            "code": "1002-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "American Indian or Alaska Native",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.59",
+        "id": {
+          "_id": {
+            "$oid": "5c880145d7c8ac4c3e1067cc"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880145d7c8ac4c3e1067c4"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "race",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicRace"
+      },
+      {
+        "_id": {
+          "$oid": "5c880145d7c8ac4c3e1067c5"
+        },
+        "dataElementCodes": [
+          {
+            "code": "M",
+            "codeSystem": "AdministrativeGender",
+            "descriptor": "M",
+            "codeSystemOid": "2.16.840.1.113883.5.1",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.55",
+        "id": {
+          "_id": {
+            "$oid": "5c880145d7c8ac4c3e1067cd"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880145d7c8ac4c3e1067c5"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "gender",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicSex"
+      }
+    ],
+    "extendedData": {
+      "type": null,
+      "measure_ids": [
+        "442F4F7E-3C22-4641-9BEE-0E968CC38EF2",
+        null
+      ],
+      "source_data_criteria": [
+        {
+          "negation": false,
+          "definition": "encounter",
+          "status": "performed",
+          "title": "Medications Encounter Code Set",
+          "description": "Encounter, Performed: Medications Encounter Code Set",
+          "code_list_id": "2.16.840.1.113883.3.600.1.1834",
+          "type": "encounters",
+          "id": "MedicationsEncounterCodeSet_EncounterPerformed_0a3e8996_7fcb_4ff8_be65_0739cba27409_source",
+          "start_date": 1342080000000,
+          "end_date": 1342080900000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "442F4F7E-3C22-4641-9BEE-0E968CC38EF2",
+          "cms_id": "CMS10v0",
+          "criteria_id": "1675bdd0864DE",
+          "codes": {
+            "SNOMED-CT": [
+              "10197000"
+            ],
+            "CPT": [
+              "59400"
+            ],
+            "HCPCS": [
+              "G0101"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5bfef119b84846254735f78f"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "id": "MeasurePeriod",
+          "start_date": 0,
+          "end_date": 0,
+          "references": null
+        }
+      ],
+      "is_shared": null,
+      "origin_data": [
+
+      ],
+      "test_id": null,
+      "medical_record_number": "2e3ea4d102b19bfcf87b8874283c0958613ad23896bb7ccec1f24daedd53a3d6",
+      "medical_record_assigner": "Bonnie",
+      "description": null,
+      "description_category": null,
+      "insurance_providers": "[{\"codes\":{\"SOP\":[\"349\"]},\"description\":null,\"end_time\":null,\"financial_responsibility_type\":{\"code\":\"SELF\",\"codeSystem\":\"HL7 Relationship Code\"},\"health_record_field\":null,\"member_id\":\"1234567890\",\"mood_code\":\"EVN\",\"name\":\"Other\",\"negationInd\":null,\"negationReason\":null,\"oid\":null,\"payer\":{\"name\":\"Other\"},\"reason\":null,\"relationship\":null,\"specifics\":null,\"start_time\":1199145600,\"status_code\":null,\"time\":null,\"type\":\"OT\"}]"
+    },
+    "qdmVersion": "5.4"
+  }
+}

--- a/test/fixtures/patients/CMS123v7/Test_PatientCharacteristic.json
+++ b/test/fixtures/patients/CMS123v7/Test_PatientCharacteristic.json
@@ -1,0 +1,232 @@
+{
+  "_id": {
+    "$oid": "5b588789b84846559a53f763"
+  },
+  "bundleId": "5a57e977942c6d1e61d32f14",
+  "expectedValues": [
+    {
+      "measure_id": "C0D72444-7C26-4863-9B51-8080F8928A85",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    }
+  ],
+  "familyName": "PatientCharacteristic",
+  "givenNames": [
+    "Test"
+  ],
+  "notes": "",
+  "qdmPatient": {
+    "_id": {
+      "$oid": "5c880143d7c8ac4c3e106753"
+    },
+    "birthDatetime": "1970-01-01T08:00:00.000+00:00",
+    "dataElements": [
+      {
+        "_id": {
+          "$oid": "5c880143d7c8ac4c3e106754"
+        },
+        "dataElementCodes": [
+          {
+            "codeSystem": "Source of Payment Typology",
+            "code": "1"
+          }
+        ],
+        "description": "Patient Characteristic Payer: Payer",
+        "hqmfOid": "2.16.840.1.113883.3.560.1.405",
+        "id": {
+          "_id": {
+            "$oid": "5c880143d7c8ac4c3e106755"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5b588789b84846559a53f764"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "payer",
+        "qdmVersion": "5.4",
+        "relevantPeriod": {
+          "low": "2012-07-25T08:00:00.000+00:00",
+          "high": "2012-07-25T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "_type": "QDM::PatientCharacteristicPayer"
+      },
+      {
+        "_id": {
+          "$oid": "5c880143d7c8ac4c3e10674e"
+        },
+        "birthDatetime": "1970-01-01T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "code": "21112-8",
+            "codeSystem": "LOINC",
+            "descriptor": null,
+            "codeSystemOid": null,
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.54",
+        "id": {
+          "_id": {
+            "$oid": "5c880143d7c8ac4c3e106756"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880143d7c8ac4c3e10674e"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "birthdate",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicBirthdate"
+      },
+      {
+        "_id": {
+          "$oid": "5c880143d7c8ac4c3e10674f"
+        },
+        "dataElementCodes": [
+          {
+            "code": "2186-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "Not Hispanic or Latino",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.56",
+        "id": {
+          "_id": {
+            "$oid": "5c880143d7c8ac4c3e106757"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880143d7c8ac4c3e10674f"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "ethnicity",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicEthnicity"
+      },
+      {
+        "_id": {
+          "$oid": "5c880143d7c8ac4c3e106750"
+        },
+        "dataElementCodes": [
+          {
+            "code": "1002-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "American Indian or Alaska Native",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.59",
+        "id": {
+          "_id": {
+            "$oid": "5c880143d7c8ac4c3e106758"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880143d7c8ac4c3e106750"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "race",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicRace"
+      },
+      {
+        "_id": {
+          "$oid": "5c880143d7c8ac4c3e106751"
+        },
+        "dataElementCodes": [
+          {
+            "code": "M",
+            "codeSystem": "AdministrativeGender",
+            "descriptor": "M",
+            "codeSystemOid": "2.16.840.1.113883.5.1",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.55",
+        "id": {
+          "_id": {
+            "$oid": "5c880143d7c8ac4c3e106759"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880143d7c8ac4c3e106751"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "gender",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicSex"
+      }
+    ],
+    "extendedData": {
+      "type": null,
+      "measure_ids": [
+        "C0D72444-7C26-4863-9B51-8080F8928A85",
+        null
+      ],
+      "source_data_criteria": [
+        {
+          "negation": false,
+          "definition": "patient_characteristic_payer",
+          "title": "Payer",
+          "description": "Patient Characteristic Payer: Payer",
+          "code_list_id": "2.16.840.1.114222.4.11.3591",
+          "type": "characteristic",
+          "id": "Payer_PatientCharacteristicPayer_028e6363_f1a0_4340_ade5_e8b4d2a93072_source",
+          "start_date": 1343203200000,
+          "end_date": 1343204100000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "C0D72444-7C26-4863-9B51-8080F8928A85",
+          "cms_id": "CMS123v7",
+          "criteria_id": "164d1d173704L",
+          "codes": {
+            "Source of Payment Typology": [
+              "1"
+            ]
+          },
+          "coded_entry_id": {
+            "$oid": "5b588789b84846559a53f764"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "id": "MeasurePeriod",
+          "start_date": 0,
+          "end_date": 0,
+          "references": null
+        }
+      ],
+      "is_shared": null,
+      "origin_data": [
+
+      ],
+      "test_id": null,
+      "medical_record_number": "99ddf802dea6b779a29e71cc5b14688667f72baf9d6816860d1447bbed646713",
+      "medical_record_assigner": "Bonnie",
+      "description": null,
+      "description_category": null,
+      "insurance_providers": "[{\"codes\":{\"SOP\":[\"349\"]},\"description\":null,\"end_time\":null,\"financial_responsibility_type\":{\"code\":\"SELF\",\"codeSystem\":\"HL7 Relationship Code\"},\"health_record_field\":null,\"member_id\":\"1234567890\",\"mood_code\":\"EVN\",\"name\":\"Other\",\"negationInd\":null,\"negationReason\":null,\"oid\":null,\"payer\":{\"name\":\"Other\"},\"reason\":null,\"relationship\":null,\"specifics\":null,\"start_time\":1199145600,\"status_code\":null,\"time\":null,\"type\":\"OT\"}]"
+    },
+    "qdmVersion": "5.4"
+  }
+}

--- a/test/fixtures/patients/CMS12v0/MedAllergyEndIP_DENEXCEPPass.json
+++ b/test/fixtures/patients/CMS12v0/MedAllergyEndIP_DENEXCEPPass.json
@@ -1,0 +1,329 @@
+{
+  "_id": {
+    "$oid": "5c12f47cb848466c63f9afca"
+  },
+  "bundleId": "5a57e977942c6d1e61d32f14",
+  "expectedValues": [
+    {
+      "measure_id": "DEAB0F79-D6C0-4E5C-9866-3DCFFAD0181B",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0,
+      "DENEXCEP": 0
+    }
+  ],
+  "familyName": "DENEXCEPPass",
+  "givenNames": [
+    "MedAllergyEndIP"
+  ],
+  "notes": "",
+  "qdmPatient": {
+    "_id": {
+      "$oid": "5c880149d7c8ac4c3e1068e1"
+    },
+    "birthDatetime": "1989-07-12T08:00:00.000+00:00",
+    "dataElements": [
+      {
+        "_id": {
+          "$oid": "5c880149d7c8ac4c3e1068e2"
+        },
+        "authorDatetime": "2010-02-01T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "RxNorm",
+            "code": "301542"
+          }
+        ],
+        "description": "Allergy/Intolerance: Statin Allergen",
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.119",
+        "id": {
+          "_id": {
+            "$oid": "5c880149d7c8ac4c3e1068e3"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c12f47cb848466c63f9afcb"
+        },
+        "prevalencePeriod": {
+          "low": "2010-02-01T08:00:00.000+00:00",
+          "high": "9999-12-31T23:59:59.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "qdmCategory": "allergy",
+        "qdmStatus": "intolerance",
+        "qdmVersion": "5.4",
+        "severity": null,
+        "type": null,
+        "_type": "QDM::AllergyIntolerance"
+      },
+      {
+        "_id": {
+          "$oid": "5c880149d7c8ac4c3e1068e4"
+        },
+        "admissionSource": null,
+        "authorDatetime": "2012-12-14T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "183452005"
+          }
+        ],
+        "description": "Encounter, Performed: Non-Elective Inpatient Encounter",
+        "diagnoses": [
+          {
+            "code": "111297002",
+            "codeSystem": "SNOMED-CT",
+            "version": null,
+            "descriptor": "Ischemic Stroke"
+          }
+        ],
+        "dischargeDisposition": null,
+        "facilityLocations": [
+
+        ],
+        "hqmfOid": "2.16.840.1.113883.3.560.1.79",
+        "id": {
+          "_id": {
+            "$oid": "5c880149d7c8ac4c3e1068e5"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c12f47cb848466c63f9afcc"
+        },
+        "lengthOfStay": {
+          "value": 0,
+          "unit": "days"
+        },
+        "negationRationale": null,
+        "principalDiagnosis": {
+          "code": "111297002",
+          "codeSystem": "SNOMED-CT",
+          "descriptor": "Ischemic Stroke",
+          "codeSystemOid": null,
+          "version": null
+        },
+        "qdmCategory": "encounter",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "relevantPeriod": {
+          "low": "2012-12-14T08:00:00.000+00:00",
+          "high": "2012-12-14T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "_type": "QDM::EncounterPerformed"
+      },
+      {
+        "_id": {
+          "$oid": "5c880149d7c8ac4c3e1068dc"
+        },
+        "birthDatetime": "1989-07-12T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "code": "21112-8",
+            "codeSystem": "LOINC",
+            "descriptor": null,
+            "codeSystemOid": null,
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.54",
+        "id": {
+          "_id": {
+            "$oid": "5c880149d7c8ac4c3e1068e6"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880149d7c8ac4c3e1068dc"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "birthdate",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicBirthdate"
+      },
+      {
+        "_id": {
+          "$oid": "5c880149d7c8ac4c3e1068dd"
+        },
+        "dataElementCodes": [
+          {
+            "code": "2186-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "Not Hispanic or Latino",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.56",
+        "id": {
+          "_id": {
+            "$oid": "5c880149d7c8ac4c3e1068e7"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880149d7c8ac4c3e1068dd"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "ethnicity",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicEthnicity"
+      },
+      {
+        "_id": {
+          "$oid": "5c880149d7c8ac4c3e1068de"
+        },
+        "dataElementCodes": [
+          {
+            "code": "1002-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "American Indian or Alaska Native",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.59",
+        "id": {
+          "_id": {
+            "$oid": "5c880149d7c8ac4c3e1068e8"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880149d7c8ac4c3e1068de"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "race",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicRace"
+      },
+      {
+        "_id": {
+          "$oid": "5c880149d7c8ac4c3e1068df"
+        },
+        "dataElementCodes": [
+          {
+            "code": "M",
+            "codeSystem": "AdministrativeGender",
+            "descriptor": "M",
+            "codeSystemOid": "2.16.840.1.113883.5.1",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.55",
+        "id": {
+          "_id": {
+            "$oid": "5c880149d7c8ac4c3e1068e9"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880149d7c8ac4c3e1068df"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "gender",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicSex"
+      }
+    ],
+    "extendedData": {
+      "type": null,
+      "measure_ids": [
+        "DEAB0F79-D6C0-4E5C-9866-3DCFFAD0181B",
+        null
+      ],
+      "source_data_criteria": [
+        {
+          "negation": false,
+          "definition": "allergy_intolerance",
+          "title": "Statin Allergen",
+          "description": "Allergy/Intolerance: Statin Allergen",
+          "code_list_id": "2.16.840.1.113883.3.117.1.7.1.423",
+          "type": "allergies_intolerances",
+          "id": "StatinAllergen_Allergy_Intolerance_0465ff33_0f70_4a43_bfa4_e0d58eaf529a_source",
+          "start_date": 1265011200000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "DEAB0F79-D6C0-4E5C-9866-3DCFFAD0181B",
+          "cms_id": "CMS12v0",
+          "criteria_id": "167aa0443c5LU",
+          "codes": {
+            "RxNorm": [
+              "301542"
+            ]
+          },
+          "coded_entry_id": {
+            "$oid": "5c12f47cb848466c63f9afcb"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "encounter",
+          "status": "performed",
+          "title": "Non-Elective Inpatient Encounter",
+          "description": "Encounter, Performed: Non-Elective Inpatient Encounter",
+          "code_list_id": "2.16.840.1.113883.3.117.1.7.1.424",
+          "type": "encounters",
+          "id": "Non_ElectiveInpatientEncounter_EncounterPerformed_2abc795f_73fb_4273_a9da_ae9a84cdca7a_source",
+          "start_date": 1355472000000,
+          "end_date": 1355472900000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+            "PRINCIPAL_DIAGNOSIS": {
+              "type": "CD",
+              "code_list_id": "2.16.840.1.113883.3.117.1.7.1.247",
+              "field_title": "Principal Diagnosis",
+              "title": "Ischemic Stroke"
+            }
+          },
+          "hqmf_set_id": "DEAB0F79-D6C0-4E5C-9866-3DCFFAD0181B",
+          "cms_id": "CMS12v0",
+          "criteria_id": "167aa0abc42Bv",
+          "codes": {
+            "SNOMED-CT": [
+              "183452005"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5c12f47cb848466c63f9afcc"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "id": "MeasurePeriod",
+          "start_date": 0,
+          "end_date": 0,
+          "references": null
+        }
+      ],
+      "is_shared": null,
+      "origin_data": [
+
+      ],
+      "test_id": null,
+      "medical_record_number": "5739baa6fa0456c1b69041eeb6fa7d3f9dbfa0b778ac82a0f14641f6e84f326d",
+      "medical_record_assigner": "Bonnie",
+      "description": null,
+      "description_category": null,
+      "insurance_providers": "[{\"codes\":{\"SOP\":[\"349\"]},\"description\":null,\"end_time\":null,\"financial_responsibility_type\":{\"code\":\"SELF\",\"codeSystem\":\"HL7 Relationship Code\"},\"health_record_field\":null,\"member_id\":\"1234567890\",\"mood_code\":\"EVN\",\"name\":\"Other\",\"negationInd\":null,\"negationReason\":null,\"oid\":null,\"payer\":{\"name\":\"Other\"},\"reason\":null,\"relationship\":null,\"specifics\":null,\"start_time\":1199145600,\"status_code\":null,\"time\":null,\"type\":\"OT\"}]"
+    },
+    "qdmVersion": "5.4"
+  }
+}

--- a/test/fixtures/patients/CMS134v6/Elements_Test.json
+++ b/test/fixtures/patients/CMS134v6/Elements_Test.json
@@ -1,0 +1,1337 @@
+{
+  "_id": {
+    "$oid": "5b6b2161b848461165a3b783"
+  },
+  "bundleId": "5a57e977942c6d1e61d32f14",
+  "expectedValues": [
+    {
+      "measure_id": "7B2A9277-43DA-4D99-9BEE-6AC271A07747",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    }
+  ],
+  "familyName": "Test",
+  "givenNames": [
+    "Elements"
+  ],
+  "notes": "",
+  "qdmPatient": {
+    "_id": {
+      "$oid": "5c88013ad7c8ac4c3e1065f5"
+    },
+    "birthDatetime": "1970-01-01T08:00:00.000+00:00",
+    "dataElements": [
+      {
+        "_id": {
+          "$oid": "5c88013ad7c8ac4c3e1065f6"
+        },
+        "anatomicalLocationSite": {
+          "code": "129151000119102",
+          "codeSystem": "SNOMED-CT",
+          "descriptor": "Kidney Failure",
+          "codeSystemOid": null,
+          "version": null
+        },
+        "authorDatetime": "2012-07-23T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "129151000119102"
+          }
+        ],
+        "description": "Diagnosis: Kidney Failure",
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.110",
+        "id": {
+          "_id": {
+            "$oid": "5c88013ad7c8ac4c3e1065f7"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5b6c2f6cb848464add087399"
+        },
+        "prevalencePeriod": {
+          "low": "2012-07-23T08:00:00.000+00:00",
+          "high": "2012-07-23T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "qdmCategory": "condition",
+        "qdmVersion": "5.4",
+        "qrdaOid": "2.16.840.1.113883.10.20.24.3.135",
+        "severity": {
+          "code": "12178007",
+          "codeSystem": "SNOMED-CT",
+          "descriptor": "Proteinuria",
+          "codeSystemOid": null,
+          "version": null
+        },
+        "_type": "QDM::Diagnosis"
+      },
+      {
+        "_id": {
+          "$oid": "5c88013ad7c8ac4c3e1065f8"
+        },
+        "admissionSource": {
+          "code": "185460008",
+          "codeSystem": "SNOMED-CT",
+          "descriptor": "Home Healthcare Services",
+          "codeSystemOid": null,
+          "version": null
+        },
+        "authorDatetime": "2012-07-23T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "12843005"
+          }
+        ],
+        "description": "Encounter, Performed: Face-to-Face Interaction",
+        "diagnoses": [
+          {
+            "code": "129151000119102",
+            "codeSystem": "SNOMED-CT",
+            "version": null,
+            "descriptor": "Kidney Failure"
+          },
+          {
+            "code": "12178007",
+            "codeSystem": "SNOMED-CT",
+            "version": null,
+            "descriptor": "Proteinuria"
+          },
+          {
+            "code": "105401000119101",
+            "codeSystem": "SNOMED-CT",
+            "version": null,
+            "descriptor": "Diabetes"
+          }
+        ],
+        "dischargeDisposition": {
+          "code": "428361000124107",
+          "codeSystem": "SNOMED-CT",
+          "descriptor": "Discharged to Home for Hospice Care",
+          "codeSystemOid": null,
+          "version": null
+        },
+        "facilityLocations": [
+          {
+            "_id": {
+              "$oid": "5c88013ad7c8ac4c3e1065ee"
+            },
+            "dataElementCodes": [
+
+            ],
+            "description": null,
+            "_type": "QDM::FacilityLocation",
+            "code": {
+              "code": "4525004",
+              "codeSystem": "SNOMED-CT",
+              "descriptor": "Emergency Department Visit",
+              "codeSystemOid": null,
+              "version": null,
+              "_type": "QDM::Code"
+            },
+            "locationPeriod": {
+              "low": "2012-07-23T08:00:00.000+00:00",
+              "high": "2012-07-23T09:00:00.000+00:00",
+              "lowClosed": true,
+              "highClosed": true,
+              "_type": "QDM::Interval"
+            },
+            "qdmVersion": "5.4"
+          },
+          {
+            "_id": {
+              "$oid": "5c88013ad7c8ac4c3e1065ef"
+            },
+            "dataElementCodes": [
+
+            ],
+            "description": null,
+            "_type": "QDM::FacilityLocation",
+            "code": {
+              "code": "185463005",
+              "codeSystem": "SNOMED-CT",
+              "descriptor": "Office Visit",
+              "codeSystemOid": null,
+              "version": null,
+              "_type": "QDM::Code"
+            },
+            "locationPeriod": {
+              "low": "2012-07-23T09:00:00.000+00:00",
+              "high": "2012-07-23T10:00:00.000+00:00",
+              "lowClosed": true,
+              "highClosed": true,
+              "_type": "QDM::Interval"
+            },
+            "qdmVersion": "5.4"
+          }
+        ],
+        "hqmfOid": "2.16.840.1.113883.3.560.1.79",
+        "id": {
+          "_id": {
+            "$oid": "5c88013ad7c8ac4c3e1065f9"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5b6c2f6cb848464add08739a"
+        },
+        "lengthOfStay": {
+          "value": 0,
+          "unit": "days"
+        },
+        "negationRationale": null,
+        "principalDiagnosis": {
+          "code": "105401000119101",
+          "codeSystem": "SNOMED-CT",
+          "descriptor": "Diabetes",
+          "codeSystemOid": null,
+          "version": null
+        },
+        "qdmCategory": "encounter",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "relevantPeriod": {
+          "low": "2012-07-23T08:00:00.000+00:00",
+          "high": "2012-07-23T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "_type": "QDM::EncounterPerformed"
+      },
+      {
+        "_id": {
+          "$oid": "5c88013ad7c8ac4c3e1065fa"
+        },
+        "dataElementCodes": [
+          {
+            "codeSystem": "RxNorm",
+            "code": "1000001"
+          }
+        ],
+        "description": "Medication, Active: ACE Inhibitor or ARB",
+        "dosage": {
+          "value": 60,
+          "unit": "mg"
+        },
+        "frequency": {
+          "code": null,
+          "codeSystem": null,
+          "descriptor": null,
+          "codeSystemOid": null,
+          "version": null
+        },
+        "hqmfOid": "2.16.840.1.113883.3.560.1.13",
+        "id": {
+          "_id": {
+            "$oid": "5c88013ad7c8ac4c3e1065fb"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5b6c2f6cb848464add08739d"
+        },
+        "qdmCategory": "medication",
+        "qdmStatus": "active",
+        "qdmVersion": "5.4",
+        "relevantPeriod": {
+          "low": "2012-07-23T08:00:00.000+00:00",
+          "high": "2012-07-23T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "route": {
+          "code": "180272001",
+          "codeSystem": "SNOMED-CT",
+          "descriptor": "Vascular Access for Dialysis",
+          "codeSystemOid": null,
+          "version": null
+        },
+        "_type": "QDM::MedicationActive"
+      },
+      {
+        "_id": {
+          "$oid": "5c88013ad7c8ac4c3e1065fc"
+        },
+        "authorDatetime": "2012-07-23T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "385763009"
+          }
+        ],
+        "description": "Intervention, Order: Hospice care ambulatory",
+        "hqmfOid": "2.16.840.1.113883.3.560.1.45",
+        "id": {
+          "_id": {
+            "$oid": "5c88013ad7c8ac4c3e1065fd"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5b6c2f6cb848464add08739e"
+        },
+        "negationRationale": null,
+        "qdmCategory": "intervention",
+        "qdmStatus": "order",
+        "qdmVersion": "5.4",
+        "reason": {
+          "code": "G0438",
+          "codeSystem": "HCPCS",
+          "descriptor": "Annual Wellness Visit",
+          "codeSystemOid": null,
+          "version": null
+        },
+        "_type": "QDM::InterventionOrder"
+      },
+      {
+        "_id": {
+          "$oid": "5c88013ad7c8ac4c3e1065fe"
+        },
+        "authorDatetime": "2012-07-23T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "385763009"
+          }
+        ],
+        "description": "Intervention, Performed: Hospice care ambulatory",
+        "hqmfOid": "2.16.840.1.113883.3.560.1.46",
+        "id": {
+          "_id": {
+            "$oid": "5c88013ad7c8ac4c3e1065ff"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5b6c2f6cb848464add08739f"
+        },
+        "negationRationale": null,
+        "qdmCategory": "intervention",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "reason": {
+          "code": "129151000119102",
+          "codeSystem": "SNOMED-CT",
+          "descriptor": "Kidney Failure",
+          "codeSystemOid": null,
+          "version": null
+        },
+        "relevantPeriod": {
+          "low": "2012-07-23T08:00:00.000+00:00",
+          "high": "2012-07-23T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "result": {
+          "code": "419099009",
+          "codeSystem": "SNOMED-CT",
+          "version": null,
+          "descriptor": "Dead"
+        },
+        "status": {
+          "code": "105401000119101",
+          "codeSystem": "SNOMED-CT",
+          "descriptor": "Diabetes",
+          "codeSystemOid": null,
+          "version": null
+        },
+        "_type": "QDM::InterventionPerformed"
+      },
+      {
+        "_id": {
+          "$oid": "5c88013ad7c8ac4c3e106600"
+        },
+        "anatomicalLocationSite": {
+          "code": "12843005",
+          "codeSystem": "SNOMED-CT",
+          "descriptor": "Face-to-Face Interaction",
+          "codeSystemOid": null,
+          "version": null
+        },
+        "authorDatetime": "2012-07-23T08:00:00.000+00:00",
+        "components": [
+
+        ],
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "108241001"
+          }
+        ],
+        "description": "Procedure, Performed: Dialysis Services",
+        "hqmfOid": "2.16.840.1.113883.3.560.1.6",
+        "id": {
+          "_id": {
+            "$oid": "5c88013ad7c8ac4c3e106601"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5b6c2f6cb848464add0873a1"
+        },
+        "incisionDatetime": "2012-07-12T08:00:00.000+00:00",
+        "method": {
+          "code": "11218-5",
+          "codeSystem": "LOINC",
+          "descriptor": "Urine Protein Tests",
+          "codeSystemOid": null,
+          "version": null
+        },
+        "negationRationale": null,
+        "ordinality": {
+          "code": "127013003",
+          "codeSystem": "SNOMED-CT",
+          "descriptor": "Diabetic Nephropathy",
+          "codeSystemOid": null,
+          "version": null
+        },
+        "qdmCategory": "procedure",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "reason": {
+          "code": "12178007",
+          "codeSystem": "SNOMED-CT",
+          "descriptor": "Proteinuria",
+          "codeSystemOid": null,
+          "version": null
+        },
+        "relevantPeriod": {
+          "low": "2012-07-23T08:00:00.000+00:00",
+          "high": "2012-07-23T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "result": {
+          "code": "419099009",
+          "codeSystem": "SNOMED-CT",
+          "version": null,
+          "descriptor": "Dead"
+        },
+        "status": {
+          "code": "419099009",
+          "codeSystem": "SNOMED-CT",
+          "descriptor": "Dead",
+          "codeSystemOid": null,
+          "version": null
+        },
+        "_type": "QDM::ProcedurePerformed"
+      },
+      {
+        "_id": {
+          "$oid": "5c88013ad7c8ac4c3e106602"
+        },
+        "anatomicalLocationSite": null,
+        "authorDatetime": "2012-07-23T08:00:00.000+00:00",
+        "components": [
+          {
+            "result": 56,
+            "code": {
+              "code": "127013003",
+              "codeSystem": "SNOMED-CT",
+              "version": null,
+              "descriptor": null
+            }
+          },
+          {
+            "result": {
+              "code": "12178007",
+              "codeSystem": "SNOMED-CT",
+              "version": null,
+              "descriptor": null
+            },
+            "code": {
+              "code": "11218-5",
+              "codeSystem": "LOINC",
+              "version": null,
+              "descriptor": "Proteinuria"
+            }
+          }
+        ],
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "175899003"
+          }
+        ],
+        "description": "Procedure, Performed: Kidney Transplant",
+        "hqmfOid": "2.16.840.1.113883.3.560.1.6",
+        "id": {
+          "_id": {
+            "$oid": "5c88013ad7c8ac4c3e106603"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5b6c2f6cb848464add0873a3"
+        },
+        "incisionDatetime": null,
+        "method": null,
+        "negationRationale": null,
+        "ordinality": null,
+        "qdmCategory": "procedure",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "relevantPeriod": {
+          "low": "2012-07-23T08:00:00.000+00:00",
+          "high": "2012-07-23T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "result": null,
+        "status": null,
+        "_type": "QDM::ProcedurePerformed"
+      },
+      {
+        "_id": {
+          "$oid": "5c88013ad7c8ac4c3e106604"
+        },
+        "authorDatetime": "2012-07-23T08:00:00.000+00:00",
+        "components": [
+
+        ],
+        "dataElementCodes": [
+          {
+            "codeSystem": "LOINC",
+            "code": "11218-5"
+          }
+        ],
+        "description": "Laboratory Test, Performed: Urine Protein Tests",
+        "hqmfOid": "2.16.840.1.113883.3.560.1.5",
+        "id": {
+          "_id": {
+            "$oid": "5c88013ad7c8ac4c3e106605"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5b6c2f6cb848464add0873a4"
+        },
+        "method": {
+          "code": "180272001",
+          "codeSystem": "SNOMED-CT",
+          "descriptor": "Vascular Access for Dialysis",
+          "codeSystemOid": null,
+          "version": null
+        },
+        "negationRationale": null,
+        "qdmCategory": "laboratory_test",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "reason": {
+          "code": "129151000119102",
+          "codeSystem": "SNOMED-CT",
+          "descriptor": "Kidney Failure",
+          "codeSystemOid": null,
+          "version": null
+        },
+        "referenceRange": {
+          "low": {
+            "unit": "mg",
+            "value": 20
+          },
+          "high": {
+            "unit": "mg",
+            "value": 60
+          },
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "relevantPeriod": {
+          "low": "2012-07-23T08:00:00.000+00:00",
+          "high": "2012-07-23T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "result": {
+          "unit": "mg",
+          "value": 35
+        },
+        "resultDatetime": "2012-07-28T08:00:00.000+00:00",
+        "status": {
+          "code": "428371000124100",
+          "codeSystem": "SNOMED-CT",
+          "descriptor": "Discharged to Health Care Facility for Hospice Care",
+          "codeSystemOid": null,
+          "version": null
+        },
+        "_type": "QDM::LaboratoryTestPerformed"
+      },
+      {
+        "_id": {
+          "$oid": "5c88013ad7c8ac4c3e106606"
+        },
+        "authorDatetime": "2012-07-23T08:00:00.000+00:00",
+        "components": [
+          {
+            "result": {
+              "unit": "mg",
+              "value": 45
+            },
+            "code": {
+              "code": "12178007",
+              "codeSystem": "SNOMED-CT",
+              "version": null,
+              "descriptor": null
+            },
+            "referenceRange": {
+              "low": "20",
+              "high": "60",
+              "lowClosed": true,
+              "highClosed": true
+            }
+          },
+          {
+            "result": {
+              "code": "105401000119101",
+              "codeSystem": "SNOMED-CT",
+              "version": null,
+              "descriptor": null
+            },
+            "code": {
+              "code": "180272001",
+              "codeSystem": "SNOMED-CT",
+              "version": null,
+              "descriptor": "Diabetes"
+            }
+          }
+        ],
+        "dataElementCodes": [
+          {
+            "codeSystem": "LOINC",
+            "code": "12842-1"
+          }
+        ],
+        "description": "Laboratory Test, Performed: Urine Protein Tests",
+        "hqmfOid": "2.16.840.1.113883.3.560.1.5",
+        "id": {
+          "_id": {
+            "$oid": "5c88013ad7c8ac4c3e106607"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5b6c2f6cb848464add0873a6"
+        },
+        "method": null,
+        "negationRationale": null,
+        "qdmCategory": "laboratory_test",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "referenceRange": null,
+        "relevantPeriod": {
+          "low": "2012-07-23T08:00:00.000+00:00",
+          "high": "2012-07-23T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "result": null,
+        "resultDatetime": null,
+        "status": null,
+        "_type": "QDM::LaboratoryTestPerformed"
+      },
+      {
+        "_id": {
+          "$oid": "5c88013ad7c8ac4c3e1065f0"
+        },
+        "birthDatetime": "1970-01-01T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "code": "21112-8",
+            "codeSystem": "LOINC",
+            "descriptor": null,
+            "codeSystemOid": null,
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.54",
+        "id": {
+          "_id": {
+            "$oid": "5c88013ad7c8ac4c3e106608"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013ad7c8ac4c3e1065f0"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "birthdate",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicBirthdate"
+      },
+      {
+        "_id": {
+          "$oid": "5c88013ad7c8ac4c3e1065f1"
+        },
+        "dataElementCodes": [
+          {
+            "code": "2186-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "Not Hispanic or Latino",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.56",
+        "id": {
+          "_id": {
+            "$oid": "5c88013ad7c8ac4c3e106609"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013ad7c8ac4c3e1065f1"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "ethnicity",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicEthnicity"
+      },
+      {
+        "_id": {
+          "$oid": "5c88013ad7c8ac4c3e1065f2"
+        },
+        "dataElementCodes": [
+          {
+            "code": "1002-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "American Indian or Alaska Native",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.59",
+        "id": {
+          "_id": {
+            "$oid": "5c88013ad7c8ac4c3e10660a"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013ad7c8ac4c3e1065f2"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "race",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicRace"
+      },
+      {
+        "_id": {
+          "$oid": "5c88013ad7c8ac4c3e1065f3"
+        },
+        "dataElementCodes": [
+          {
+            "code": "M",
+            "codeSystem": "AdministrativeGender",
+            "descriptor": "M",
+            "codeSystemOid": "2.16.840.1.113883.5.1",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.55",
+        "id": {
+          "_id": {
+            "$oid": "5c88013ad7c8ac4c3e10660b"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013ad7c8ac4c3e1065f3"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "gender",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicSex"
+      }
+    ],
+    "extendedData": {
+      "type": null,
+      "measure_ids": [
+        "7B2A9277-43DA-4D99-9BEE-6AC271A07747",
+        null
+      ],
+      "source_data_criteria": [
+        {
+          "negation": false,
+          "definition": "intervention",
+          "status": "ordered",
+          "title": "Hospicecareambulatory",
+          "description": "Intervention, Order: Hospice care ambulatory",
+          "code_list_id": "2.16.840.1.113762.1.4.1108.15",
+          "type": "interventions",
+          "id": "Hospicecareambulatory_InterventionOrder_95cca057_9695_4ee4_a5bd_eff4b54c6098_source",
+          "start_date": 1343030400000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+            "REASON": {
+              "type": "CD",
+              "code_list_id": "2.16.840.1.113883.3.526.3.1240",
+              "field_title": "Reason",
+              "title": "Annual Wellness Visit"
+            }
+          },
+          "hqmf_set_id": "7B2A9277-43DA-4D99-9BEE-6AC271A07747",
+          "cms_id": "CMS134v6",
+          "criteria_id": "1651a76c4eezO",
+          "codes": {
+            "SNOMED-CT": [
+              "385763009"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5b6c2f6cb848464add08739e"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "diagnosis",
+          "title": "KidneyFailure",
+          "description": "Diagnosis: Kidney Failure",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.109.12.1028",
+          "type": "conditions",
+          "id": "KidneyFailure_Diagnosis_96400e6f_2f81_4eb4_ab44_62586d331790_source",
+          "start_date": 1343030400000,
+          "end_date": 1343031300000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+            "ANATOMICAL_LOCATION_SITE": {
+              "type": "CD",
+              "code_list_id": "2.16.840.1.113883.3.464.1003.109.12.1028",
+              "field_title": "Anatomical Location Site",
+              "title": "Kidney Failure"
+            },
+            "SEVERITY": {
+              "type": "CD",
+              "code_list_id": "2.16.840.1.113883.3.526.3.1003",
+              "field_title": "Severity",
+              "title": "Proteinuria"
+            }
+          },
+          "hqmf_set_id": "7B2A9277-43DA-4D99-9BEE-6AC271A07747",
+          "cms_id": "CMS134v6",
+          "criteria_id": "1651a7738384e",
+          "codes": {
+            "SNOMED-CT": [
+              "129151000119102"
+            ]
+          },
+          "coded_entry_id": {
+            "$oid": "5b6c2f6cb848464add087399"
+          },
+          "code_source": "USER_DEFINED"
+        },
+        {
+          "negation": false,
+          "definition": "encounter",
+          "status": "performed",
+          "title": "Face-to-FaceInteraction",
+          "description": "Encounter, Performed: Face-to-Face Interaction",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.101.12.1048",
+          "type": "encounters",
+          "id": "Face_to_FaceInteraction_EncounterPerformed_40280381_3d61_56a7_013e_62abf57e301a_source",
+          "start_date": 1343030400000,
+          "end_date": 1343031300000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+            "ADMISSION_SOURCE": {
+              "type": "CD",
+              "code_list_id": "2.16.840.1.113883.3.464.1003.101.12.1016",
+              "field_title": "Admission Source",
+              "title": "Home Healthcare Services"
+            },
+            "DIAGNOSIS": {
+              "type": "COL",
+              "values": [
+                {
+                  "type": "CD",
+                  "key": "DIAGNOSIS",
+                  "code_list_id": "2.16.840.1.113883.3.464.1003.109.12.1028",
+                  "field_title": "Diagnosis",
+                  "title": "Kidney Failure"
+                },
+                {
+                  "type": "CD",
+                  "key": "DIAGNOSIS",
+                  "code_list_id": "2.16.840.1.113883.3.526.3.1003",
+                  "field_title": "Diagnosis",
+                  "title": "Proteinuria"
+                }
+              ],
+              "field_title": "Diagnosis"
+            },
+            "DISCHARGE_STATUS": {
+              "type": "CD",
+              "code_list_id": "2.16.840.1.113883.3.117.1.7.1.209",
+              "field_title": "Discharge Disposition",
+              "title": "Discharged to Home for Hospice Care"
+            },
+            "PRINCIPAL_DIAGNOSIS": {
+              "type": "CD",
+              "code_list_id": "2.16.840.1.113883.3.464.1003.103.12.1001",
+              "field_title": "Principal Diagnosis",
+              "title": "Diabetes"
+            },
+            "FACILITY_LOCATION": {
+              "type": "COL",
+              "values": [
+                {
+                  "type": "FAC",
+                  "key": "FACILITY_LOCATION",
+                  "code_list_id": "2.16.840.1.113883.3.117.1.7.1.292",
+                  "field_title": "Facility Location",
+                  "start_date": "07/23/2012",
+                  "start_time": "8:00 AM",
+                  "end_date": "07/23/2012",
+                  "end_time": "9:00 AM",
+                  "value": 1343030400000,
+                  "locationPeriodLow": "07/23/2012 8:00 AM",
+                  "locationPeriodHigh": "07/23/2012 9:00 AM",
+                  "end_value": 1343034000000,
+                  "title": "Emergency Department Visit"
+                },
+                {
+                  "type": "FAC",
+                  "key": "FACILITY_LOCATION",
+                  "code_list_id": "2.16.840.1.113883.3.464.1003.101.12.1001",
+                  "field_title": "Facility Location",
+                  "start_date": "07/23/2012",
+                  "start_time": "9:00 AM",
+                  "end_date": "07/23/2012",
+                  "end_time": "10:00 AM",
+                  "value": 1343034000000,
+                  "locationPeriodLow": "07/23/2012 9:00 AM",
+                  "locationPeriodHigh": "07/23/2012 10:00 AM",
+                  "end_value": 1343037600000,
+                  "title": "Office Visit"
+                }
+              ],
+              "field_title": "Facility Location"
+            }
+          },
+          "hqmf_set_id": "7B2A9277-43DA-4D99-9BEE-6AC271A07747",
+          "cms_id": "CMS134v6",
+          "criteria_id": "1651a78658aJ5",
+          "codes": {
+            "SNOMED-CT": [
+              "12843005"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5b6c2f6cb848464add08739a"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "intervention",
+          "status": "performed",
+          "title": "Hospicecareambulatory",
+          "description": "Intervention, Performed: Hospice care ambulatory",
+          "code_list_id": "2.16.840.1.113762.1.4.1108.15",
+          "type": "interventions",
+          "id": "Hospicecareambulatory_InterventionPerformed_95cca057_9695_4ee4_a5bd_eff4b54c6098_source",
+          "start_date": 1343030400000,
+          "end_date": 1343031300000,
+          "value": [
+            {
+              "type": "CD",
+              "type_cmp": "CD",
+              "code_list_id": "drc-288b28533ea3e20c8bed70cf4e0a8d78afa536cf3be01339e67e189ef32d0b58",
+              "title": "Dead"
+            }
+          ],
+          "references": null,
+          "field_values": {
+            "REASON": {
+              "type": "CD",
+              "code_list_id": "2.16.840.1.113883.3.464.1003.109.12.1028",
+              "field_title": "Reason",
+              "title": "Kidney Failure"
+            },
+            "STATUS": {
+              "type": "CD",
+              "code_list_id": "2.16.840.1.113883.3.464.1003.103.12.1001",
+              "field_title": "Status",
+              "title": "Diabetes"
+            }
+          },
+          "hqmf_set_id": "7B2A9277-43DA-4D99-9BEE-6AC271A07747",
+          "cms_id": "CMS134v6",
+          "criteria_id": "1651a7af0ce5A",
+          "codes": {
+            "SNOMED-CT": [
+              "385763009"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5b6c2f6cb848464add08739f"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "laboratory_test",
+          "status": "performed",
+          "title": "UrineProteinTests",
+          "description": "Laboratory Test, Performed: Urine Protein Tests",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.109.12.1024",
+          "type": "laboratory_tests",
+          "id": "UrineProteinTests_LaboratoryTestPerformed_28120d98_866d_488a_b3c6_4cd573a59048_source",
+          "start_date": 1343030400000,
+          "end_date": 1343031300000,
+          "value": [
+            {
+              "type": "PQ",
+              "type_cmp": "CD",
+              "value": "35",
+              "unit": "mg"
+            }
+          ],
+          "references": null,
+          "field_values": {
+            "REFERENCE_RANGE_HIGH": {
+              "type": "PQ",
+              "code_list_id": "",
+              "field_title": "Reference Range - High",
+              "value": "60",
+              "unit": "mg"
+            },
+            "REFERENCE_RANGE_LOW": {
+              "type": "PQ",
+              "code_list_id": "",
+              "field_title": "Reference Range - Low",
+              "value": "20",
+              "unit": "mg"
+            },
+            "METHOD": {
+              "type": "CD",
+              "code_list_id": "2.16.840.1.113883.3.464.1003.109.12.1011",
+              "field_title": "Method",
+              "title": "Vascular Access for Dialysis"
+            },
+            "REASON": {
+              "type": "CD",
+              "code_list_id": "2.16.840.1.113883.3.464.1003.109.12.1028",
+              "field_title": "Reason",
+              "title": "Kidney Failure"
+            },
+            "RESULT_DATETIME": {
+              "type": "TS",
+              "code_list_id": "",
+              "field_title": "Result Date/Time",
+              "start_date": "07/28/2012",
+              "start_time": "8:00 AM",
+              "value": 1343462400000
+            },
+            "STATUS": {
+              "type": "CD",
+              "code_list_id": "2.16.840.1.113883.3.117.1.7.1.207",
+              "field_title": "Status",
+              "title": "Discharged to Health Care Facility for Hospice Care"
+            }
+          },
+          "hqmf_set_id": "7B2A9277-43DA-4D99-9BEE-6AC271A07747",
+          "cms_id": "CMS134v6",
+          "criteria_id": "1651a7b95aeYP",
+          "codes": {
+            "LOINC": [
+              "11218-5"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5b6c2f6cb848464add0873a4"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "laboratory_test",
+          "status": "performed",
+          "title": "UrineProteinTests",
+          "description": "Laboratory Test, Performed: Urine Protein Tests",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.109.12.1024",
+          "type": "laboratory_tests",
+          "id": "UrineProteinTests_LaboratoryTestPerformed_28120d98_866d_488a_b3c6_4cd573a59048_source",
+          "start_date": 1343030400000,
+          "end_date": 1343031300000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+            "COMPONENT": {
+              "type": "COL",
+              "values": [
+                {
+                  "type": "CMP",
+                  "type_cmp": "PQ",
+                  "key": "COMPONENT",
+                  "code_list_id": "2.16.840.1.113883.3.526.3.1003",
+                  "field_title": "Component",
+                  "code_list_id_cmp": "",
+                  "referenceRangeLow_value": "20",
+                  "referenceRangeLow_unit": "mg",
+                  "referenceRangeHigh_value": "60",
+                  "referenceRangeHigh_unit": "mg",
+                  "title": "Proteinuria",
+                  "value": "45",
+                  "unit": "mg"
+                },
+                {
+                  "type": "CMP",
+                  "key": "COMPONENT",
+                  "code_list_id": "2.16.840.1.113883.3.464.1003.109.12.1011",
+                  "title_cmp": "Diabetes",
+                  "field_title": "Component",
+                  "type_cmp": "CD",
+                  "code_list_id_cmp": "2.16.840.1.113883.3.464.1003.103.12.1001",
+                  "referenceRangeLow_value": "",
+                  "referenceRangeLow_unit": "",
+                  "referenceRangeHigh_value": "",
+                  "referenceRangeHigh_unit": "",
+                  "title": "Vascular Access for Dialysis"
+                }
+              ],
+              "field_title": "Component"
+            }
+          },
+          "hqmf_set_id": "7B2A9277-43DA-4D99-9BEE-6AC271A07747",
+          "cms_id": "CMS134v6",
+          "criteria_id": "1651a7d7903MW",
+          "codes": {
+            "LOINC": [
+              "12842-1"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5b6c2f6cb848464add0873a6"
+          },
+          "code_source": "USER_DEFINED"
+        },
+        {
+          "negation": false,
+          "definition": "medication",
+          "status": "active",
+          "title": "ACEInhibitororARB",
+          "description": "Medication, Active: ACE Inhibitor or ARB",
+          "code_list_id": "2.16.840.1.113883.3.526.3.1139",
+          "type": "medications",
+          "id": "ACEInhibitororARB_MedicationActive_40280381_3d61_56a7_013e_62abf57e301b_source",
+          "start_date": 1343030400000,
+          "end_date": 1343031300000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+            "SUPPLY": {
+              "type": "PQ",
+              "code_list_id": "",
+              "field_title": "Supply",
+              "value": "60",
+              "unit": "{pills}"
+            },
+            "DOSE": {
+              "type": "PQ",
+              "code_list_id": "",
+              "field_title": "Dosage",
+              "value": "60",
+              "unit": "mg"
+            },
+            "FREQUENCY": {
+              "type": "PQ",
+              "code_list_id": "",
+              "field_title": "Frequency",
+              "value": "1",
+              "unit": "mg/day"
+            },
+            "ROUTE": {
+              "type": "CD",
+              "code_list_id": "2.16.840.1.113883.3.464.1003.109.12.1011",
+              "field_title": "Route",
+              "title": "Vascular Access for Dialysis"
+            }
+          },
+          "hqmf_set_id": "7B2A9277-43DA-4D99-9BEE-6AC271A07747",
+          "cms_id": "CMS134v6",
+          "criteria_id": "1651a7ef215WS",
+          "codes": {
+            "RxNorm": [
+              "1000001"
+            ]
+          },
+          "coded_entry_id": {
+            "$oid": "5b6c2f6cb848464add08739d"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "procedure",
+          "status": "performed",
+          "title": "DialysisServices",
+          "description": "Procedure, Performed: Dialysis Services",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.109.12.1013",
+          "type": "procedures",
+          "id": "DialysisServices_ProcedurePerformed_40280381_3d61_56a7_013e_62abf57d300e_source",
+          "start_date": 1343030400000,
+          "end_date": 1343031300000,
+          "value": [
+            {
+              "type": "CD",
+              "type_cmp": "CD",
+              "code_list_id": "drc-288b28533ea3e20c8bed70cf4e0a8d78afa536cf3be01339e67e189ef32d0b58",
+              "title": "Dead"
+            }
+          ],
+          "references": null,
+          "field_values": {
+            "ANATOMICAL_LOCATION_SITE": {
+              "type": "CD",
+              "code_list_id": "2.16.840.1.113883.3.464.1003.101.12.1048",
+              "field_title": "Anatomical Location Site",
+              "title": "Face-to-Face Interaction"
+            },
+            "INCISION_DATETIME": {
+              "type": "TS",
+              "code_list_id": "",
+              "field_title": "Incision Date/Time",
+              "start_date": "07/12/2012",
+              "start_time": "8:00 AM",
+              "value": 1342080000000
+            },
+            "METHOD": {
+              "type": "CD",
+              "code_list_id": "2.16.840.1.113883.3.464.1003.109.12.1024",
+              "field_title": "Method",
+              "title": "Urine Protein Tests"
+            },
+            "REASON": {
+              "type": "CD",
+              "code_list_id": "2.16.840.1.113883.3.526.3.1003",
+              "field_title": "Reason",
+              "title": "Proteinuria"
+            },
+            "STATUS": {
+              "type": "CD",
+              "code_list_id": "drc-288b28533ea3e20c8bed70cf4e0a8d78afa536cf3be01339e67e189ef32d0b58",
+              "field_title": "Status",
+              "title": "Dead"
+            },
+            "ORDINAL": {
+              "type": "CD",
+              "code_list_id": "2.16.840.1.113883.3.464.1003.109.12.1004",
+              "field_title": "Ordinality",
+              "title": "Diabetic Nephropathy"
+            }
+          },
+          "hqmf_set_id": "7B2A9277-43DA-4D99-9BEE-6AC271A07747",
+          "cms_id": "CMS134v6",
+          "criteria_id": "1651a801eecs0",
+          "codes": {
+            "SNOMED-CT": [
+              "108241001"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5b6c2f6cb848464add0873a1"
+          },
+          "code_source": "USER_DEFINED"
+        },
+        {
+          "negation": false,
+          "definition": "procedure",
+          "status": "performed",
+          "title": "KidneyTransplant",
+          "description": "Procedure, Performed: Kidney Transplant",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.109.12.1012",
+          "type": "procedures",
+          "id": "KidneyTransplant_ProcedurePerformed_40280381_3d61_56a7_013e_62abf57d300c_source",
+          "start_date": 1343030400000,
+          "end_date": 1343031300000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+            "COMPONENT": {
+              "type": "COL",
+              "values": [
+                {
+                  "type": "CMP",
+                  "type_cmp": "PQ",
+                  "key": "COMPONENT",
+                  "code_list_id": "2.16.840.1.113883.3.464.1003.109.12.1004",
+                  "field_title": "Component",
+                  "code_list_id_cmp": "",
+                  "title": "Diabetic Nephropathy",
+                  "value": "56",
+                  "unit": ""
+                },
+                {
+                  "type": "CMP",
+                  "key": "COMPONENT",
+                  "code_list_id": "2.16.840.1.113883.3.464.1003.109.12.1024",
+                  "title_cmp": "Proteinuria",
+                  "field_title": "Component",
+                  "type_cmp": "CD",
+                  "code_list_id_cmp": "2.16.840.1.113883.3.526.3.1003",
+                  "title": "Urine Protein Tests"
+                }
+              ],
+              "field_title": "Component"
+            }
+          },
+          "hqmf_set_id": "7B2A9277-43DA-4D99-9BEE-6AC271A07747",
+          "cms_id": "CMS134v6",
+          "criteria_id": "1651a8153dbOs",
+          "codes": {
+            "SNOMED-CT": [
+              "175899003"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5b6c2f6cb848464add0873a3"
+          },
+          "code_source": "USER_DEFINED"
+        },
+        {
+          "id": "MeasurePeriod",
+          "start_date": 0,
+          "end_date": 0,
+          "references": null
+        }
+      ],
+      "is_shared": null,
+      "origin_data": [
+
+      ],
+      "test_id": null,
+      "medical_record_number": "311fb11d919d608cffe0b352235bac8b505f9c29b9b0f7f1f58c26e94aa26844",
+      "medical_record_assigner": "Bonnie",
+      "description": null,
+      "description_category": null,
+      "insurance_providers": "[{\"codes\":{\"SOP\":[\"349\"]},\"description\":null,\"end_time\":null,\"financial_responsibility_type\":{\"code\":\"SELF\",\"codeSystem\":\"HL7 Relationship Code\"},\"health_record_field\":null,\"member_id\":\"1234567890\",\"mood_code\":\"EVN\",\"name\":\"Other\",\"negationInd\":null,\"negationReason\":null,\"oid\":null,\"payer\":{\"name\":\"Other\"},\"reason\":null,\"relationship\":null,\"specifics\":null,\"start_time\":1199145600,\"status_code\":null,\"time\":null,\"type\":\"OT\"}]"
+    },
+    "qdmVersion": "5.4"
+  }
+}

--- a/test/fixtures/patients/CMS134v6/Fail_Hospice_Not_Performed_Denex.json
+++ b/test/fixtures/patients/CMS134v6/Fail_Hospice_Not_Performed_Denex.json
@@ -1,0 +1,375 @@
+{
+  "_id": {
+    "$oid": "5a73955cb848465f695c4ecb"
+  },
+  "bundleId": "5a57e977942c6d1e61d32f14",
+  "expectedValues": [
+    {
+      "measure_id": "7B2A9277-43DA-4D99-9BEE-6AC271A07747",
+      "population_index": 0,
+      "IPP": 1,
+      "DENOM": 1,
+      "DENEX": 0,
+      "NUMER": 0
+    }
+  ],
+  "familyName": "Denex",
+  "givenNames": [
+    "Fail_Hospice_Not_Performed"
+  ],
+  "notes": "",
+  "qdmPatient": {
+    "_id": {
+      "$oid": "5c88013ad7c8ac4c3e1065e3"
+    },
+    "birthDatetime": "1937-07-01T08:00:00.000+00:00",
+    "dataElements": [
+      {
+        "_id": {
+          "$oid": "5c88013ad7c8ac4c3e1065e4"
+        },
+        "anatomicalLocationSite": null,
+        "authorDatetime": "1949-02-17T09:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "190372001"
+          }
+        ],
+        "description": "Diagnosis: Diabetes",
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.110",
+        "id": {
+          "_id": {
+            "$oid": "5c88013ad7c8ac4c3e1065e5"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5aeb7764b848463d625b3424"
+        },
+        "prevalencePeriod": {
+          "low": "1949-02-17T09:00:00.000+00:00",
+          "high": "9999-12-31T23:59:59.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "qdmCategory": "condition",
+        "qdmVersion": "5.4",
+        "qrdaOid": "2.16.840.1.113883.10.20.24.3.135",
+        "severity": null,
+        "_type": "QDM::Diagnosis"
+      },
+      {
+        "_id": {
+          "$oid": "5c88013ad7c8ac4c3e1065e6"
+        },
+        "admissionSource": null,
+        "authorDatetime": "2012-02-02T08:45:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "HCPCS",
+            "code": "G0438"
+          }
+        ],
+        "description": "Encounter, Performed: Annual Wellness Visit",
+        "diagnoses": [
+
+        ],
+        "dischargeDisposition": null,
+        "facilityLocations": [
+
+        ],
+        "hqmfOid": "2.16.840.1.113883.3.560.1.79",
+        "id": {
+          "_id": {
+            "$oid": "5c88013ad7c8ac4c3e1065e7"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5aeb7764b848463d625b3425"
+        },
+        "lengthOfStay": {
+          "value": 0,
+          "unit": "days"
+        },
+        "negationRationale": null,
+        "principalDiagnosis": null,
+        "qdmCategory": "encounter",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "relevantPeriod": {
+          "low": "2012-02-02T08:45:00.000+00:00",
+          "high": "2012-02-02T08:45:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "_type": "QDM::EncounterPerformed"
+      },
+      {
+        "_id": {
+          "$oid": "5c88013ad7c8ac4c3e1065e8"
+        },
+        "authorDatetime": "2012-01-31T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "385763009"
+          }
+        ],
+        "description": "Intervention, Order: Hospice care ambulatory",
+        "hqmfOid": "2.16.840.1.113883.3.560.1.145",
+        "id": {
+          "_id": {
+            "$oid": "5c88013ad7c8ac4c3e1065e9"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5aeb7764b848463d625b3426"
+        },
+        "negationRationale": {
+          "code": "4525004",
+          "codeSystem": "SNOMED-CT",
+          "descriptor": null,
+          "codeSystemOid": null,
+          "version": null
+        },
+        "qdmCategory": "intervention",
+        "qdmStatus": "order",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "_type": "QDM::InterventionOrder"
+      },
+      {
+        "_id": {
+          "$oid": "5c88013ad7c8ac4c3e1065de"
+        },
+        "birthDatetime": "1937-07-01T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "code": "21112-8",
+            "codeSystem": "LOINC",
+            "descriptor": null,
+            "codeSystemOid": null,
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.54",
+        "id": {
+          "_id": {
+            "$oid": "5c88013ad7c8ac4c3e1065ea"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013ad7c8ac4c3e1065de"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "birthdate",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicBirthdate"
+      },
+      {
+        "_id": {
+          "$oid": "5c88013ad7c8ac4c3e1065df"
+        },
+        "dataElementCodes": [
+          {
+            "code": "2186-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "Not Hispanic or Latino",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.56",
+        "id": {
+          "_id": {
+            "$oid": "5c88013ad7c8ac4c3e1065eb"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013ad7c8ac4c3e1065df"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "ethnicity",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicEthnicity"
+      },
+      {
+        "_id": {
+          "$oid": "5c88013ad7c8ac4c3e1065e0"
+        },
+        "dataElementCodes": [
+          {
+            "code": "1002-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "American Indian or Alaska Native",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.59",
+        "id": {
+          "_id": {
+            "$oid": "5c88013ad7c8ac4c3e1065ec"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013ad7c8ac4c3e1065e0"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "race",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicRace"
+      },
+      {
+        "_id": {
+          "$oid": "5c88013ad7c8ac4c3e1065e1"
+        },
+        "dataElementCodes": [
+          {
+            "code": "F",
+            "codeSystem": "AdministrativeGender",
+            "descriptor": "F",
+            "codeSystemOid": "2.16.840.1.113883.5.1",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.55",
+        "id": {
+          "_id": {
+            "$oid": "5c88013ad7c8ac4c3e1065ed"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013ad7c8ac4c3e1065e1"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "gender",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicSex"
+      }
+    ],
+    "extendedData": {
+      "type": null,
+      "measure_ids": [
+        "7B2A9277-43DA-4D99-9BEE-6AC271A07747",
+        null
+      ],
+      "source_data_criteria": [
+        {
+          "negation": false,
+          "definition": "diagnosis",
+          "title": "Diabetes",
+          "description": "Diagnosis: Diabetes",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.103.12.1001",
+          "type": "conditions",
+          "id": "Diabetes_Diagnosis_40280381_3d61_56a7_013e_62abf57d3006_source",
+          "start_date": -658594800000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "7B2A9277-43DA-4D99-9BEE-6AC271A07747",
+          "cms_id": "CMS134v6",
+          "criteria_id": "160eb64a4ffoq",
+          "codes": {
+            "SNOMED-CT": [
+              "190372001"
+            ]
+          },
+          "coded_entry_id": {
+            "$oid": "5aeb7764b848463d625b3424"
+          },
+          "code_source": "USER_DEFINED"
+        },
+        {
+          "negation": true,
+          "definition": "intervention",
+          "status": "ordered",
+          "title": "Hospicecareambulatory",
+          "description": "Intervention, Order: Hospice care ambulatory",
+          "code_list_id": "2.16.840.1.113762.1.4.1108.15",
+          "type": "interventions",
+          "id": "Hospicecareambulatory_InterventionOrder_95cca057_9695_4ee4_a5bd_eff4b54c6098_source",
+          "start_date": 1327996800000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "7B2A9277-43DA-4D99-9BEE-6AC271A07747",
+          "cms_id": "CMS134v6",
+          "criteria_id": "161537f0ab83k",
+          "codes": {
+            "SNOMED-CT": [
+              "385763009"
+            ]
+          },
+          "negation_code_list_id": "2.16.840.1.113883.3.117.1.7.1.292",
+          "coded_entry_id": {
+            "$oid": "5aeb7764b848463d625b3426"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "encounter",
+          "status": "performed",
+          "title": "AnnualWellnessVisit",
+          "description": "Encounter, Performed: Annual Wellness Visit",
+          "code_list_id": "2.16.840.1.113883.3.526.3.1240",
+          "type": "encounters",
+          "id": "AnnualWellnessVisit_EncounterPerformed_40280381_3d61_56a7_013e_62abf57e3022_source",
+          "start_date": 1328172300000,
+          "end_date": 1328172300000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "7B2A9277-43DA-4D99-9BEE-6AC271A07747",
+          "cms_id": "CMS134v6",
+          "criteria_id": "160eb65f2eaz2",
+          "codes": {
+            "HCPCS": [
+              "G0438"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5aeb7764b848463d625b3425"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "id": "MeasurePeriod",
+          "start_date": 0,
+          "end_date": 0,
+          "references": null
+        }
+      ],
+      "is_shared": null,
+      "origin_data": [
+
+      ],
+      "test_id": null,
+      "medical_record_number": "07490a6ba93a8d1d0252541c260e02e7f7efdaae5ef3613011dff6ce4c0dbd42",
+      "medical_record_assigner": "Bonnie",
+      "description": null,
+      "description_category": null,
+      "insurance_providers": "[]"
+    },
+    "qdmVersion": "5.4"
+  }
+}

--- a/test/fixtures/patients/CMS136v7/Pass_IPP1.json
+++ b/test/fixtures/patients/CMS136v7/Pass_IPP1.json
@@ -1,0 +1,341 @@
+{
+  "_id": {
+    "$oid": "5a7dc63db8484620c5183d39"
+  },
+  "bundleId": "5a57e977942c6d1e61d32f14",
+  "expectedValues": [
+    {
+      "measure_id": "703CC49B-B653-4885-80E8-245A057F5AE9",
+      "population_index": 0,
+      "IPP": 1,
+      "DENOM": 1,
+      "DENEX": 0,
+      "NUMER": 1
+    },
+    {
+      "measure_id": "703CC49B-B653-4885-80E8-245A057F5AE9",
+      "population_index": 1,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    }
+  ],
+  "familyName": "IPP1",
+  "givenNames": [
+    "Pass"
+  ],
+  "notes": "",
+  "qdmPatient": {
+    "_id": {
+      "$oid": "5c88013ed7c8ac4c3e10669b"
+    },
+    "birthDatetime": "2005-02-01T08:00:00.000+00:00",
+    "dataElements": [
+      {
+        "_id": {
+          "$oid": "5c88013ed7c8ac4c3e10669c"
+        },
+        "admissionSource": null,
+        "authorDatetime": "2012-02-09T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "185463005"
+          },
+          {
+            "codeSystem": "CPT",
+            "code": "99201"
+          }
+        ],
+        "description": "Encounter, Performed: Office Visit",
+        "diagnoses": [
+
+        ],
+        "dischargeDisposition": null,
+        "facilityLocations": [
+
+        ],
+        "hqmfOid": "2.16.840.1.113883.3.560.1.79",
+        "id": {
+          "_id": {
+            "$oid": "5c88013ed7c8ac4c3e10669d"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5aeb7734b848463d625b2038"
+        },
+        "lengthOfStay": {
+          "value": 0,
+          "unit": "days"
+        },
+        "negationRationale": null,
+        "principalDiagnosis": null,
+        "qdmCategory": "encounter",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "relevantPeriod": {
+          "low": "2012-02-09T08:00:00.000+00:00",
+          "high": "2012-02-09T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "_type": "QDM::EncounterPerformed"
+      },
+      {
+        "_id": {
+          "$oid": "5c88013ed7c8ac4c3e10669e"
+        },
+        "authorDatetime": "2012-02-09T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "RxNorm",
+            "code": "1006608"
+          }
+        ],
+        "daysSupplied": null,
+        "description": "Medication, Dispensed: ADHD Medications",
+        "dispenserId": null,
+        "dosage": null,
+        "frequency": null,
+        "hqmfOid": "2.16.840.1.113883.3.560.1.8",
+        "id": {
+          "_id": {
+            "$oid": "5c88013ed7c8ac4c3e10669f"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5aeb7734b848463d625b2039"
+        },
+        "negationRationale": null,
+        "prescriberId": null,
+        "qdmCategory": "medication",
+        "qdmStatus": "dispensed",
+        "qdmVersion": "5.4",
+        "refills": null,
+        "relevantPeriod": {
+          "low": "2012-02-09T08:00:00.000+00:00",
+          "high": "2012-02-09T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "route": null,
+        "supply": null,
+        "_type": "QDM::MedicationDispensed"
+      },
+      {
+        "_id": {
+          "$oid": "5c88013ed7c8ac4c3e106696"
+        },
+        "birthDatetime": "2005-02-01T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "code": "21112-8",
+            "codeSystem": "LOINC",
+            "descriptor": null,
+            "codeSystemOid": null,
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.54",
+        "id": {
+          "_id": {
+            "$oid": "5c88013ed7c8ac4c3e1066a0"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013ed7c8ac4c3e106696"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "birthdate",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicBirthdate"
+      },
+      {
+        "_id": {
+          "$oid": "5c88013ed7c8ac4c3e106697"
+        },
+        "dataElementCodes": [
+          {
+            "code": "2186-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "Not Hispanic or Latino",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.56",
+        "id": {
+          "_id": {
+            "$oid": "5c88013ed7c8ac4c3e1066a1"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013ed7c8ac4c3e106697"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "ethnicity",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicEthnicity"
+      },
+      {
+        "_id": {
+          "$oid": "5c88013ed7c8ac4c3e106698"
+        },
+        "dataElementCodes": [
+          {
+            "code": "1002-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "American Indian or Alaska Native",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.59",
+        "id": {
+          "_id": {
+            "$oid": "5c88013ed7c8ac4c3e1066a2"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013ed7c8ac4c3e106698"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "race",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicRace"
+      },
+      {
+        "_id": {
+          "$oid": "5c88013ed7c8ac4c3e106699"
+        },
+        "dataElementCodes": [
+          {
+            "code": "M",
+            "codeSystem": "AdministrativeGender",
+            "descriptor": "M",
+            "codeSystemOid": "2.16.840.1.113883.5.1",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.55",
+        "id": {
+          "_id": {
+            "$oid": "5c88013ed7c8ac4c3e1066a3"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013ed7c8ac4c3e106699"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "gender",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicSex"
+      }
+    ],
+    "extendedData": {
+      "type": null,
+      "measure_ids": [
+        "703CC49B-B653-4885-80E8-245A057F5AE9",
+        null
+      ],
+      "source_data_criteria": [
+        {
+          "negation": false,
+          "definition": "encounter",
+          "status": "performed",
+          "title": "OfficeVisit",
+          "description": "Encounter, Performed: Office Visit",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.101.12.1001",
+          "type": "encounters",
+          "id": "OfficeVisit_EncounterPerformed_40280381_3d61_56a7_013e_62e0524536ae_source",
+          "start_date": 1328774400000,
+          "end_date": 1328775300000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "703CC49B-B653-4885-80E8-245A057F5AE9",
+          "cms_id": "CMS136v7",
+          "criteria_id": "1617b4e4764Cu",
+          "codes": {
+            "SNOMED-CT": [
+              "185463005"
+            ],
+            "CPT": [
+              "99201"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5aeb7734b848463d625b2038"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "medication",
+          "status": "dispensed",
+          "title": "ADHDMedications",
+          "description": "Medication, Dispensed: ADHD Medications",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.196.12.1171",
+          "type": "medications",
+          "id": "ADHDMedications_MedicationDispensed_40280381_3d61_56a7_013e_62e0524536a7_source",
+          "start_date": 1328774400000,
+          "end_date": 1328775300000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "703CC49B-B653-4885-80E8-245A057F5AE9",
+          "cms_id": "CMS136v7",
+          "criteria_id": "1617b4e684fqB",
+          "codes": {
+            "RxNorm": [
+              "1006608"
+            ]
+          },
+          "fulfillments": null,
+          "dose_value": "",
+          "dose_unit": "{Capsule}",
+          "frequency_value": "",
+          "frequency_unit": "min",
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5aeb7734b848463d625b2039"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "id": "MeasurePeriod",
+          "start_date": 0,
+          "end_date": 0,
+          "references": null
+        }
+      ],
+      "is_shared": null,
+      "origin_data": [
+
+      ],
+      "test_id": null,
+      "medical_record_number": "b7ad2cc9e2a89ba7961791d541d1fd41970d60549e86ec25038e859fcab42ae0",
+      "medical_record_assigner": "Bonnie",
+      "description": null,
+      "description_category": null,
+      "insurance_providers": "[]"
+    },
+    "qdmVersion": "5.4"
+  }
+}

--- a/test/fixtures/patients/CMS136v7/Pass_IPP2.json
+++ b/test/fixtures/patients/CMS136v7/Pass_IPP2.json
@@ -1,0 +1,410 @@
+{
+  "_id": {
+    "$oid": "5a7dc67fb8484620c5183d68"
+  },
+  "bundleId": "5a57e977942c6d1e61d32f14",
+  "expectedValues": [
+    {
+      "measure_id": "703CC49B-B653-4885-80E8-245A057F5AE9",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "703CC49B-B653-4885-80E8-245A057F5AE9",
+      "population_index": 1,
+      "IPP": 1,
+      "DENOM": 1,
+      "DENEX": 1,
+      "NUMER": 0
+    }
+  ],
+  "familyName": "IPP2",
+  "givenNames": [
+    "Pass"
+  ],
+  "notes": "",
+  "qdmPatient": {
+    "_id": {
+      "$oid": "5c88013ed7c8ac4c3e1066a9"
+    },
+    "birthDatetime": "2005-02-02T08:00:00.000+00:00",
+    "dataElements": [
+      {
+        "_id": {
+          "$oid": "5c88013ed7c8ac4c3e1066aa"
+        },
+        "admissionSource": null,
+        "authorDatetime": "2012-02-09T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "185463005"
+          },
+          {
+            "codeSystem": "CPT",
+            "code": "99201"
+          }
+        ],
+        "description": "Encounter, Performed: Office Visit",
+        "diagnoses": [
+
+        ],
+        "dischargeDisposition": null,
+        "facilityLocations": [
+
+        ],
+        "hqmfOid": "2.16.840.1.113883.3.560.1.79",
+        "id": {
+          "_id": {
+            "$oid": "5c88013ed7c8ac4c3e1066ab"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5aeb7734b848463d625b203a"
+        },
+        "lengthOfStay": {
+          "value": 0,
+          "unit": "days"
+        },
+        "negationRationale": null,
+        "principalDiagnosis": null,
+        "qdmCategory": "encounter",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "relevantPeriod": {
+          "low": "2012-02-09T08:00:00.000+00:00",
+          "high": "2012-02-09T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "_type": "QDM::EncounterPerformed"
+      },
+      {
+        "_id": {
+          "$oid": "5c88013ed7c8ac4c3e1066ac"
+        },
+        "authorDatetime": "2012-02-09T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "RxNorm",
+            "code": "1006608"
+          }
+        ],
+        "daysSupplied": null,
+        "description": "Medication, Dispensed: ADHD Medications",
+        "dispenserId": null,
+        "dosage": null,
+        "frequency": null,
+        "hqmfOid": "2.16.840.1.113883.3.560.1.8",
+        "id": {
+          "_id": {
+            "$oid": "5c88013ed7c8ac4c3e1066ad"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5aeb7734b848463d625b203b"
+        },
+        "negationRationale": null,
+        "prescriberId": null,
+        "qdmCategory": "medication",
+        "qdmStatus": "dispensed",
+        "qdmVersion": "5.4",
+        "refills": null,
+        "relevantPeriod": {
+          "low": "2012-02-09T08:00:00.000+00:00",
+          "high": "2012-02-09T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "route": null,
+        "supply": null,
+        "_type": "QDM::MedicationDispensed"
+      },
+      {
+        "_id": {
+          "$oid": "5c88013ed7c8ac4c3e1066ae"
+        },
+        "dataElementCodes": [
+          {
+            "codeSystem": "RxNorm",
+            "code": "1006608"
+          }
+        ],
+        "description": "Medication, Active: ADHD Medications",
+        "dosage": null,
+        "frequency": null,
+        "hqmfOid": "2.16.840.1.113883.3.560.1.13",
+        "id": {
+          "_id": {
+            "$oid": "5c88013ed7c8ac4c3e1066af"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5aeb7734b848463d625b203c"
+        },
+        "qdmCategory": "medication",
+        "qdmStatus": "active",
+        "qdmVersion": "5.4",
+        "relevantPeriod": {
+          "low": "2012-02-09T08:00:00.000+00:00",
+          "high": "2012-12-09T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "route": null,
+        "_type": "QDM::MedicationActive"
+      },
+      {
+        "_id": {
+          "$oid": "5c88013ed7c8ac4c3e1066a4"
+        },
+        "birthDatetime": "2005-02-02T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "code": "21112-8",
+            "codeSystem": "LOINC",
+            "descriptor": null,
+            "codeSystemOid": null,
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.54",
+        "id": {
+          "_id": {
+            "$oid": "5c88013ed7c8ac4c3e1066b0"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013ed7c8ac4c3e1066a4"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "birthdate",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicBirthdate"
+      },
+      {
+        "_id": {
+          "$oid": "5c88013ed7c8ac4c3e1066a5"
+        },
+        "dataElementCodes": [
+          {
+            "code": "2186-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "Not Hispanic or Latino",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.56",
+        "id": {
+          "_id": {
+            "$oid": "5c88013ed7c8ac4c3e1066b1"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013ed7c8ac4c3e1066a5"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "ethnicity",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicEthnicity"
+      },
+      {
+        "_id": {
+          "$oid": "5c88013ed7c8ac4c3e1066a6"
+        },
+        "dataElementCodes": [
+          {
+            "code": "1002-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "American Indian or Alaska Native",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.59",
+        "id": {
+          "_id": {
+            "$oid": "5c88013ed7c8ac4c3e1066b2"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013ed7c8ac4c3e1066a6"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "race",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicRace"
+      },
+      {
+        "_id": {
+          "$oid": "5c88013ed7c8ac4c3e1066a7"
+        },
+        "dataElementCodes": [
+          {
+            "code": "M",
+            "codeSystem": "AdministrativeGender",
+            "descriptor": "M",
+            "codeSystemOid": "2.16.840.1.113883.5.1",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.55",
+        "id": {
+          "_id": {
+            "$oid": "5c88013ed7c8ac4c3e1066b3"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013ed7c8ac4c3e1066a7"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "gender",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicSex"
+      }
+    ],
+    "extendedData": {
+      "type": null,
+      "measure_ids": [
+        "703CC49B-B653-4885-80E8-245A057F5AE9",
+        null
+      ],
+      "source_data_criteria": [
+        {
+          "negation": false,
+          "definition": "encounter",
+          "status": "performed",
+          "title": "OfficeVisit",
+          "description": "Encounter, Performed: Office Visit",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.101.12.1001",
+          "type": "encounters",
+          "id": "OfficeVisit_EncounterPerformed_40280381_3d61_56a7_013e_62e0524536ae_source",
+          "start_date": 1328774400000,
+          "end_date": 1328775300000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "703CC49B-B653-4885-80E8-245A057F5AE9",
+          "cms_id": "CMS136v7",
+          "criteria_id": "1617b4f2f27a5",
+          "codes": {
+            "SNOMED-CT": [
+              "185463005"
+            ],
+            "CPT": [
+              "99201"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5aeb7734b848463d625b203a"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "medication",
+          "status": "dispensed",
+          "title": "ADHDMedications",
+          "description": "Medication, Dispensed: ADHD Medications",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.196.12.1171",
+          "type": "medications",
+          "id": "ADHDMedications_MedicationDispensed_40280381_3d61_56a7_013e_62e0524536a7_source",
+          "start_date": 1328774400000,
+          "end_date": 1328775300000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "703CC49B-B653-4885-80E8-245A057F5AE9",
+          "cms_id": "CMS136v7",
+          "criteria_id": "1617b4f4941uT",
+          "codes": {
+            "RxNorm": [
+              "1006608"
+            ]
+          },
+          "fulfillments": null,
+          "dose_value": "",
+          "dose_unit": "{Capsule}",
+          "frequency_value": "",
+          "frequency_unit": "min",
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5aeb7734b848463d625b203b"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "medication",
+          "status": "active",
+          "title": "ADHDMedications",
+          "description": "Medication, Active: ADHD Medications",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.196.12.1171",
+          "type": "medications",
+          "id": "ADHDMedications_MedicationActive_40280381_3d61_56a7_013e_62e0524536a7_source",
+          "start_date": 1328774400000,
+          "end_date": 1355040900000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "703CC49B-B653-4885-80E8-245A057F5AE9",
+          "cms_id": "CMS136v7",
+          "criteria_id": "1617b4f5d84zD",
+          "codes": {
+            "RxNorm": [
+              "1006608"
+            ]
+          },
+          "fulfillments": null,
+          "dose_value": "",
+          "dose_unit": "{Capsule}",
+          "frequency_value": "",
+          "frequency_unit": "min",
+          "coded_entry_id": {
+            "$oid": "5aeb7734b848463d625b203c"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "id": "MeasurePeriod",
+          "start_date": 0,
+          "end_date": 0,
+          "references": null
+        }
+      ],
+      "is_shared": null,
+      "origin_data": [
+
+      ],
+      "test_id": null,
+      "medical_record_number": "978377cb9abfa822ea7943ce0ac537f2638722c872dcb77b05b86b106367455a",
+      "medical_record_assigner": "Bonnie",
+      "description": null,
+      "description_category": null,
+      "insurance_providers": "[]"
+    },
+    "qdmVersion": "5.4"
+  }
+}

--- a/test/fixtures/patients/CMS146v6/Pass_IPP.json
+++ b/test/fixtures/patients/CMS146v6/Pass_IPP.json
@@ -1,0 +1,403 @@
+{
+  "_id": {
+    "$oid": "5a7dc601b8484620c5183d15"
+  },
+  "bundleId": "5a57e977942c6d1e61d32f14",
+  "expectedValues": [
+    {
+      "measure_id": "BEB1C33C-2549-4E7F-9567-05ED38448464",
+      "population_index": 0,
+      "IPP": 1,
+      "DENOM": 1,
+      "DENEX": 0,
+      "NUMER": 0
+    }
+  ],
+  "familyName": "IPP",
+  "givenNames": [
+    "Pass"
+  ],
+  "notes": "",
+  "qdmPatient": {
+    "_id": {
+      "$oid": "5c88013ed7c8ac4c3e10668b"
+    },
+    "birthDatetime": "2000-02-01T08:00:00.000+00:00",
+    "dataElements": [
+      {
+        "_id": {
+          "$oid": "5c88013ed7c8ac4c3e10668c"
+        },
+        "anatomicalLocationSite": null,
+        "authorDatetime": "2012-02-07T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "1532007"
+          },
+          {
+            "codeSystem": "ICD-10-CM",
+            "code": "J02.0"
+          }
+        ],
+        "description": "Diagnosis: Acute Pharyngitis",
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.110",
+        "id": {
+          "_id": {
+            "$oid": "5c88013ed7c8ac4c3e10668d"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5aeb77d7b848463d625b60da"
+        },
+        "prevalencePeriod": {
+          "low": "2012-02-07T08:00:00.000+00:00",
+          "high": "2012-02-09T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "qdmCategory": "condition",
+        "qdmVersion": "5.4",
+        "qrdaOid": "2.16.840.1.113883.10.20.24.3.135",
+        "severity": null,
+        "_type": "QDM::Diagnosis"
+      },
+      {
+        "_id": {
+          "$oid": "5c88013ed7c8ac4c3e10668e"
+        },
+        "admissionSource": null,
+        "authorDatetime": "2012-02-07T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "12843005"
+          },
+          {
+            "codeSystem": "CPT",
+            "code": "99201"
+          }
+        ],
+        "description": "Encounter, Performed: Ambulatory/ED Visit",
+        "diagnoses": [
+
+        ],
+        "dischargeDisposition": null,
+        "facilityLocations": [
+
+        ],
+        "hqmfOid": "2.16.840.1.113883.3.560.1.79",
+        "id": {
+          "_id": {
+            "$oid": "5c88013ed7c8ac4c3e10668f"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5aeb77d7b848463d625b60db"
+        },
+        "lengthOfStay": {
+          "value": 2,
+          "unit": "days"
+        },
+        "negationRationale": null,
+        "principalDiagnosis": null,
+        "qdmCategory": "encounter",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "relevantPeriod": {
+          "low": "2012-02-07T08:00:00.000+00:00",
+          "high": "2012-02-09T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "_type": "QDM::EncounterPerformed"
+      },
+      {
+        "_id": {
+          "$oid": "5c88013ed7c8ac4c3e106690"
+        },
+        "authorDatetime": "2012-02-09T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "RxNorm",
+            "code": "1013659"
+          }
+        ],
+        "daysSupplied": null,
+        "description": "Medication, Order: Antibiotic Medications for Pharyngitis",
+        "dosage": null,
+        "frequency": null,
+        "hqmfOid": "2.16.840.1.113883.3.560.1.17",
+        "id": {
+          "_id": {
+            "$oid": "5c88013ed7c8ac4c3e106691"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5aeb77d7b848463d625b60dc"
+        },
+        "negationRationale": null,
+        "prescriberId": null,
+        "qdmCategory": "medication",
+        "qdmStatus": "order",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "refills": null,
+        "relevantPeriod": {
+          "low": "2012-02-09T08:00:00.000+00:00",
+          "high": "2012-02-09T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "route": null,
+        "setting": null,
+        "supply": null,
+        "_type": "QDM::MedicationOrder"
+      },
+      {
+        "_id": {
+          "$oid": "5c88013ed7c8ac4c3e106686"
+        },
+        "birthDatetime": "2000-02-01T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "code": "21112-8",
+            "codeSystem": "LOINC",
+            "descriptor": null,
+            "codeSystemOid": null,
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.54",
+        "id": {
+          "_id": {
+            "$oid": "5c88013ed7c8ac4c3e106692"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013ed7c8ac4c3e106686"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "birthdate",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicBirthdate"
+      },
+      {
+        "_id": {
+          "$oid": "5c88013ed7c8ac4c3e106687"
+        },
+        "dataElementCodes": [
+          {
+            "code": "2186-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "Not Hispanic or Latino",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.56",
+        "id": {
+          "_id": {
+            "$oid": "5c88013ed7c8ac4c3e106693"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013ed7c8ac4c3e106687"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "ethnicity",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicEthnicity"
+      },
+      {
+        "_id": {
+          "$oid": "5c88013ed7c8ac4c3e106688"
+        },
+        "dataElementCodes": [
+          {
+            "code": "1002-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "American Indian or Alaska Native",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.59",
+        "id": {
+          "_id": {
+            "$oid": "5c88013ed7c8ac4c3e106694"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013ed7c8ac4c3e106688"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "race",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicRace"
+      },
+      {
+        "_id": {
+          "$oid": "5c88013ed7c8ac4c3e106689"
+        },
+        "dataElementCodes": [
+          {
+            "code": "M",
+            "codeSystem": "AdministrativeGender",
+            "descriptor": "M",
+            "codeSystemOid": "2.16.840.1.113883.5.1",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.55",
+        "id": {
+          "_id": {
+            "$oid": "5c88013ed7c8ac4c3e106695"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013ed7c8ac4c3e106689"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "gender",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicSex"
+      }
+    ],
+    "extendedData": {
+      "type": null,
+      "measure_ids": [
+        "BEB1C33C-2549-4E7F-9567-05ED38448464",
+        null
+      ],
+      "source_data_criteria": [
+        {
+          "negation": false,
+          "definition": "encounter",
+          "status": "performed",
+          "title": "Ambulatory/EDVisit",
+          "description": "Encounter, Performed: Ambulatory/ED Visit",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.101.12.1061",
+          "type": "encounters",
+          "id": "Ambulatory_EDVisit_EncounterPerformed_a6c00a1e_e319_498e_9b26_ff64eded029a_source",
+          "start_date": 1328601600000,
+          "end_date": 1328775300000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "BEB1C33C-2549-4E7F-9567-05ED38448464",
+          "cms_id": "CMS146v6",
+          "criteria_id": "1617b4cdc0bbk",
+          "codes": {
+            "SNOMED-CT": [
+              "12843005"
+            ],
+            "CPT": [
+              "99201"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5aeb77d7b848463d625b60db"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "diagnosis",
+          "title": "AcutePharyngitis",
+          "description": "Diagnosis: Acute Pharyngitis",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.102.12.1011",
+          "type": "conditions",
+          "id": "AcutePharyngitis_Diagnosis_178608ed_404c_4278_be24_3ad6b726d0f3_source",
+          "start_date": 1328601600000,
+          "end_date": 1328775300000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "BEB1C33C-2549-4E7F-9567-05ED38448464",
+          "cms_id": "CMS146v6",
+          "criteria_id": "1617b4d2c77l0",
+          "codes": {
+            "SNOMED-CT": [
+              "1532007"
+            ],
+            "ICD-10-CM": [
+              "J02.0"
+            ]
+          },
+          "coded_entry_id": {
+            "$oid": "5aeb77d7b848463d625b60da"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "medication",
+          "status": "ordered",
+          "title": "AntibioticMedicationsforPharyngitis",
+          "description": "Medication, Order: Antibiotic Medications for Pharyngitis",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.196.12.1001",
+          "type": "medications",
+          "id": "AntibioticMedicationsforPharyngitis_MedicationOrder_40280381_3d61_56a7_013e_5d1ef9ce6a5b_source",
+          "start_date": 1328774400000,
+          "end_date": 1328775300000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "BEB1C33C-2549-4E7F-9567-05ED38448464",
+          "cms_id": "CMS146v6",
+          "criteria_id": "1617b4d3523e7",
+          "codes": {
+            "RxNorm": [
+              "1013659"
+            ]
+          },
+          "fulfillments": null,
+          "administrations_value": "",
+          "frequency_value": "",
+          "frequency_unit": "min",
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5aeb77d7b848463d625b60dc"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "id": "MeasurePeriod",
+          "start_date": 0,
+          "end_date": 0,
+          "references": null
+        }
+      ],
+      "is_shared": null,
+      "origin_data": [
+
+      ],
+      "test_id": null,
+      "medical_record_number": "12580b7c221836aac3202ea2d5813c6172d6f05b972c94c0d234921f43523f98",
+      "medical_record_assigner": "Bonnie",
+      "description": null,
+      "description_category": null,
+      "insurance_providers": "[]"
+    },
+    "qdmVersion": "5.4"
+  }
+}

--- a/test/fixtures/patients/CMS158v6/Fail_IPP.json
+++ b/test/fixtures/patients/CMS158v6/Fail_IPP.json
@@ -1,0 +1,260 @@
+{
+  "_id": {
+    "$oid": "5a9ee161b84846563e7d57e3"
+  },
+  "bundleId": "5a57e977942c6d1e61d32f14",
+  "expectedValues": [
+    {
+      "measure_id": "3BBFC929-50C8-44B8-8D34-82BE75C08A70",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "NUMER": 0,
+      "DENEXCEP": 0
+    }
+  ],
+  "familyName": "IPP",
+  "givenNames": [
+    "Fail"
+  ],
+  "notes": "",
+  "qdmPatient": {
+    "_id": {
+      "$oid": "5c880139d7c8ac4c3e1065d7"
+    },
+    "birthDatetime": "1984-06-21T08:00:00.000+00:00",
+    "dataElements": [
+      {
+        "_id": {
+          "$oid": "5c880139d7c8ac4c3e1065d8"
+        },
+        "anatomicalLocationSite": null,
+        "authorDatetime": "2012-03-06T08:00:00.000+00:00",
+        "components": [
+
+        ],
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "10745001"
+          },
+          {
+            "codeSystem": "ICD-10-PCS",
+            "code": "10D00Z0"
+          },
+          {
+            "codeSystem": "CPT",
+            "code": "59400"
+          }
+        ],
+        "description": "Procedure, Performed: Delivery - Procedure",
+        "hqmfOid": "2.16.840.1.113883.3.560.1.6",
+        "id": {
+          "_id": {
+            "$oid": "5c880139d7c8ac4c3e1065d9"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5aeb77a2b848463d625b4c6f"
+        },
+        "incisionDatetime": null,
+        "method": null,
+        "negationRationale": null,
+        "ordinality": null,
+        "qdmCategory": "procedure",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "relevantPeriod": {
+          "low": "2012-03-06T08:00:00.000+00:00",
+          "high": "2012-03-06T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "result": null,
+        "status": null,
+        "_type": "QDM::ProcedurePerformed"
+      },
+      {
+        "_id": {
+          "$oid": "5c880139d7c8ac4c3e1065d2"
+        },
+        "birthDatetime": "1984-06-21T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "code": "21112-8",
+            "codeSystem": "LOINC",
+            "descriptor": null,
+            "codeSystemOid": null,
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.54",
+        "id": {
+          "_id": {
+            "$oid": "5c880139d7c8ac4c3e1065da"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880139d7c8ac4c3e1065d2"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "birthdate",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicBirthdate"
+      },
+      {
+        "_id": {
+          "$oid": "5c880139d7c8ac4c3e1065d3"
+        },
+        "dataElementCodes": [
+          {
+            "code": "2186-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "Not Hispanic or Latino",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.56",
+        "id": {
+          "_id": {
+            "$oid": "5c880139d7c8ac4c3e1065db"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880139d7c8ac4c3e1065d3"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "ethnicity",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicEthnicity"
+      },
+      {
+        "_id": {
+          "$oid": "5c880139d7c8ac4c3e1065d4"
+        },
+        "dataElementCodes": [
+          {
+            "code": "1002-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "American Indian or Alaska Native",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.59",
+        "id": {
+          "_id": {
+            "$oid": "5c880139d7c8ac4c3e1065dc"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880139d7c8ac4c3e1065d4"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "race",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicRace"
+      },
+      {
+        "_id": {
+          "$oid": "5c880139d7c8ac4c3e1065d5"
+        },
+        "dataElementCodes": [
+          {
+            "code": "F",
+            "codeSystem": "AdministrativeGender",
+            "descriptor": "F",
+            "codeSystemOid": "2.16.840.1.113883.5.1",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.55",
+        "id": {
+          "_id": {
+            "$oid": "5c880139d7c8ac4c3e1065dd"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880139d7c8ac4c3e1065d5"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "gender",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicSex"
+      }
+    ],
+    "extendedData": {
+      "type": null,
+      "measure_ids": [
+        "3BBFC929-50C8-44B8-8D34-82BE75C08A70",
+        null
+      ],
+      "source_data_criteria": [
+        {
+          "negation": false,
+          "definition": "procedure",
+          "status": "performed",
+          "title": "Delivery-Procedure",
+          "description": "Procedure, Performed: Delivery - Procedure",
+          "code_list_id": "2.16.840.1.113762.1.4.1078.5",
+          "type": "procedures",
+          "id": "Delivery_Procedure_ProcedurePerformed_d55d2514_1421_44fb_98ca_195188229890_source",
+          "start_date": 1331020800000,
+          "end_date": 1331021700000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "3BBFC929-50C8-44B8-8D34-82BE75C08A70",
+          "cms_id": "CMS158v6",
+          "criteria_id": "161fc9fdd71rb",
+          "codes": {
+            "SNOMED-CT": [
+              "10745001"
+            ],
+            "ICD-10-PCS": [
+              "10D00Z0"
+            ],
+            "CPT": [
+              "59400"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5aeb77a2b848463d625b4c6f"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "id": "MeasurePeriod",
+          "start_date": 0,
+          "end_date": 0,
+          "references": null
+        }
+      ],
+      "is_shared": null,
+      "origin_data": [
+
+      ],
+      "test_id": null,
+      "medical_record_number": "9aa4af6addb9684b2dcb0d69b248031bdbea049c7cd8e8c7105417ab9dd6765e",
+      "medical_record_assigner": "Bonnie",
+      "description": null,
+      "description_category": null,
+      "insurance_providers": "[]"
+    },
+    "qdmVersion": "5.4"
+  }
+}

--- a/test/fixtures/patients/CMS158v6/Pass_Numer.json
+++ b/test/fixtures/patients/CMS158v6/Pass_Numer.json
@@ -1,0 +1,592 @@
+{
+  "_id": {
+    "$oid": "5a58f275942c6d5479457994"
+  },
+  "bundleId": "5a57e977942c6d1e61d32f14",
+  "expectedValues": [
+    {
+      "measure_id": "3BBFC929-50C8-44B8-8D34-82BE75C08A70",
+      "population_index": 0,
+      "IPP": 1,
+      "DENOM": 1,
+      "NUMER": 1,
+      "DENEXCEP": 0
+    }
+  ],
+  "familyName": "Numer",
+  "givenNames": [
+    "Pass"
+  ],
+  "notes": "Based on NUMERPass 2Deliveries_MostRecentDeliveryNUMPass in epecqmtelligen@gmail.com",
+  "qdmPatient": {
+    "_id": {
+      "$oid": "5c880138d7c8ac4c3e1065c1"
+    },
+    "birthDatetime": "1986-03-12T08:00:00.000+00:00",
+    "dataElements": [
+      {
+        "_id": {
+          "$oid": "5c880138d7c8ac4c3e1065c2"
+        },
+        "anatomicalLocationSite": null,
+        "authorDatetime": "2012-01-11T06:50:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "102879009"
+          }
+        ],
+        "description": "Diagnosis: Delivery - Diagnosis",
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.110",
+        "id": {
+          "_id": {
+            "$oid": "5c880138d7c8ac4c3e1065c3"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5aeb77c8b848463d625b5aab"
+        },
+        "prevalencePeriod": {
+          "low": "2012-01-11T06:50:00.000+00:00",
+          "high": "2012-01-11T09:25:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "qdmCategory": "condition",
+        "qdmVersion": "5.4",
+        "qrdaOid": "2.16.840.1.113883.10.20.24.3.135",
+        "severity": null,
+        "_type": "QDM::Diagnosis"
+      },
+      {
+        "_id": {
+          "$oid": "5c880138d7c8ac4c3e1065c4"
+        },
+        "anatomicalLocationSite": null,
+        "authorDatetime": "2012-12-20T08:50:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "102879009"
+          }
+        ],
+        "description": "Diagnosis: Delivery - Diagnosis",
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.110",
+        "id": {
+          "_id": {
+            "$oid": "5c880138d7c8ac4c3e1065c5"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5aeb77c8b848463d625b5aac"
+        },
+        "prevalencePeriod": {
+          "low": "2012-12-20T08:50:00.000+00:00",
+          "high": "2012-12-20T09:25:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "qdmCategory": "condition",
+        "qdmVersion": "5.4",
+        "qrdaOid": "2.16.840.1.113883.10.20.24.3.135",
+        "severity": null,
+        "_type": "QDM::Diagnosis"
+      },
+      {
+        "_id": {
+          "$oid": "5c880138d7c8ac4c3e1065c6"
+        },
+        "anatomicalLocationSite": null,
+        "authorDatetime": "2012-01-10T09:30:00.000+00:00",
+        "components": [
+
+        ],
+        "dataElementCodes": [
+          {
+            "codeSystem": "ICD-10-PCS",
+            "code": "10D07Z6"
+          }
+        ],
+        "description": "Procedure, Performed: Delivery - Procedure",
+        "hqmfOid": "2.16.840.1.113883.3.560.1.6",
+        "id": {
+          "_id": {
+            "$oid": "5c880138d7c8ac4c3e1065c7"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5aeb77c8b848463d625b5aad"
+        },
+        "incisionDatetime": null,
+        "method": null,
+        "negationRationale": null,
+        "ordinality": null,
+        "qdmCategory": "procedure",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "relevantPeriod": {
+          "low": "2012-01-10T09:30:00.000+00:00",
+          "high": "2012-01-10T11:30:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "result": null,
+        "status": null,
+        "_type": "QDM::ProcedurePerformed"
+      },
+      {
+        "_id": {
+          "$oid": "5c880138d7c8ac4c3e1065c8"
+        },
+        "anatomicalLocationSite": null,
+        "authorDatetime": "2012-12-20T08:40:00.000+00:00",
+        "components": [
+
+        ],
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "5556001"
+          }
+        ],
+        "description": "Procedure, Performed: Delivery - Procedure",
+        "hqmfOid": "2.16.840.1.113883.3.560.1.6",
+        "id": {
+          "_id": {
+            "$oid": "5c880138d7c8ac4c3e1065c9"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5aeb77c8b848463d625b5aae"
+        },
+        "incisionDatetime": null,
+        "method": null,
+        "negationRationale": null,
+        "ordinality": null,
+        "qdmCategory": "procedure",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "relevantPeriod": {
+          "low": "2012-12-20T08:40:00.000+00:00",
+          "high": "2012-12-20T11:55:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "result": null,
+        "status": null,
+        "_type": "QDM::ProcedurePerformed"
+      },
+      {
+        "_id": {
+          "$oid": "5c880138d7c8ac4c3e1065ca"
+        },
+        "authorDatetime": "2011-12-20T08:00:00.000+00:00",
+        "components": [
+
+        ],
+        "dataElementCodes": [
+          {
+            "codeSystem": "LOINC",
+            "code": "5195-3"
+          }
+        ],
+        "description": "Laboratory Test, Performed: HBsAg",
+        "hqmfOid": "2.16.840.1.113883.3.560.1.5",
+        "id": {
+          "_id": {
+            "$oid": "5c880138d7c8ac4c3e1065cb"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5aeb77c8b848463d625b5aaf"
+        },
+        "method": null,
+        "negationRationale": null,
+        "qdmCategory": "laboratory_test",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "referenceRange": null,
+        "relevantPeriod": {
+          "low": "2011-12-20T08:00:00.000+00:00",
+          "high": "2011-12-20T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "result": null,
+        "resultDatetime": null,
+        "status": null,
+        "_type": "QDM::LaboratoryTestPerformed"
+      },
+      {
+        "_id": {
+          "$oid": "5c880138d7c8ac4c3e1065cc"
+        },
+        "authorDatetime": "2012-04-20T13:00:00.000+00:00",
+        "components": [
+
+        ],
+        "dataElementCodes": [
+          {
+            "codeSystem": "LOINC",
+            "code": "5195-3"
+          }
+        ],
+        "description": "Laboratory Test, Performed: HBsAg",
+        "hqmfOid": "2.16.840.1.113883.3.560.1.5",
+        "id": {
+          "_id": {
+            "$oid": "5c880138d7c8ac4c3e1065cd"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5aeb77c8b848463d625b5ab0"
+        },
+        "method": null,
+        "negationRationale": null,
+        "qdmCategory": "laboratory_test",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "referenceRange": null,
+        "relevantPeriod": {
+          "low": "2012-04-20T13:00:00.000+00:00",
+          "high": "2012-04-20T13:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "result": null,
+        "resultDatetime": null,
+        "status": null,
+        "_type": "QDM::LaboratoryTestPerformed"
+      },
+      {
+        "_id": {
+          "$oid": "5c880138d7c8ac4c3e1065bc"
+        },
+        "birthDatetime": "1986-03-12T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "code": "21112-8",
+            "codeSystem": "LOINC",
+            "descriptor": null,
+            "codeSystemOid": null,
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.54",
+        "id": {
+          "_id": {
+            "$oid": "5c880138d7c8ac4c3e1065ce"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880138d7c8ac4c3e1065bc"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "birthdate",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicBirthdate"
+      },
+      {
+        "_id": {
+          "$oid": "5c880138d7c8ac4c3e1065bd"
+        },
+        "dataElementCodes": [
+          {
+            "code": "2186-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "Not Hispanic or Latino",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.56",
+        "id": {
+          "_id": {
+            "$oid": "5c880138d7c8ac4c3e1065cf"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880138d7c8ac4c3e1065bd"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "ethnicity",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicEthnicity"
+      },
+      {
+        "_id": {
+          "$oid": "5c880138d7c8ac4c3e1065be"
+        },
+        "dataElementCodes": [
+          {
+            "code": "2131-1",
+            "codeSystem": "CDC Race",
+            "descriptor": "Other",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.59",
+        "id": {
+          "_id": {
+            "$oid": "5c880138d7c8ac4c3e1065d0"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880138d7c8ac4c3e1065be"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "race",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicRace"
+      },
+      {
+        "_id": {
+          "$oid": "5c880138d7c8ac4c3e1065bf"
+        },
+        "dataElementCodes": [
+          {
+            "code": "F",
+            "codeSystem": "AdministrativeGender",
+            "descriptor": "F",
+            "codeSystemOid": "2.16.840.1.113883.5.1",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.55",
+        "id": {
+          "_id": {
+            "$oid": "5c880138d7c8ac4c3e1065d1"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880138d7c8ac4c3e1065bf"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "gender",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicSex"
+      }
+    ],
+    "extendedData": {
+      "type": null,
+      "measure_ids": [
+        "3BBFC929-50C8-44B8-8D34-82BE75C08A70",
+        null
+      ],
+      "source_data_criteria": [
+        {
+          "negation": false,
+          "definition": "laboratory_test",
+          "status": "performed",
+          "title": "HBsAg",
+          "description": "Laboratory Test, Performed: HBsAg",
+          "code_list_id": "2.16.840.1.113883.3.67.1.101.1.279",
+          "type": "laboratory_tests",
+          "id": "HBsAg_LaboratoryTestPerformed_40280381_3d61_56a7_013e_7f3878ec7630_source",
+          "start_date": 1324368000000,
+          "end_date": 1324368900000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "3BBFC929-50C8-44B8-8D34-82BE75C08A70",
+          "cms_id": "CMS158v6",
+          "criteria_id": "160eb6d07cciv",
+          "codes": {
+            "LOINC": [
+              "5195-3"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5aeb77c8b848463d625b5aaf"
+          },
+          "code_source": "USER_DEFINED"
+        },
+        {
+          "negation": false,
+          "definition": "procedure",
+          "status": "performed",
+          "title": "Delivery-Procedure",
+          "description": "Procedure, Performed: Delivery - Procedure",
+          "code_list_id": "2.16.840.1.113762.1.4.1078.5",
+          "type": "procedures",
+          "id": "Delivery_Procedure_ProcedurePerformed_d55d2514_1421_44fb_98ca_195188229890_source",
+          "start_date": 1326187800000,
+          "end_date": 1326195000000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "3BBFC929-50C8-44B8-8D34-82BE75C08A70",
+          "cms_id": "CMS158v6",
+          "criteria_id": "160eb6db935E3",
+          "codes": {
+            "ICD-10-PCS": [
+              "10D07Z6"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5aeb77c8b848463d625b5aad"
+          },
+          "code_source": "USER_DEFINED"
+        },
+        {
+          "negation": false,
+          "definition": "diagnosis",
+          "title": "Delivery-Diagnosis",
+          "description": "Diagnosis: Delivery - Diagnosis",
+          "code_list_id": "2.16.840.1.113883.3.67.1.101.1.278",
+          "type": "conditions",
+          "id": "Delivery_Diagnosis_Diagnosis_f9272c9f_18fc_4c40_a2bf_d3dfbc477434_source",
+          "start_date": 1326264600000,
+          "end_date": 1326273900000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "3BBFC929-50C8-44B8-8D34-82BE75C08A70",
+          "cms_id": "CMS158v6",
+          "criteria_id": "160eb6ef38dHK",
+          "codes": {
+            "SNOMED-CT": [
+              "102879009"
+            ]
+          },
+          "coded_entry_id": {
+            "$oid": "5aeb77c8b848463d625b5aab"
+          },
+          "code_source": "USER_DEFINED"
+        },
+        {
+          "negation": false,
+          "definition": "laboratory_test",
+          "status": "performed",
+          "title": "HBsAg",
+          "description": "Laboratory Test, Performed: HBsAg",
+          "code_list_id": "2.16.840.1.113883.3.67.1.101.1.279",
+          "type": "laboratory_tests",
+          "id": "HBsAg_LaboratoryTestPerformed_40280381_3d61_56a7_013e_7f3878ec7630_source",
+          "start_date": 1334926800000,
+          "end_date": 1334927700000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "3BBFC929-50C8-44B8-8D34-82BE75C08A70",
+          "cms_id": "CMS158v6",
+          "criteria_id": "160eb6faa51Be",
+          "codes": {
+            "LOINC": [
+              "5195-3"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5aeb77c8b848463d625b5ab0"
+          },
+          "code_source": "USER_DEFINED"
+        },
+        {
+          "negation": false,
+          "definition": "procedure",
+          "status": "performed",
+          "title": "Delivery-Procedure",
+          "description": "Procedure, Performed: Delivery - Procedure",
+          "code_list_id": "2.16.840.1.113762.1.4.1078.5",
+          "type": "procedures",
+          "id": "Delivery_Procedure_ProcedurePerformed_d55d2514_1421_44fb_98ca_195188229890_source",
+          "start_date": 1355992800000,
+          "end_date": 1356004500000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "3BBFC929-50C8-44B8-8D34-82BE75C08A70",
+          "cms_id": "CMS158v6",
+          "criteria_id": "160eb70b9fcZO",
+          "codes": {
+            "SNOMED-CT": [
+              "5556001"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5aeb77c8b848463d625b5aae"
+          },
+          "code_source": "USER_DEFINED"
+        },
+        {
+          "negation": false,
+          "definition": "diagnosis",
+          "title": "Delivery-Diagnosis",
+          "description": "Diagnosis: Delivery - Diagnosis",
+          "code_list_id": "2.16.840.1.113883.3.67.1.101.1.278",
+          "type": "conditions",
+          "id": "Delivery_Diagnosis_Diagnosis_f9272c9f_18fc_4c40_a2bf_d3dfbc477434_source",
+          "start_date": 1355993400000,
+          "end_date": 1355995500000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "3BBFC929-50C8-44B8-8D34-82BE75C08A70",
+          "cms_id": "CMS158v6",
+          "criteria_id": "160eb725935z5",
+          "codes": {
+            "SNOMED-CT": [
+              "102879009"
+            ]
+          },
+          "coded_entry_id": {
+            "$oid": "5aeb77c8b848463d625b5aac"
+          },
+          "code_source": "USER_DEFINED"
+        },
+        {
+          "id": "MeasurePeriod",
+          "start_date": 0,
+          "end_date": 0,
+          "references": null
+        }
+      ],
+      "is_shared": null,
+      "origin_data": [
+
+      ],
+      "test_id": null,
+      "medical_record_number": "c3fcbb95c7ae0994293afa4f6607fe2a29e7cb6c01e348917baa144b93328d47",
+      "medical_record_assigner": "Bonnie",
+      "description": null,
+      "description_category": null,
+      "insurance_providers": "[]"
+    },
+    "qdmVersion": "5.4"
+  }
+}

--- a/test/fixtures/patients/CMS160v6/Expired_DENEX.json
+++ b/test/fixtures/patients/CMS160v6/Expired_DENEX.json
@@ -1,0 +1,365 @@
+{
+  "_id": {
+    "$oid": "5a9ee716b848465b0064f52c"
+  },
+  "bundleId": "5a57e977942c6d1e61d32f14",
+  "expectedValues": [
+    {
+      "measure_id": "A4B9763C-847E-4E02-BB7E-ACC596E90E2C",
+      "population_index": 0,
+      "IPP": 1,
+      "DENOM": 1,
+      "DENEX": 1,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "A4B9763C-847E-4E02-BB7E-ACC596E90E2C",
+      "population_index": 1,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "A4B9763C-847E-4E02-BB7E-ACC596E90E2C",
+      "population_index": 2,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    }
+  ],
+  "familyName": "DENEX",
+  "givenNames": [
+    "Expired"
+  ],
+  "notes": "",
+  "qdmPatient": {
+    "_id": {
+      "$oid": "5c88013bd7c8ac4c3e106624"
+    },
+    "birthDatetime": "1970-01-01T08:00:00.000+00:00",
+    "dataElements": [
+      {
+        "_id": {
+          "$oid": "5c88013bd7c8ac4c3e106625"
+        },
+        "anatomicalLocationSite": null,
+        "authorDatetime": "2012-04-12T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "19694002"
+          },
+          {
+            "codeSystem": "ICD-10-CM",
+            "code": "F34.1"
+          }
+        ],
+        "description": "Diagnosis: Dysthymia",
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.110",
+        "id": {
+          "_id": {
+            "$oid": "5c88013bd7c8ac4c3e106626"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5aeb77a2b848463d625b4c70"
+        },
+        "prevalencePeriod": {
+          "low": "2012-04-12T08:00:00.000+00:00",
+          "high": "9999-12-31T23:59:59.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "qdmCategory": "condition",
+        "qdmVersion": "5.4",
+        "qrdaOid": "2.16.840.1.113883.10.20.24.3.135",
+        "severity": null,
+        "_type": "QDM::Diagnosis"
+      },
+      {
+        "_id": {
+          "$oid": "5c88013bd7c8ac4c3e106627"
+        },
+        "admissionSource": null,
+        "authorDatetime": "2012-11-04T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "CPT",
+            "code": "99201"
+          }
+        ],
+        "description": "Encounter, Performed: Office Visit",
+        "diagnoses": [
+
+        ],
+        "dischargeDisposition": null,
+        "facilityLocations": [
+
+        ],
+        "hqmfOid": "2.16.840.1.113883.3.560.1.79",
+        "id": {
+          "_id": {
+            "$oid": "5c88013bd7c8ac4c3e106628"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5aeb77a2b848463d625b4c71"
+        },
+        "lengthOfStay": {
+          "value": 0,
+          "unit": "days"
+        },
+        "negationRationale": null,
+        "principalDiagnosis": null,
+        "qdmCategory": "encounter",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "relevantPeriod": {
+          "low": "2012-11-04T08:00:00.000+00:00",
+          "high": "2012-11-04T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "_type": "QDM::EncounterPerformed"
+      },
+      {
+        "_id": {
+          "$oid": "5c88013bd7c8ac4c3e10661e"
+        },
+        "birthDatetime": "1970-01-01T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "code": "21112-8",
+            "codeSystem": "LOINC",
+            "descriptor": null,
+            "codeSystemOid": null,
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.54",
+        "id": {
+          "_id": {
+            "$oid": "5c88013bd7c8ac4c3e106629"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013bd7c8ac4c3e10661e"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "birthdate",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicBirthdate"
+      },
+      {
+        "_id": {
+          "$oid": "5c88013bd7c8ac4c3e10661f"
+        },
+        "dataElementCodes": [
+          {
+            "code": "2186-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "Not Hispanic or Latino",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.56",
+        "id": {
+          "_id": {
+            "$oid": "5c88013bd7c8ac4c3e10662a"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013bd7c8ac4c3e10661f"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "ethnicity",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicEthnicity"
+      },
+      {
+        "_id": {
+          "$oid": "5c88013bd7c8ac4c3e106620"
+        },
+        "cause": null,
+        "dataElementCodes": [
+          {
+            "code": "419099009",
+            "codeSystem": "SNOMED-CT",
+            "descriptor": null,
+            "codeSystemOid": null,
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "expiredDatetime": "2012-12-04T08:00:00.000+00:00",
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.57",
+        "id": {
+          "_id": {
+            "$oid": "5c88013bd7c8ac4c3e10662b"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013bd7c8ac4c3e106620"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "expired",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicExpired"
+      },
+      {
+        "_id": {
+          "$oid": "5c88013bd7c8ac4c3e106621"
+        },
+        "dataElementCodes": [
+          {
+            "code": "1002-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "American Indian or Alaska Native",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.59",
+        "id": {
+          "_id": {
+            "$oid": "5c88013bd7c8ac4c3e10662c"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013bd7c8ac4c3e106621"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "race",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicRace"
+      },
+      {
+        "_id": {
+          "$oid": "5c88013bd7c8ac4c3e106622"
+        },
+        "dataElementCodes": [
+          {
+            "code": "M",
+            "codeSystem": "AdministrativeGender",
+            "descriptor": "M",
+            "codeSystemOid": "2.16.840.1.113883.5.1",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.55",
+        "id": {
+          "_id": {
+            "$oid": "5c88013bd7c8ac4c3e10662d"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013bd7c8ac4c3e106622"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "gender",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicSex"
+      }
+    ],
+    "extendedData": {
+      "type": null,
+      "measure_ids": [
+        "A4B9763C-847E-4E02-BB7E-ACC596E90E2C",
+        null
+      ],
+      "source_data_criteria": [
+        {
+          "negation": false,
+          "definition": "diagnosis",
+          "title": "Dysthymia",
+          "description": "Diagnosis: Dysthymia",
+          "code_list_id": "2.16.840.1.113883.3.67.1.101.1.254",
+          "type": "conditions",
+          "id": "Dysthymia_Diagnosis_6193b77b_e502_40cd_8ff4_a51a269f141a_source",
+          "start_date": 1334217600000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "A4B9763C-847E-4E02-BB7E-ACC596E90E2C",
+          "cms_id": "CMS160v6",
+          "criteria_id": "161fcb4cf7chz",
+          "codes": {
+            "SNOMED-CT": [
+              "19694002"
+            ],
+            "ICD-10-CM": [
+              "F34.1"
+            ]
+          },
+          "coded_entry_id": {
+            "$oid": "5aeb77a2b848463d625b4c70"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "encounter",
+          "status": "performed",
+          "title": "OfficeVisit",
+          "description": "Encounter, Performed: Office Visit",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.101.12.1001",
+          "type": "encounters",
+          "id": "OfficeVisit_EncounterPerformed_40280381_3d61_56a7_013e_8a363827334f_source",
+          "start_date": 1352016000000,
+          "end_date": 1352016900000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "A4B9763C-847E-4E02-BB7E-ACC596E90E2C",
+          "cms_id": "CMS160v6",
+          "criteria_id": "161fcb54fcd6O",
+          "codes": {
+            "CPT": [
+              "99201"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5aeb77a2b848463d625b4c71"
+          },
+          "code_source": "USER_DEFINED"
+        },
+        {
+          "id": "MeasurePeriod",
+          "start_date": 0,
+          "end_date": 0,
+          "references": null
+        }
+      ],
+      "is_shared": null,
+      "origin_data": [
+
+      ],
+      "test_id": null,
+      "medical_record_number": "c41b2fc639938515ddbedfbb122df57bd818474278962683a0c3d50e3e3cbfed",
+      "medical_record_assigner": "Bonnie",
+      "description": null,
+      "description_category": null,
+      "insurance_providers": "[]"
+    },
+    "qdmVersion": "5.4"
+  }
+}

--- a/test/fixtures/patients/CMS160v6/Pass_NUM2.json
+++ b/test/fixtures/patients/CMS160v6/Pass_NUM2.json
@@ -1,0 +1,457 @@
+{
+  "_id": {
+    "$oid": "5a58f485942c6d5479457a7b"
+  },
+  "bundleId": "5a57e977942c6d1e61d32f14",
+  "expectedValues": [
+    {
+      "measure_id": "A4B9763C-847E-4E02-BB7E-ACC596E90E2C",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "A4B9763C-847E-4E02-BB7E-ACC596E90E2C",
+      "population_index": 1,
+      "IPP": 1,
+      "DENOM": 1,
+      "DENEX": 0,
+      "NUMER": 1
+    },
+    {
+      "measure_id": "A4B9763C-847E-4E02-BB7E-ACC596E90E2C",
+      "population_index": 2,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    }
+  ],
+  "familyName": "NUM2",
+  "givenNames": [
+    "Pass"
+  ],
+  "notes": "Based on  NUM2Pass PHQ9>4mo<8moEASMP_BipolarDxSAEMP in epecqmtelligen@gmail.com",
+  "qdmPatient": {
+    "_id": {
+      "$oid": "5c88013bd7c8ac4c3e106611"
+    },
+    "birthDatetime": "1965-04-13T08:00:00.000+00:00",
+    "dataElements": [
+      {
+        "_id": {
+          "$oid": "5c88013bd7c8ac4c3e106612"
+        },
+        "authorDatetime": "2012-08-31T14:35:00.000+00:00",
+        "components": [
+
+        ],
+        "dataElementCodes": [
+          {
+            "codeSystem": "LOINC",
+            "code": "44261-6"
+          }
+        ],
+        "description": "Assessment, Performed: PHQ-9 Tool",
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.117",
+        "id": {
+          "_id": {
+            "$oid": "5c88013bd7c8ac4c3e106613"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5aeb7763b848463d625b33d9"
+        },
+        "method": null,
+        "negationRationale": null,
+        "qdmCategory": "assessment",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "result": 10,
+        "_type": "QDM::AssessmentPerformed"
+      },
+      {
+        "_id": {
+          "$oid": "5c88013bd7c8ac4c3e106614"
+        },
+        "anatomicalLocationSite": null,
+        "authorDatetime": "2012-06-08T14:35:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "ICD-10-CM",
+            "code": "F33.9"
+          }
+        ],
+        "description": "Diagnosis: Major Depression Including Remission",
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.110",
+        "id": {
+          "_id": {
+            "$oid": "5c88013bd7c8ac4c3e106615"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5aeb7763b848463d625b33d6"
+        },
+        "prevalencePeriod": {
+          "low": "2012-06-08T14:35:00.000+00:00",
+          "high": "9999-12-31T23:59:59.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "qdmCategory": "condition",
+        "qdmVersion": "5.4",
+        "qrdaOid": "2.16.840.1.113883.10.20.24.3.135",
+        "severity": null,
+        "_type": "QDM::Diagnosis"
+      },
+      {
+        "_id": {
+          "$oid": "5c88013bd7c8ac4c3e106616"
+        },
+        "anatomicalLocationSite": null,
+        "authorDatetime": "2013-11-08T14:35:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "81319007"
+          }
+        ],
+        "description": "Diagnosis: Bipolar Disorder",
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.110",
+        "id": {
+          "_id": {
+            "$oid": "5c88013bd7c8ac4c3e106617"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5aeb7763b848463d625b33d7"
+        },
+        "prevalencePeriod": {
+          "low": "2013-11-08T14:35:00.000+00:00",
+          "high": "9999-12-31T23:59:59.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "qdmCategory": "condition",
+        "qdmVersion": "5.4",
+        "qrdaOid": "2.16.840.1.113883.10.20.24.3.135",
+        "severity": null,
+        "_type": "QDM::Diagnosis"
+      },
+      {
+        "_id": {
+          "$oid": "5c88013bd7c8ac4c3e106618"
+        },
+        "admissionSource": null,
+        "authorDatetime": "2012-06-08T14:30:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "CPT",
+            "code": "99201"
+          }
+        ],
+        "description": "Encounter, Performed: Office Visit",
+        "diagnoses": [
+
+        ],
+        "dischargeDisposition": null,
+        "facilityLocations": [
+
+        ],
+        "hqmfOid": "2.16.840.1.113883.3.560.1.79",
+        "id": {
+          "_id": {
+            "$oid": "5c88013bd7c8ac4c3e106619"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5aeb7763b848463d625b33d8"
+        },
+        "lengthOfStay": {
+          "value": 0,
+          "unit": "days"
+        },
+        "negationRationale": null,
+        "principalDiagnosis": null,
+        "qdmCategory": "encounter",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "relevantPeriod": {
+          "low": "2012-06-08T14:30:00.000+00:00",
+          "high": "2012-06-08T14:50:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "_type": "QDM::EncounterPerformed"
+      },
+      {
+        "_id": {
+          "$oid": "5c88013bd7c8ac4c3e10660c"
+        },
+        "birthDatetime": "1965-04-13T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "code": "21112-8",
+            "codeSystem": "LOINC",
+            "descriptor": null,
+            "codeSystemOid": null,
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.54",
+        "id": {
+          "_id": {
+            "$oid": "5c88013bd7c8ac4c3e10661a"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013bd7c8ac4c3e10660c"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "birthdate",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicBirthdate"
+      },
+      {
+        "_id": {
+          "$oid": "5c88013bd7c8ac4c3e10660d"
+        },
+        "dataElementCodes": [
+          {
+            "code": "2186-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "Not Hispanic or Latino",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.56",
+        "id": {
+          "_id": {
+            "$oid": "5c88013bd7c8ac4c3e10661b"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013bd7c8ac4c3e10660d"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "ethnicity",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicEthnicity"
+      },
+      {
+        "_id": {
+          "$oid": "5c88013bd7c8ac4c3e10660e"
+        },
+        "dataElementCodes": [
+          {
+            "code": "1002-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "American Indian or Alaska Native",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.59",
+        "id": {
+          "_id": {
+            "$oid": "5c88013bd7c8ac4c3e10661c"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013bd7c8ac4c3e10660e"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "race",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicRace"
+      },
+      {
+        "_id": {
+          "$oid": "5c88013bd7c8ac4c3e10660f"
+        },
+        "dataElementCodes": [
+          {
+            "code": "F",
+            "codeSystem": "AdministrativeGender",
+            "descriptor": "F",
+            "codeSystemOid": "2.16.840.1.113883.5.1",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.55",
+        "id": {
+          "_id": {
+            "$oid": "5c88013bd7c8ac4c3e10661d"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013bd7c8ac4c3e10660f"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "gender",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicSex"
+      }
+    ],
+    "extendedData": {
+      "type": null,
+      "measure_ids": [
+        "A4B9763C-847E-4E02-BB7E-ACC596E90E2C",
+        null
+      ],
+      "source_data_criteria": [
+        {
+          "negation": false,
+          "definition": "encounter",
+          "status": "performed",
+          "title": "OfficeVisit",
+          "description": "Encounter, Performed: Office Visit",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.101.12.1001",
+          "type": "encounters",
+          "id": "OfficeVisit_EncounterPerformed_40280381_3d61_56a7_013e_8a363827334f_source",
+          "start_date": 1339165800000,
+          "end_date": 1339167000000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "A4B9763C-847E-4E02-BB7E-ACC596E90E2C",
+          "cms_id": "CMS160v6",
+          "criteria_id": "160eb75c1d3El",
+          "codes": {
+            "CPT": [
+              "99201"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5aeb7763b848463d625b33d8"
+          },
+          "code_source": "USER_DEFINED"
+        },
+        {
+          "negation": false,
+          "definition": "diagnosis",
+          "title": "MajorDepressionIncludingRemission",
+          "description": "Diagnosis: Major Depression Including Remission",
+          "code_list_id": "2.16.840.113883.3.67.1.101.3.2444",
+          "type": "conditions",
+          "id": "MajorDepressionIncludingRemission_Diagnosis_aa4805f4_54e9_4e60_9bbf_b316aeaa95ba_source",
+          "start_date": 1339166100000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "A4B9763C-847E-4E02-BB7E-ACC596E90E2C",
+          "cms_id": "CMS160v6",
+          "criteria_id": "160eb76956cSo",
+          "codes": {
+            "ICD-10-CM": [
+              "F33.9"
+            ]
+          },
+          "coded_entry_id": {
+            "$oid": "5aeb7763b848463d625b33d6"
+          },
+          "code_source": "USER_DEFINED"
+        },
+        {
+          "negation": false,
+          "definition": "assessment",
+          "status": "performed",
+          "title": "PHQ-9Tool",
+          "description": "Assessment, Performed: PHQ-9 Tool",
+          "code_list_id": "2.16.840.1.113883.3.67.1.101.11.723",
+          "type": "assessments",
+          "id": "PHQ_9Tool_AssessmentPerformed_40280381_3d61_56a7_013e_8a363828336d_source",
+          "start_date": 1346423700000,
+          "value": [
+            {
+              "type": "PQ",
+              "type_cmp": "CD",
+              "value": "10",
+              "unit": ""
+            }
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "A4B9763C-847E-4E02-BB7E-ACC596E90E2C",
+          "cms_id": "CMS160v6",
+          "criteria_id": "160eb8174dclO",
+          "codes": {
+            "LOINC": [
+              "44261-6"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5aeb7763b848463d625b33d9"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "diagnosis",
+          "title": "BipolarDisorder",
+          "description": "Diagnosis: Bipolar Disorder",
+          "code_list_id": "2.16.840.1.113883.3.67.1.101.1.128",
+          "type": "conditions",
+          "id": "BipolarDisorder_Diagnosis_89a1244b_f388_4261_949a_70b82971f63d_source",
+          "start_date": 1383921300000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "A4B9763C-847E-4E02-BB7E-ACC596E90E2C",
+          "cms_id": "CMS160v6",
+          "criteria_id": "160eb7773f7Zc",
+          "codes": {
+            "SNOMED-CT": [
+              "81319007"
+            ]
+          },
+          "coded_entry_id": {
+            "$oid": "5aeb7763b848463d625b33d7"
+          },
+          "code_source": "USER_DEFINED"
+        },
+        {
+          "id": "MeasurePeriod",
+          "start_date": 0,
+          "end_date": 0,
+          "references": null
+        }
+      ],
+      "is_shared": null,
+      "origin_data": [
+
+      ],
+      "test_id": null,
+      "medical_record_number": "62eb0c6cafb20eeb143aaa87226f769ed92076b0173c0a756d62af1145f54b6c",
+      "medical_record_assigner": "Bonnie",
+      "description": null,
+      "description_category": null,
+      "insurance_providers": "[]"
+    },
+    "qdmVersion": "5.4"
+  }
+}

--- a/test/fixtures/patients/CMS177v6/Fail_IPP.json
+++ b/test/fixtures/patients/CMS177v6/Fail_IPP.json
@@ -1,0 +1,255 @@
+{
+  "_id": {
+    "$oid": "5a9eddefb84846563e7d578c"
+  },
+  "bundleId": "5a57e977942c6d1e61d32f14",
+  "expectedValues": [
+    {
+      "measure_id": "848D09DE-7E6B-43C4-BEDD-5A2957CCFFE3",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "NUMER": 0
+    }
+  ],
+  "familyName": "IPP",
+  "givenNames": [
+    "Fail"
+  ],
+  "notes": "",
+  "qdmPatient": {
+    "_id": {
+      "$oid": "5c88013cd7c8ac4c3e106641"
+    },
+    "birthDatetime": "2001-03-15T08:00:00.000+00:00",
+    "dataElements": [
+      {
+        "_id": {
+          "$oid": "5c88013cd7c8ac4c3e106642"
+        },
+        "admissionSource": null,
+        "authorDatetime": "2012-03-06T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "185463005"
+          },
+          {
+            "codeSystem": "CPT",
+            "code": "99201"
+          }
+        ],
+        "description": "Encounter, Performed: Office Visit",
+        "diagnoses": [
+
+        ],
+        "dischargeDisposition": null,
+        "facilityLocations": [
+
+        ],
+        "hqmfOid": "2.16.840.1.113883.3.560.1.79",
+        "id": {
+          "_id": {
+            "$oid": "5c88013cd7c8ac4c3e106643"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5aeb77a2b848463d625b4c6e"
+        },
+        "lengthOfStay": {
+          "value": 0,
+          "unit": "days"
+        },
+        "negationRationale": null,
+        "principalDiagnosis": null,
+        "qdmCategory": "encounter",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "relevantPeriod": {
+          "low": "2012-03-06T08:00:00.000+00:00",
+          "high": "2012-03-06T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "_type": "QDM::EncounterPerformed"
+      },
+      {
+        "_id": {
+          "$oid": "5c88013cd7c8ac4c3e10663c"
+        },
+        "birthDatetime": "2001-03-15T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "code": "21112-8",
+            "codeSystem": "LOINC",
+            "descriptor": null,
+            "codeSystemOid": null,
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.54",
+        "id": {
+          "_id": {
+            "$oid": "5c88013cd7c8ac4c3e106644"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013cd7c8ac4c3e10663c"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "birthdate",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicBirthdate"
+      },
+      {
+        "_id": {
+          "$oid": "5c88013cd7c8ac4c3e10663d"
+        },
+        "dataElementCodes": [
+          {
+            "code": "2186-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "Not Hispanic or Latino",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.56",
+        "id": {
+          "_id": {
+            "$oid": "5c88013cd7c8ac4c3e106645"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013cd7c8ac4c3e10663d"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "ethnicity",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicEthnicity"
+      },
+      {
+        "_id": {
+          "$oid": "5c88013cd7c8ac4c3e10663e"
+        },
+        "dataElementCodes": [
+          {
+            "code": "1002-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "American Indian or Alaska Native",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.59",
+        "id": {
+          "_id": {
+            "$oid": "5c88013cd7c8ac4c3e106646"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013cd7c8ac4c3e10663e"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "race",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicRace"
+      },
+      {
+        "_id": {
+          "$oid": "5c88013cd7c8ac4c3e10663f"
+        },
+        "dataElementCodes": [
+          {
+            "code": "M",
+            "codeSystem": "AdministrativeGender",
+            "descriptor": "M",
+            "codeSystemOid": "2.16.840.1.113883.5.1",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.55",
+        "id": {
+          "_id": {
+            "$oid": "5c88013cd7c8ac4c3e106647"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013cd7c8ac4c3e10663f"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "gender",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicSex"
+      }
+    ],
+    "extendedData": {
+      "type": null,
+      "measure_ids": [
+        "848D09DE-7E6B-43C4-BEDD-5A2957CCFFE3",
+        null
+      ],
+      "source_data_criteria": [
+        {
+          "negation": false,
+          "definition": "encounter",
+          "status": "performed",
+          "title": "OfficeVisit",
+          "description": "Encounter, Performed: Office Visit",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.101.12.1001",
+          "type": "encounters",
+          "id": "OfficeVisit_EncounterPerformed_40280381_3d61_56a7_013e_5d9034eb706f_source",
+          "start_date": 1331020800000,
+          "end_date": 1331021700000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "848D09DE-7E6B-43C4-BEDD-5A2957CCFFE3",
+          "cms_id": "CMS177v6",
+          "criteria_id": "161fc92d3bdZ2",
+          "codes": {
+            "SNOMED-CT": [
+              "185463005"
+            ],
+            "CPT": [
+              "99201"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5aeb77a2b848463d625b4c6e"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "id": "MeasurePeriod",
+          "start_date": 0,
+          "end_date": 0,
+          "references": null
+        }
+      ],
+      "is_shared": null,
+      "origin_data": [
+
+      ],
+      "test_id": null,
+      "medical_record_number": "7073619254c07fe4cccedec594bc09426191af6ccbd402b98746bd2a51d21405",
+      "medical_record_assigner": "Bonnie",
+      "description": null,
+      "description_category": null,
+      "insurance_providers": "[]"
+    },
+    "qdmVersion": "5.4"
+  }
+}

--- a/test/fixtures/patients/CMS177v6/Pass_Numer.json
+++ b/test/fixtures/patients/CMS177v6/Pass_Numer.json
@@ -1,0 +1,341 @@
+{
+  "_id": {
+    "$oid": "5a58ecb2942c6d500fc8ca0b"
+  },
+  "bundleId": "5a57e977942c6d1e61d32f14",
+  "expectedValues": [
+    {
+      "measure_id": "848D09DE-7E6B-43C4-BEDD-5A2957CCFFE3",
+      "population_index": 0,
+      "IPP": 1,
+      "DENOM": 1,
+      "NUMER": 1
+    }
+  ],
+  "familyName": "Numer",
+  "givenNames": [
+    "Pass"
+  ],
+  "notes": "Based on NUMERPass RiskAssessF2FEnc in epecqmama@gmail.com ",
+  "qdmPatient": {
+    "_id": {
+      "$oid": "5c88013cd7c8ac4c3e106633"
+    },
+    "birthDatetime": "1995-12-13T08:00:00.000+00:00",
+    "dataElements": [
+      {
+        "_id": {
+          "$oid": "5c88013cd7c8ac4c3e106634"
+        },
+        "admissionSource": null,
+        "authorDatetime": "2012-02-11T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "12843005"
+          }
+        ],
+        "description": "Encounter, Performed: Face-to-Face Interaction",
+        "diagnoses": [
+          {
+            "code": "14183003",
+            "codeSystem": "SNOMED-CT",
+            "version": null,
+            "descriptor": "Major Depressive Disorder-Active"
+          }
+        ],
+        "dischargeDisposition": null,
+        "facilityLocations": [
+
+        ],
+        "hqmfOid": "2.16.840.1.113883.3.560.1.79",
+        "id": {
+          "_id": {
+            "$oid": "5c88013cd7c8ac4c3e106635"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5aeb7763b848463d625b33d2"
+        },
+        "lengthOfStay": {
+          "value": 0,
+          "unit": "days"
+        },
+        "negationRationale": null,
+        "principalDiagnosis": {
+          "code": "14183003",
+          "codeSystem": "SNOMED-CT",
+          "descriptor": "Major Depressive Disorder-Active",
+          "codeSystemOid": null,
+          "version": null
+        },
+        "qdmCategory": "encounter",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "relevantPeriod": {
+          "low": "2012-02-11T08:00:00.000+00:00",
+          "high": "2012-02-11T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "_type": "QDM::EncounterPerformed"
+      },
+      {
+        "_id": {
+          "$oid": "5c88013cd7c8ac4c3e106636"
+        },
+        "authorDatetime": "2012-02-11T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "225337009"
+          }
+        ],
+        "description": "Intervention, Performed: Suicide Risk Assessment",
+        "hqmfOid": "2.16.840.1.113883.3.560.1.46",
+        "id": {
+          "_id": {
+            "$oid": "5c88013cd7c8ac4c3e106637"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5aeb7763b848463d625b33d4"
+        },
+        "negationRationale": null,
+        "qdmCategory": "intervention",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "relevantPeriod": {
+          "low": "2012-02-11T08:00:00.000+00:00",
+          "high": "2012-02-11T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "result": null,
+        "status": null,
+        "_type": "QDM::InterventionPerformed"
+      },
+      {
+        "_id": {
+          "$oid": "5c88013cd7c8ac4c3e10662e"
+        },
+        "birthDatetime": "1995-12-13T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "code": "21112-8",
+            "codeSystem": "LOINC",
+            "descriptor": null,
+            "codeSystemOid": null,
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.54",
+        "id": {
+          "_id": {
+            "$oid": "5c88013cd7c8ac4c3e106638"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013cd7c8ac4c3e10662e"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "birthdate",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicBirthdate"
+      },
+      {
+        "_id": {
+          "$oid": "5c88013cd7c8ac4c3e10662f"
+        },
+        "dataElementCodes": [
+          {
+            "code": "2186-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "Not Hispanic or Latino",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.56",
+        "id": {
+          "_id": {
+            "$oid": "5c88013cd7c8ac4c3e106639"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013cd7c8ac4c3e10662f"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "ethnicity",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicEthnicity"
+      },
+      {
+        "_id": {
+          "$oid": "5c88013cd7c8ac4c3e106630"
+        },
+        "dataElementCodes": [
+          {
+            "code": "1002-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "American Indian or Alaska Native",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.59",
+        "id": {
+          "_id": {
+            "$oid": "5c88013cd7c8ac4c3e10663a"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013cd7c8ac4c3e106630"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "race",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicRace"
+      },
+      {
+        "_id": {
+          "$oid": "5c88013cd7c8ac4c3e106631"
+        },
+        "dataElementCodes": [
+          {
+            "code": "F",
+            "codeSystem": "AdministrativeGender",
+            "descriptor": "F",
+            "codeSystemOid": "2.16.840.1.113883.5.1",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.55",
+        "id": {
+          "_id": {
+            "$oid": "5c88013cd7c8ac4c3e10663b"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013cd7c8ac4c3e106631"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "gender",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicSex"
+      }
+    ],
+    "extendedData": {
+      "type": null,
+      "measure_ids": [
+        "848D09DE-7E6B-43C4-BEDD-5A2957CCFFE3",
+        null
+      ],
+      "source_data_criteria": [
+        {
+          "negation": false,
+          "definition": "encounter",
+          "status": "performed",
+          "title": "Face-to-FaceInteraction",
+          "description": "Encounter, Performed: Face-to-Face Interaction",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.101.12.1048",
+          "type": "encounters",
+          "id": "Face_to_FaceInteraction_EncounterPerformed_40280381_3d61_56a7_013e_5d9034ec707c_source",
+          "start_date": 1328947200000,
+          "end_date": 1328948100000,
+          "value": [
+
+          ],
+          "references": [
+            {
+              "type": "CD",
+              "reference_type": "Related To",
+              "reference_id": "160eb5db5bdEU",
+              "description": "Intervention, Performed: Suicide Risk Assessment",
+              "start_date": "02/11/2012",
+              "end_date": "02/11/2012"
+            }
+          ],
+          "field_values": {
+            "PRINCIPAL_DIAGNOSIS": {
+              "type": "CD",
+              "code_list_id": "2.16.840.1.113883.3.526.3.1491",
+              "field_title": "Principal Diagnosis",
+              "title": "Major Depressive Disorder-Active"
+            }
+          },
+          "hqmf_set_id": "848D09DE-7E6B-43C4-BEDD-5A2957CCFFE3",
+          "cms_id": "CMS177v6",
+          "criteria_id": "160eb5b1d5fas",
+          "codes": {
+            "SNOMED-CT": [
+              "12843005"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5aeb7763b848463d625b33d2"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "intervention",
+          "status": "performed",
+          "title": "SuicideRiskAssessment",
+          "description": "Intervention, Performed: Suicide Risk Assessment",
+          "code_list_id": "2.16.840.1.113883.3.526.3.1484",
+          "type": "interventions",
+          "id": "SuicideRiskAssessment_InterventionPerformed_40280381_3d61_56a7_013e_5d9034ec708a_source",
+          "start_date": 1328947200000,
+          "end_date": 1328948100000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "848D09DE-7E6B-43C4-BEDD-5A2957CCFFE3",
+          "cms_id": "CMS177v6",
+          "criteria_id": "160eb5db5bdEU",
+          "codes": {
+            "SNOMED-CT": [
+              "225337009"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5aeb7763b848463d625b33d4"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "id": "MeasurePeriod",
+          "start_date": 0,
+          "end_date": 0,
+          "references": null
+        }
+      ],
+      "is_shared": null,
+      "origin_data": [
+
+      ],
+      "test_id": null,
+      "medical_record_number": "7d65b9b331c09bb8364fed78d25eb1cbd53d3be035705c792ecca931c549d217",
+      "medical_record_assigner": "Bonnie",
+      "description": null,
+      "description_category": null,
+      "insurance_providers": "[]"
+    },
+    "qdmVersion": "5.4"
+  }
+}

--- a/test/fixtures/patients/CMS231v0/Patient_Test 1.json
+++ b/test/fixtures/patients/CMS231v0/Patient_Test 1.json
@@ -1,0 +1,449 @@
+{
+  "_id": {
+    "$oid": "5c06ec72b848466bbc906066"
+  },
+  "bundleId": "5a57e977942c6d1e61d32f14",
+  "expectedValues": [
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+      "population_index": 0,
+      "IPP": 1,
+      "DENOM": 1,
+      "DENEX": 0,
+      "NUMER": 1
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC",
+      "population_index": 0,
+      "IPP": 1,
+      "MSRPOPL": 1,
+      "MSRPOPLEX": 0,
+      "OBSERV": [
+        0.25
+      ],
+      "OBSERV_UNIT": ""
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&7B905B21-D904-454F-885B-9CE5D19674E3",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "NUMER": 0,
+      "DENEXCEP": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&5B20AFEA-D4AF-4F7A-A5A3-F1F6165B9E5F",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&3000797E-11B1-4F62-A078-341A4002A11C",
+      "population_index": 0,
+      "IPP": 1,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&920D5B27-DF5A-4770-BD60-FC4EE251C4D2",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&BA108B7B-90B4-4692-B1D0-5DB554D2A1A2",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0,
+      "DENEXCEP": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&F03324C2-9147-457B-BC34-811BB7859C91",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    }
+  ],
+  "familyName": "Test 1",
+  "givenNames": [
+    "Patient"
+  ],
+  "notes": "",
+  "qdmPatient": {
+    "_id": {
+      "$oid": "5c880146d7c8ac4c3e1067e1"
+    },
+    "birthDatetime": "1940-01-01T08:00:00.000+00:00",
+    "dataElements": [
+      {
+        "_id": {
+          "$oid": "5c880146d7c8ac4c3e1067e2"
+        },
+        "authorDatetime": "2011-07-04T08:00:00.000+00:00",
+        "components": [
+
+        ],
+        "dataElementCodes": [
+          {
+            "codeSystem": "LOINC",
+            "code": "59458-0"
+          }
+        ],
+        "description": "Assessment, Performed: Ambulatory Status",
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.117",
+        "id": {
+          "_id": {
+            "$oid": "5c880146d7c8ac4c3e1067e3"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c06ece3b848466bbc906174"
+        },
+        "method": null,
+        "negationRationale": null,
+        "qdmCategory": "assessment",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "result": null,
+        "_type": "QDM::AssessmentPerformed"
+      },
+      {
+        "_id": {
+          "$oid": "5c880146d7c8ac4c3e1067e4"
+        },
+        "authorDatetime": "2012-07-04T08:00:00.000+00:00",
+        "components": [
+
+        ],
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "401196007"
+          },
+          {
+            "codeSystem": "LOINC",
+            "code": "52552-7"
+          }
+        ],
+        "description": "Assessment, Performed: Falls Screening",
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.117",
+        "id": {
+          "_id": {
+            "$oid": "5c880146d7c8ac4c3e1067e5"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c06ece3b848466bbc906175"
+        },
+        "method": null,
+        "negationRationale": null,
+        "qdmCategory": "assessment",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "result": null,
+        "_type": "QDM::AssessmentPerformed"
+      },
+      {
+        "_id": {
+          "$oid": "5c880146d7c8ac4c3e1067e6"
+        },
+        "admissionSource": null,
+        "authorDatetime": "2012-12-04T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "HCPCS",
+            "code": "G0438"
+          }
+        ],
+        "description": "Encounter, Performed: Annual Wellness Visit",
+        "diagnoses": [
+
+        ],
+        "dischargeDisposition": null,
+        "facilityLocations": [
+
+        ],
+        "hqmfOid": "2.16.840.1.113883.3.560.1.79",
+        "id": {
+          "_id": {
+            "$oid": "5c880146d7c8ac4c3e1067e7"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c06ece3b848466bbc906173"
+        },
+        "lengthOfStay": {
+          "value": 0,
+          "unit": "days"
+        },
+        "negationRationale": null,
+        "principalDiagnosis": null,
+        "qdmCategory": "encounter",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "relevantPeriod": {
+          "low": "2012-12-04T08:00:00.000+00:00",
+          "high": "2012-12-04T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "_type": "QDM::EncounterPerformed"
+      },
+      {
+        "_id": {
+          "$oid": "5c880146d7c8ac4c3e1067dc"
+        },
+        "birthDatetime": "1940-01-01T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "code": "21112-8",
+            "codeSystem": "LOINC",
+            "descriptor": null,
+            "codeSystemOid": null,
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.54",
+        "id": {
+          "_id": {
+            "$oid": "5c880146d7c8ac4c3e1067e8"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880146d7c8ac4c3e1067dc"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "birthdate",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicBirthdate"
+      },
+      {
+        "_id": {
+          "$oid": "5c880146d7c8ac4c3e1067dd"
+        },
+        "dataElementCodes": [
+          {
+            "code": "2186-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "Not Hispanic or Latino",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.56",
+        "id": {
+          "_id": {
+            "$oid": "5c880146d7c8ac4c3e1067e9"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880146d7c8ac4c3e1067dd"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "ethnicity",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicEthnicity"
+      },
+      {
+        "_id": {
+          "$oid": "5c880146d7c8ac4c3e1067de"
+        },
+        "dataElementCodes": [
+          {
+            "code": "1002-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "American Indian or Alaska Native",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.59",
+        "id": {
+          "_id": {
+            "$oid": "5c880146d7c8ac4c3e1067ea"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880146d7c8ac4c3e1067de"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "race",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicRace"
+      },
+      {
+        "_id": {
+          "$oid": "5c880146d7c8ac4c3e1067df"
+        },
+        "dataElementCodes": [
+          {
+            "code": "M",
+            "codeSystem": "AdministrativeGender",
+            "descriptor": "M",
+            "codeSystemOid": "2.16.840.1.113883.5.1",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.55",
+        "id": {
+          "_id": {
+            "$oid": "5c880146d7c8ac4c3e1067eb"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880146d7c8ac4c3e1067df"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "gender",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicSex"
+      }
+    ],
+    "extendedData": {
+      "type": null,
+      "measure_ids": [
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+        null,
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&7B905B21-D904-454F-885B-9CE5D19674E3",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&920D5B27-DF5A-4770-BD60-FC4EE251C4D2",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&3000797E-11B1-4F62-A078-341A4002A11C",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&5B20AFEA-D4AF-4F7A-A5A3-F1F6165B9E5F",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&F03324C2-9147-457B-BC34-811BB7859C91",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&BA108B7B-90B4-4692-B1D0-5DB554D2A1A2",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC"
+      ],
+      "source_data_criteria": [
+        {
+          "negation": false,
+          "definition": "assessment",
+          "status": "performed",
+          "title": "AmbulatoryStatus",
+          "description": "Assessment, Performed: Ambulatory Status",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.118.11.1219",
+          "type": "assessments",
+          "id": "AmbulatoryStatus_AssessmentPerformed_eb84926c_ae80_4768_9f88_ea55ed355df6_source",
+          "start_date": 1309766400000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+          "cms_id": "CMS231v0",
+          "criteria_id": "1677b0af52fFX",
+          "codes": {
+            "LOINC": [
+              "59458-0"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5c06ece3b848466bbc906174"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "assessment",
+          "status": "performed",
+          "title": "FallsScreening",
+          "description": "Assessment, Performed: Falls Screening",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.118.12.1028",
+          "type": "assessments",
+          "id": "FallsScreening_AssessmentPerformed_3296d6d9_085b_4acd_84a9_819c01e4e5cd_source",
+          "start_date": 1341388800000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+          "cms_id": "CMS231v0",
+          "criteria_id": "1677b0b4e9bGs",
+          "codes": {
+            "SNOMED-CT": [
+              "401196007"
+            ],
+            "LOINC": [
+              "52552-7"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5c06ece3b848466bbc906175"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "encounter",
+          "status": "performed",
+          "title": "AnnualWellnessVisit",
+          "description": "Encounter, Performed: Annual Wellness Visit",
+          "code_list_id": "2.16.840.1.113883.3.526.3.1240",
+          "type": "encounters",
+          "id": "AnnualWellnessVisit_EncounterPerformed_d50103e4_3ce4_48e3_9489_68dc37fb0b20_source",
+          "start_date": 1354608000000,
+          "end_date": 1354608900000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+          "cms_id": "CMS231v0",
+          "criteria_id": "1677b0ac53a4Q",
+          "codes": {
+            "HCPCS": [
+              "G0438"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5c06ece3b848466bbc906173"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "id": "MeasurePeriod",
+          "start_date": 0,
+          "end_date": 0,
+          "references": null
+        }
+      ],
+      "is_shared": null,
+      "origin_data": [
+
+      ],
+      "test_id": null,
+      "medical_record_number": "d975a2c11a5dbfa9af64642c349f94b5f5e5b43b211617f5d2992dd0438ca8fd",
+      "medical_record_assigner": "Bonnie",
+      "description": null,
+      "description_category": null,
+      "insurance_providers": "[{\"codes\":{\"SOP\":[\"349\"]},\"description\":null,\"end_time\":null,\"financial_responsibility_type\":{\"code\":\"SELF\",\"codeSystem\":\"HL7 Relationship Code\"},\"health_record_field\":null,\"member_id\":\"1234567890\",\"mood_code\":\"EVN\",\"name\":\"Other\",\"negationInd\":null,\"negationReason\":null,\"oid\":null,\"payer\":{\"name\":\"Other\"},\"reason\":null,\"relationship\":null,\"specifics\":null,\"start_time\":1199145600,\"status_code\":null,\"time\":null,\"type\":\"OT\"}]"
+    },
+    "qdmVersion": "5.4"
+  }
+}

--- a/test/fixtures/patients/CMS231v0/Patient_Test 2.json
+++ b/test/fixtures/patients/CMS231v0/Patient_Test 2.json
@@ -1,0 +1,449 @@
+{
+  "_id": {
+    "$oid": "5c06ecf1b848466bbc906184"
+  },
+  "bundleId": "5a57e977942c6d1e61d32f14",
+  "expectedValues": [
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+      "population_index": 0,
+      "IPP": 1,
+      "DENOM": 1,
+      "DENEX": 0,
+      "NUMER": 1
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC",
+      "population_index": 0,
+      "IPP": 1,
+      "MSRPOPL": 1,
+      "MSRPOPLEX": 0,
+      "OBSERV": [
+        0.25
+      ],
+      "OBSERV_UNIT": ""
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&7B905B21-D904-454F-885B-9CE5D19674E3",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "NUMER": 0,
+      "DENEXCEP": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&5B20AFEA-D4AF-4F7A-A5A3-F1F6165B9E5F",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&3000797E-11B1-4F62-A078-341A4002A11C",
+      "population_index": 0,
+      "IPP": 1,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&920D5B27-DF5A-4770-BD60-FC4EE251C4D2",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&BA108B7B-90B4-4692-B1D0-5DB554D2A1A2",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0,
+      "DENEXCEP": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&F03324C2-9147-457B-BC34-811BB7859C91",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    }
+  ],
+  "familyName": "Test 2",
+  "givenNames": [
+    "Patient"
+  ],
+  "notes": "",
+  "qdmPatient": {
+    "_id": {
+      "$oid": "5c880146d7c8ac4c3e1067f1"
+    },
+    "birthDatetime": "1940-01-01T08:00:00.000+00:00",
+    "dataElements": [
+      {
+        "_id": {
+          "$oid": "5c880146d7c8ac4c3e1067f2"
+        },
+        "authorDatetime": "2011-07-04T08:00:00.000+00:00",
+        "components": [
+
+        ],
+        "dataElementCodes": [
+          {
+            "codeSystem": "LOINC",
+            "code": "59458-0"
+          }
+        ],
+        "description": "Assessment, Performed: Ambulatory Status",
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.117",
+        "id": {
+          "_id": {
+            "$oid": "5c880146d7c8ac4c3e1067f3"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c06ecf1b848466bbc906185"
+        },
+        "method": null,
+        "negationRationale": null,
+        "qdmCategory": "assessment",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "result": null,
+        "_type": "QDM::AssessmentPerformed"
+      },
+      {
+        "_id": {
+          "$oid": "5c880146d7c8ac4c3e1067f4"
+        },
+        "authorDatetime": "2012-07-04T08:00:00.000+00:00",
+        "components": [
+
+        ],
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "401196007"
+          },
+          {
+            "codeSystem": "LOINC",
+            "code": "52552-7"
+          }
+        ],
+        "description": "Assessment, Performed: Falls Screening",
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.117",
+        "id": {
+          "_id": {
+            "$oid": "5c880146d7c8ac4c3e1067f5"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c06ecf1b848466bbc906186"
+        },
+        "method": null,
+        "negationRationale": null,
+        "qdmCategory": "assessment",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "result": null,
+        "_type": "QDM::AssessmentPerformed"
+      },
+      {
+        "_id": {
+          "$oid": "5c880146d7c8ac4c3e1067f6"
+        },
+        "admissionSource": null,
+        "authorDatetime": "2012-12-04T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "HCPCS",
+            "code": "G0438"
+          }
+        ],
+        "description": "Encounter, Performed: Annual Wellness Visit",
+        "diagnoses": [
+
+        ],
+        "dischargeDisposition": null,
+        "facilityLocations": [
+
+        ],
+        "hqmfOid": "2.16.840.1.113883.3.560.1.79",
+        "id": {
+          "_id": {
+            "$oid": "5c880146d7c8ac4c3e1067f7"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c06ecf1b848466bbc906187"
+        },
+        "lengthOfStay": {
+          "value": 0,
+          "unit": "days"
+        },
+        "negationRationale": null,
+        "principalDiagnosis": null,
+        "qdmCategory": "encounter",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "relevantPeriod": {
+          "low": "2012-12-04T08:00:00.000+00:00",
+          "high": "2012-12-04T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "_type": "QDM::EncounterPerformed"
+      },
+      {
+        "_id": {
+          "$oid": "5c880146d7c8ac4c3e1067ec"
+        },
+        "birthDatetime": "1940-01-01T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "code": "21112-8",
+            "codeSystem": "LOINC",
+            "descriptor": null,
+            "codeSystemOid": null,
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.54",
+        "id": {
+          "_id": {
+            "$oid": "5c880146d7c8ac4c3e1067f8"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880146d7c8ac4c3e1067ec"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "birthdate",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicBirthdate"
+      },
+      {
+        "_id": {
+          "$oid": "5c880146d7c8ac4c3e1067ed"
+        },
+        "dataElementCodes": [
+          {
+            "code": "2186-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "Not Hispanic or Latino",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.56",
+        "id": {
+          "_id": {
+            "$oid": "5c880146d7c8ac4c3e1067f9"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880146d7c8ac4c3e1067ed"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "ethnicity",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicEthnicity"
+      },
+      {
+        "_id": {
+          "$oid": "5c880146d7c8ac4c3e1067ee"
+        },
+        "dataElementCodes": [
+          {
+            "code": "1002-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "American Indian or Alaska Native",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.59",
+        "id": {
+          "_id": {
+            "$oid": "5c880146d7c8ac4c3e1067fa"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880146d7c8ac4c3e1067ee"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "race",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicRace"
+      },
+      {
+        "_id": {
+          "$oid": "5c880146d7c8ac4c3e1067ef"
+        },
+        "dataElementCodes": [
+          {
+            "code": "M",
+            "codeSystem": "AdministrativeGender",
+            "descriptor": "M",
+            "codeSystemOid": "2.16.840.1.113883.5.1",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.55",
+        "id": {
+          "_id": {
+            "$oid": "5c880146d7c8ac4c3e1067fb"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880146d7c8ac4c3e1067ef"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "gender",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicSex"
+      }
+    ],
+    "extendedData": {
+      "type": null,
+      "measure_ids": [
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&7B905B21-D904-454F-885B-9CE5D19674E3",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&920D5B27-DF5A-4770-BD60-FC4EE251C4D2",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&3000797E-11B1-4F62-A078-341A4002A11C",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&5B20AFEA-D4AF-4F7A-A5A3-F1F6165B9E5F",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&F03324C2-9147-457B-BC34-811BB7859C91",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&BA108B7B-90B4-4692-B1D0-5DB554D2A1A2",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC",
+        null
+      ],
+      "source_data_criteria": [
+        {
+          "negation": false,
+          "definition": "assessment",
+          "status": "performed",
+          "title": "AmbulatoryStatus",
+          "description": "Assessment, Performed: Ambulatory Status",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.118.11.1219",
+          "type": "assessments",
+          "id": "AmbulatoryStatus_AssessmentPerformed_eb84926c_ae80_4768_9f88_ea55ed355df6_source",
+          "start_date": 1309766400000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+          "cms_id": "CMS231v0",
+          "criteria_id": "1677b0af52fFX",
+          "codes": {
+            "LOINC": [
+              "59458-0"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5c06ecf1b848466bbc906185"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "assessment",
+          "status": "performed",
+          "title": "FallsScreening",
+          "description": "Assessment, Performed: Falls Screening",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.118.12.1028",
+          "type": "assessments",
+          "id": "FallsScreening_AssessmentPerformed_3296d6d9_085b_4acd_84a9_819c01e4e5cd_source",
+          "start_date": 1341388800000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+          "cms_id": "CMS231v0",
+          "criteria_id": "1677b0b4e9bGs",
+          "codes": {
+            "SNOMED-CT": [
+              "401196007"
+            ],
+            "LOINC": [
+              "52552-7"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5c06ecf1b848466bbc906186"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "encounter",
+          "status": "performed",
+          "title": "AnnualWellnessVisit",
+          "description": "Encounter, Performed: Annual Wellness Visit",
+          "code_list_id": "2.16.840.1.113883.3.526.3.1240",
+          "type": "encounters",
+          "id": "AnnualWellnessVisit_EncounterPerformed_d50103e4_3ce4_48e3_9489_68dc37fb0b20_source",
+          "start_date": 1354608000000,
+          "end_date": 1354608900000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+          "cms_id": "CMS231v0",
+          "criteria_id": "1677b0ac53a4Q",
+          "codes": {
+            "HCPCS": [
+              "G0438"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5c06ecf1b848466bbc906187"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "id": "MeasurePeriod",
+          "start_date": 0,
+          "end_date": 0,
+          "references": null
+        }
+      ],
+      "is_shared": null,
+      "origin_data": [
+
+      ],
+      "test_id": null,
+      "medical_record_number": "66e7185c846fb50aaff1541a59d0b72284f89f64783a89bb33f9ae0d93f07361",
+      "medical_record_assigner": "Bonnie",
+      "description": null,
+      "description_category": null,
+      "insurance_providers": "[{\"codes\":{\"SOP\":[\"349\"]},\"description\":null,\"end_time\":null,\"financial_responsibility_type\":{\"code\":\"SELF\",\"codeSystem\":\"HL7 Relationship Code\"},\"health_record_field\":null,\"member_id\":\"1234567890\",\"mood_code\":\"EVN\",\"name\":\"Other\",\"negationInd\":null,\"negationReason\":null,\"oid\":null,\"payer\":{\"name\":\"Other\"},\"reason\":null,\"relationship\":null,\"specifics\":null,\"start_time\":1199145600,\"status_code\":null,\"time\":null,\"type\":\"OT\"}]"
+    },
+    "qdmVersion": "5.4"
+  }
+}

--- a/test/fixtures/patients/CMS232v0/Patient_Test 1.json
+++ b/test/fixtures/patients/CMS232v0/Patient_Test 1.json
@@ -1,0 +1,449 @@
+{
+  "_id": {
+    "$oid": "5c06ec72b848466bbc906066"
+  },
+  "bundleId": "5a57e977942c6d1e61d32f14",
+  "expectedValues": [
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+      "population_index": 0,
+      "IPP": 1,
+      "DENOM": 1,
+      "DENEX": 0,
+      "NUMER": 1
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC",
+      "population_index": 0,
+      "IPP": 1,
+      "MSRPOPL": 1,
+      "MSRPOPLEX": 0,
+      "OBSERV": [
+        0.25
+      ],
+      "OBSERV_UNIT": ""
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&7B905B21-D904-454F-885B-9CE5D19674E3",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "NUMER": 0,
+      "DENEXCEP": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&5B20AFEA-D4AF-4F7A-A5A3-F1F6165B9E5F",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&3000797E-11B1-4F62-A078-341A4002A11C",
+      "population_index": 0,
+      "IPP": 1,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&920D5B27-DF5A-4770-BD60-FC4EE251C4D2",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&BA108B7B-90B4-4692-B1D0-5DB554D2A1A2",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0,
+      "DENEXCEP": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&F03324C2-9147-457B-BC34-811BB7859C91",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    }
+  ],
+  "familyName": "Test 1",
+  "givenNames": [
+    "Patient"
+  ],
+  "notes": "",
+  "qdmPatient": {
+    "_id": {
+      "$oid": "5c880147d7c8ac4c3e106801"
+    },
+    "birthDatetime": "1940-01-01T08:00:00.000+00:00",
+    "dataElements": [
+      {
+        "_id": {
+          "$oid": "5c880147d7c8ac4c3e106802"
+        },
+        "authorDatetime": "2011-07-04T08:00:00.000+00:00",
+        "components": [
+
+        ],
+        "dataElementCodes": [
+          {
+            "codeSystem": "LOINC",
+            "code": "59458-0"
+          }
+        ],
+        "description": "Assessment, Performed: Ambulatory Status",
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.117",
+        "id": {
+          "_id": {
+            "$oid": "5c880147d7c8ac4c3e106803"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c06ece3b848466bbc906174"
+        },
+        "method": null,
+        "negationRationale": null,
+        "qdmCategory": "assessment",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "result": null,
+        "_type": "QDM::AssessmentPerformed"
+      },
+      {
+        "_id": {
+          "$oid": "5c880147d7c8ac4c3e106804"
+        },
+        "authorDatetime": "2012-07-04T08:00:00.000+00:00",
+        "components": [
+
+        ],
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "401196007"
+          },
+          {
+            "codeSystem": "LOINC",
+            "code": "52552-7"
+          }
+        ],
+        "description": "Assessment, Performed: Falls Screening",
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.117",
+        "id": {
+          "_id": {
+            "$oid": "5c880147d7c8ac4c3e106805"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c06ece3b848466bbc906175"
+        },
+        "method": null,
+        "negationRationale": null,
+        "qdmCategory": "assessment",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "result": null,
+        "_type": "QDM::AssessmentPerformed"
+      },
+      {
+        "_id": {
+          "$oid": "5c880147d7c8ac4c3e106806"
+        },
+        "admissionSource": null,
+        "authorDatetime": "2012-12-04T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "HCPCS",
+            "code": "G0438"
+          }
+        ],
+        "description": "Encounter, Performed: Annual Wellness Visit",
+        "diagnoses": [
+
+        ],
+        "dischargeDisposition": null,
+        "facilityLocations": [
+
+        ],
+        "hqmfOid": "2.16.840.1.113883.3.560.1.79",
+        "id": {
+          "_id": {
+            "$oid": "5c880147d7c8ac4c3e106807"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c06ece3b848466bbc906173"
+        },
+        "lengthOfStay": {
+          "value": 0,
+          "unit": "days"
+        },
+        "negationRationale": null,
+        "principalDiagnosis": null,
+        "qdmCategory": "encounter",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "relevantPeriod": {
+          "low": "2012-12-04T08:00:00.000+00:00",
+          "high": "2012-12-04T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "_type": "QDM::EncounterPerformed"
+      },
+      {
+        "_id": {
+          "$oid": "5c880147d7c8ac4c3e1067fc"
+        },
+        "birthDatetime": "1940-01-01T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "code": "21112-8",
+            "codeSystem": "LOINC",
+            "descriptor": null,
+            "codeSystemOid": null,
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.54",
+        "id": {
+          "_id": {
+            "$oid": "5c880147d7c8ac4c3e106808"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880147d7c8ac4c3e1067fc"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "birthdate",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicBirthdate"
+      },
+      {
+        "_id": {
+          "$oid": "5c880147d7c8ac4c3e1067fd"
+        },
+        "dataElementCodes": [
+          {
+            "code": "2186-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "Not Hispanic or Latino",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.56",
+        "id": {
+          "_id": {
+            "$oid": "5c880147d7c8ac4c3e106809"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880147d7c8ac4c3e1067fd"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "ethnicity",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicEthnicity"
+      },
+      {
+        "_id": {
+          "$oid": "5c880147d7c8ac4c3e1067fe"
+        },
+        "dataElementCodes": [
+          {
+            "code": "1002-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "American Indian or Alaska Native",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.59",
+        "id": {
+          "_id": {
+            "$oid": "5c880147d7c8ac4c3e10680a"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880147d7c8ac4c3e1067fe"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "race",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicRace"
+      },
+      {
+        "_id": {
+          "$oid": "5c880147d7c8ac4c3e1067ff"
+        },
+        "dataElementCodes": [
+          {
+            "code": "M",
+            "codeSystem": "AdministrativeGender",
+            "descriptor": "M",
+            "codeSystemOid": "2.16.840.1.113883.5.1",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.55",
+        "id": {
+          "_id": {
+            "$oid": "5c880147d7c8ac4c3e10680b"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880147d7c8ac4c3e1067ff"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "gender",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicSex"
+      }
+    ],
+    "extendedData": {
+      "type": null,
+      "measure_ids": [
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+        null,
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&7B905B21-D904-454F-885B-9CE5D19674E3",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&920D5B27-DF5A-4770-BD60-FC4EE251C4D2",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&3000797E-11B1-4F62-A078-341A4002A11C",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&5B20AFEA-D4AF-4F7A-A5A3-F1F6165B9E5F",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&F03324C2-9147-457B-BC34-811BB7859C91",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&BA108B7B-90B4-4692-B1D0-5DB554D2A1A2",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC"
+      ],
+      "source_data_criteria": [
+        {
+          "negation": false,
+          "definition": "assessment",
+          "status": "performed",
+          "title": "AmbulatoryStatus",
+          "description": "Assessment, Performed: Ambulatory Status",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.118.11.1219",
+          "type": "assessments",
+          "id": "AmbulatoryStatus_AssessmentPerformed_eb84926c_ae80_4768_9f88_ea55ed355df6_source",
+          "start_date": 1309766400000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+          "cms_id": "CMS231v0",
+          "criteria_id": "1677b0af52fFX",
+          "codes": {
+            "LOINC": [
+              "59458-0"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5c06ece3b848466bbc906174"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "assessment",
+          "status": "performed",
+          "title": "FallsScreening",
+          "description": "Assessment, Performed: Falls Screening",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.118.12.1028",
+          "type": "assessments",
+          "id": "FallsScreening_AssessmentPerformed_3296d6d9_085b_4acd_84a9_819c01e4e5cd_source",
+          "start_date": 1341388800000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+          "cms_id": "CMS231v0",
+          "criteria_id": "1677b0b4e9bGs",
+          "codes": {
+            "SNOMED-CT": [
+              "401196007"
+            ],
+            "LOINC": [
+              "52552-7"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5c06ece3b848466bbc906175"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "encounter",
+          "status": "performed",
+          "title": "AnnualWellnessVisit",
+          "description": "Encounter, Performed: Annual Wellness Visit",
+          "code_list_id": "2.16.840.1.113883.3.526.3.1240",
+          "type": "encounters",
+          "id": "AnnualWellnessVisit_EncounterPerformed_d50103e4_3ce4_48e3_9489_68dc37fb0b20_source",
+          "start_date": 1354608000000,
+          "end_date": 1354608900000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+          "cms_id": "CMS231v0",
+          "criteria_id": "1677b0ac53a4Q",
+          "codes": {
+            "HCPCS": [
+              "G0438"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5c06ece3b848466bbc906173"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "id": "MeasurePeriod",
+          "start_date": 0,
+          "end_date": 0,
+          "references": null
+        }
+      ],
+      "is_shared": null,
+      "origin_data": [
+
+      ],
+      "test_id": null,
+      "medical_record_number": "d975a2c11a5dbfa9af64642c349f94b5f5e5b43b211617f5d2992dd0438ca8fd",
+      "medical_record_assigner": "Bonnie",
+      "description": null,
+      "description_category": null,
+      "insurance_providers": "[{\"codes\":{\"SOP\":[\"349\"]},\"description\":null,\"end_time\":null,\"financial_responsibility_type\":{\"code\":\"SELF\",\"codeSystem\":\"HL7 Relationship Code\"},\"health_record_field\":null,\"member_id\":\"1234567890\",\"mood_code\":\"EVN\",\"name\":\"Other\",\"negationInd\":null,\"negationReason\":null,\"oid\":null,\"payer\":{\"name\":\"Other\"},\"reason\":null,\"relationship\":null,\"specifics\":null,\"start_time\":1199145600,\"status_code\":null,\"time\":null,\"type\":\"OT\"}]"
+    },
+    "qdmVersion": "5.4"
+  }
+}

--- a/test/fixtures/patients/CMS232v0/Patient_Test 2.json
+++ b/test/fixtures/patients/CMS232v0/Patient_Test 2.json
@@ -1,0 +1,449 @@
+{
+  "_id": {
+    "$oid": "5c06ecf1b848466bbc906184"
+  },
+  "bundleId": "5a57e977942c6d1e61d32f14",
+  "expectedValues": [
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+      "population_index": 0,
+      "IPP": 1,
+      "DENOM": 1,
+      "DENEX": 0,
+      "NUMER": 1
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC",
+      "population_index": 0,
+      "IPP": 1,
+      "MSRPOPL": 1,
+      "MSRPOPLEX": 0,
+      "OBSERV": [
+        0.25
+      ],
+      "OBSERV_UNIT": ""
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&7B905B21-D904-454F-885B-9CE5D19674E3",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "NUMER": 0,
+      "DENEXCEP": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&5B20AFEA-D4AF-4F7A-A5A3-F1F6165B9E5F",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&3000797E-11B1-4F62-A078-341A4002A11C",
+      "population_index": 0,
+      "IPP": 1,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&920D5B27-DF5A-4770-BD60-FC4EE251C4D2",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&BA108B7B-90B4-4692-B1D0-5DB554D2A1A2",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0,
+      "DENEXCEP": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&F03324C2-9147-457B-BC34-811BB7859C91",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    }
+  ],
+  "familyName": "Test 2",
+  "givenNames": [
+    "Patient"
+  ],
+  "notes": "",
+  "qdmPatient": {
+    "_id": {
+      "$oid": "5c880147d7c8ac4c3e106811"
+    },
+    "birthDatetime": "1940-01-01T08:00:00.000+00:00",
+    "dataElements": [
+      {
+        "_id": {
+          "$oid": "5c880147d7c8ac4c3e106812"
+        },
+        "authorDatetime": "2011-07-04T08:00:00.000+00:00",
+        "components": [
+
+        ],
+        "dataElementCodes": [
+          {
+            "codeSystem": "LOINC",
+            "code": "59458-0"
+          }
+        ],
+        "description": "Assessment, Performed: Ambulatory Status",
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.117",
+        "id": {
+          "_id": {
+            "$oid": "5c880147d7c8ac4c3e106813"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c06ecf1b848466bbc906185"
+        },
+        "method": null,
+        "negationRationale": null,
+        "qdmCategory": "assessment",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "result": null,
+        "_type": "QDM::AssessmentPerformed"
+      },
+      {
+        "_id": {
+          "$oid": "5c880147d7c8ac4c3e106814"
+        },
+        "authorDatetime": "2012-07-04T08:00:00.000+00:00",
+        "components": [
+
+        ],
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "401196007"
+          },
+          {
+            "codeSystem": "LOINC",
+            "code": "52552-7"
+          }
+        ],
+        "description": "Assessment, Performed: Falls Screening",
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.117",
+        "id": {
+          "_id": {
+            "$oid": "5c880147d7c8ac4c3e106815"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c06ecf1b848466bbc906186"
+        },
+        "method": null,
+        "negationRationale": null,
+        "qdmCategory": "assessment",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "result": null,
+        "_type": "QDM::AssessmentPerformed"
+      },
+      {
+        "_id": {
+          "$oid": "5c880147d7c8ac4c3e106816"
+        },
+        "admissionSource": null,
+        "authorDatetime": "2012-12-04T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "HCPCS",
+            "code": "G0438"
+          }
+        ],
+        "description": "Encounter, Performed: Annual Wellness Visit",
+        "diagnoses": [
+
+        ],
+        "dischargeDisposition": null,
+        "facilityLocations": [
+
+        ],
+        "hqmfOid": "2.16.840.1.113883.3.560.1.79",
+        "id": {
+          "_id": {
+            "$oid": "5c880147d7c8ac4c3e106817"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c06ecf1b848466bbc906187"
+        },
+        "lengthOfStay": {
+          "value": 0,
+          "unit": "days"
+        },
+        "negationRationale": null,
+        "principalDiagnosis": null,
+        "qdmCategory": "encounter",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "relevantPeriod": {
+          "low": "2012-12-04T08:00:00.000+00:00",
+          "high": "2012-12-04T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "_type": "QDM::EncounterPerformed"
+      },
+      {
+        "_id": {
+          "$oid": "5c880147d7c8ac4c3e10680c"
+        },
+        "birthDatetime": "1940-01-01T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "code": "21112-8",
+            "codeSystem": "LOINC",
+            "descriptor": null,
+            "codeSystemOid": null,
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.54",
+        "id": {
+          "_id": {
+            "$oid": "5c880147d7c8ac4c3e106818"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880147d7c8ac4c3e10680c"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "birthdate",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicBirthdate"
+      },
+      {
+        "_id": {
+          "$oid": "5c880147d7c8ac4c3e10680d"
+        },
+        "dataElementCodes": [
+          {
+            "code": "2186-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "Not Hispanic or Latino",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.56",
+        "id": {
+          "_id": {
+            "$oid": "5c880147d7c8ac4c3e106819"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880147d7c8ac4c3e10680d"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "ethnicity",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicEthnicity"
+      },
+      {
+        "_id": {
+          "$oid": "5c880147d7c8ac4c3e10680e"
+        },
+        "dataElementCodes": [
+          {
+            "code": "1002-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "American Indian or Alaska Native",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.59",
+        "id": {
+          "_id": {
+            "$oid": "5c880147d7c8ac4c3e10681a"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880147d7c8ac4c3e10680e"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "race",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicRace"
+      },
+      {
+        "_id": {
+          "$oid": "5c880147d7c8ac4c3e10680f"
+        },
+        "dataElementCodes": [
+          {
+            "code": "M",
+            "codeSystem": "AdministrativeGender",
+            "descriptor": "M",
+            "codeSystemOid": "2.16.840.1.113883.5.1",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.55",
+        "id": {
+          "_id": {
+            "$oid": "5c880147d7c8ac4c3e10681b"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880147d7c8ac4c3e10680f"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "gender",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicSex"
+      }
+    ],
+    "extendedData": {
+      "type": null,
+      "measure_ids": [
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&7B905B21-D904-454F-885B-9CE5D19674E3",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&920D5B27-DF5A-4770-BD60-FC4EE251C4D2",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&3000797E-11B1-4F62-A078-341A4002A11C",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&5B20AFEA-D4AF-4F7A-A5A3-F1F6165B9E5F",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&F03324C2-9147-457B-BC34-811BB7859C91",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&BA108B7B-90B4-4692-B1D0-5DB554D2A1A2",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC",
+        null
+      ],
+      "source_data_criteria": [
+        {
+          "negation": false,
+          "definition": "assessment",
+          "status": "performed",
+          "title": "AmbulatoryStatus",
+          "description": "Assessment, Performed: Ambulatory Status",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.118.11.1219",
+          "type": "assessments",
+          "id": "AmbulatoryStatus_AssessmentPerformed_eb84926c_ae80_4768_9f88_ea55ed355df6_source",
+          "start_date": 1309766400000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+          "cms_id": "CMS231v0",
+          "criteria_id": "1677b0af52fFX",
+          "codes": {
+            "LOINC": [
+              "59458-0"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5c06ecf1b848466bbc906185"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "assessment",
+          "status": "performed",
+          "title": "FallsScreening",
+          "description": "Assessment, Performed: Falls Screening",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.118.12.1028",
+          "type": "assessments",
+          "id": "FallsScreening_AssessmentPerformed_3296d6d9_085b_4acd_84a9_819c01e4e5cd_source",
+          "start_date": 1341388800000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+          "cms_id": "CMS231v0",
+          "criteria_id": "1677b0b4e9bGs",
+          "codes": {
+            "SNOMED-CT": [
+              "401196007"
+            ],
+            "LOINC": [
+              "52552-7"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5c06ecf1b848466bbc906186"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "encounter",
+          "status": "performed",
+          "title": "AnnualWellnessVisit",
+          "description": "Encounter, Performed: Annual Wellness Visit",
+          "code_list_id": "2.16.840.1.113883.3.526.3.1240",
+          "type": "encounters",
+          "id": "AnnualWellnessVisit_EncounterPerformed_d50103e4_3ce4_48e3_9489_68dc37fb0b20_source",
+          "start_date": 1354608000000,
+          "end_date": 1354608900000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+          "cms_id": "CMS231v0",
+          "criteria_id": "1677b0ac53a4Q",
+          "codes": {
+            "HCPCS": [
+              "G0438"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5c06ecf1b848466bbc906187"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "id": "MeasurePeriod",
+          "start_date": 0,
+          "end_date": 0,
+          "references": null
+        }
+      ],
+      "is_shared": null,
+      "origin_data": [
+
+      ],
+      "test_id": null,
+      "medical_record_number": "66e7185c846fb50aaff1541a59d0b72284f89f64783a89bb33f9ae0d93f07361",
+      "medical_record_assigner": "Bonnie",
+      "description": null,
+      "description_category": null,
+      "insurance_providers": "[{\"codes\":{\"SOP\":[\"349\"]},\"description\":null,\"end_time\":null,\"financial_responsibility_type\":{\"code\":\"SELF\",\"codeSystem\":\"HL7 Relationship Code\"},\"health_record_field\":null,\"member_id\":\"1234567890\",\"mood_code\":\"EVN\",\"name\":\"Other\",\"negationInd\":null,\"negationReason\":null,\"oid\":null,\"payer\":{\"name\":\"Other\"},\"reason\":null,\"relationship\":null,\"specifics\":null,\"start_time\":1199145600,\"status_code\":null,\"time\":null,\"type\":\"OT\"}]"
+    },
+    "qdmVersion": "5.4"
+  }
+}

--- a/test/fixtures/patients/CMS233v0/Patient_Test 1.json
+++ b/test/fixtures/patients/CMS233v0/Patient_Test 1.json
@@ -1,0 +1,449 @@
+{
+  "_id": {
+    "$oid": "5c06ec72b848466bbc906066"
+  },
+  "bundleId": "5a57e977942c6d1e61d32f14",
+  "expectedValues": [
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+      "population_index": 0,
+      "IPP": 1,
+      "DENOM": 1,
+      "DENEX": 0,
+      "NUMER": 1
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC",
+      "population_index": 0,
+      "IPP": 1,
+      "MSRPOPL": 1,
+      "MSRPOPLEX": 0,
+      "OBSERV": [
+        0.25
+      ],
+      "OBSERV_UNIT": ""
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&7B905B21-D904-454F-885B-9CE5D19674E3",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "NUMER": 0,
+      "DENEXCEP": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&5B20AFEA-D4AF-4F7A-A5A3-F1F6165B9E5F",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&3000797E-11B1-4F62-A078-341A4002A11C",
+      "population_index": 0,
+      "IPP": 1,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&920D5B27-DF5A-4770-BD60-FC4EE251C4D2",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&BA108B7B-90B4-4692-B1D0-5DB554D2A1A2",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0,
+      "DENEXCEP": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&F03324C2-9147-457B-BC34-811BB7859C91",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    }
+  ],
+  "familyName": "Test 1",
+  "givenNames": [
+    "Patient"
+  ],
+  "notes": "",
+  "qdmPatient": {
+    "_id": {
+      "$oid": "5c880147d7c8ac4c3e106821"
+    },
+    "birthDatetime": "1940-01-01T08:00:00.000+00:00",
+    "dataElements": [
+      {
+        "_id": {
+          "$oid": "5c880147d7c8ac4c3e106822"
+        },
+        "authorDatetime": "2011-07-04T08:00:00.000+00:00",
+        "components": [
+
+        ],
+        "dataElementCodes": [
+          {
+            "codeSystem": "LOINC",
+            "code": "59458-0"
+          }
+        ],
+        "description": "Assessment, Performed: Ambulatory Status",
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.117",
+        "id": {
+          "_id": {
+            "$oid": "5c880147d7c8ac4c3e106823"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c06ece3b848466bbc906174"
+        },
+        "method": null,
+        "negationRationale": null,
+        "qdmCategory": "assessment",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "result": null,
+        "_type": "QDM::AssessmentPerformed"
+      },
+      {
+        "_id": {
+          "$oid": "5c880147d7c8ac4c3e106824"
+        },
+        "authorDatetime": "2012-07-04T08:00:00.000+00:00",
+        "components": [
+
+        ],
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "401196007"
+          },
+          {
+            "codeSystem": "LOINC",
+            "code": "52552-7"
+          }
+        ],
+        "description": "Assessment, Performed: Falls Screening",
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.117",
+        "id": {
+          "_id": {
+            "$oid": "5c880147d7c8ac4c3e106825"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c06ece3b848466bbc906175"
+        },
+        "method": null,
+        "negationRationale": null,
+        "qdmCategory": "assessment",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "result": null,
+        "_type": "QDM::AssessmentPerformed"
+      },
+      {
+        "_id": {
+          "$oid": "5c880147d7c8ac4c3e106826"
+        },
+        "admissionSource": null,
+        "authorDatetime": "2012-12-04T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "HCPCS",
+            "code": "G0438"
+          }
+        ],
+        "description": "Encounter, Performed: Annual Wellness Visit",
+        "diagnoses": [
+
+        ],
+        "dischargeDisposition": null,
+        "facilityLocations": [
+
+        ],
+        "hqmfOid": "2.16.840.1.113883.3.560.1.79",
+        "id": {
+          "_id": {
+            "$oid": "5c880147d7c8ac4c3e106827"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c06ece3b848466bbc906173"
+        },
+        "lengthOfStay": {
+          "value": 0,
+          "unit": "days"
+        },
+        "negationRationale": null,
+        "principalDiagnosis": null,
+        "qdmCategory": "encounter",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "relevantPeriod": {
+          "low": "2012-12-04T08:00:00.000+00:00",
+          "high": "2012-12-04T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "_type": "QDM::EncounterPerformed"
+      },
+      {
+        "_id": {
+          "$oid": "5c880147d7c8ac4c3e10681c"
+        },
+        "birthDatetime": "1940-01-01T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "code": "21112-8",
+            "codeSystem": "LOINC",
+            "descriptor": null,
+            "codeSystemOid": null,
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.54",
+        "id": {
+          "_id": {
+            "$oid": "5c880147d7c8ac4c3e106828"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880147d7c8ac4c3e10681c"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "birthdate",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicBirthdate"
+      },
+      {
+        "_id": {
+          "$oid": "5c880147d7c8ac4c3e10681d"
+        },
+        "dataElementCodes": [
+          {
+            "code": "2186-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "Not Hispanic or Latino",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.56",
+        "id": {
+          "_id": {
+            "$oid": "5c880147d7c8ac4c3e106829"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880147d7c8ac4c3e10681d"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "ethnicity",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicEthnicity"
+      },
+      {
+        "_id": {
+          "$oid": "5c880147d7c8ac4c3e10681e"
+        },
+        "dataElementCodes": [
+          {
+            "code": "1002-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "American Indian or Alaska Native",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.59",
+        "id": {
+          "_id": {
+            "$oid": "5c880147d7c8ac4c3e10682a"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880147d7c8ac4c3e10681e"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "race",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicRace"
+      },
+      {
+        "_id": {
+          "$oid": "5c880147d7c8ac4c3e10681f"
+        },
+        "dataElementCodes": [
+          {
+            "code": "M",
+            "codeSystem": "AdministrativeGender",
+            "descriptor": "M",
+            "codeSystemOid": "2.16.840.1.113883.5.1",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.55",
+        "id": {
+          "_id": {
+            "$oid": "5c880147d7c8ac4c3e10682b"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880147d7c8ac4c3e10681f"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "gender",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicSex"
+      }
+    ],
+    "extendedData": {
+      "type": null,
+      "measure_ids": [
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+        null,
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&7B905B21-D904-454F-885B-9CE5D19674E3",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&920D5B27-DF5A-4770-BD60-FC4EE251C4D2",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&3000797E-11B1-4F62-A078-341A4002A11C",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&5B20AFEA-D4AF-4F7A-A5A3-F1F6165B9E5F",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&F03324C2-9147-457B-BC34-811BB7859C91",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&BA108B7B-90B4-4692-B1D0-5DB554D2A1A2",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC"
+      ],
+      "source_data_criteria": [
+        {
+          "negation": false,
+          "definition": "assessment",
+          "status": "performed",
+          "title": "AmbulatoryStatus",
+          "description": "Assessment, Performed: Ambulatory Status",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.118.11.1219",
+          "type": "assessments",
+          "id": "AmbulatoryStatus_AssessmentPerformed_eb84926c_ae80_4768_9f88_ea55ed355df6_source",
+          "start_date": 1309766400000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+          "cms_id": "CMS231v0",
+          "criteria_id": "1677b0af52fFX",
+          "codes": {
+            "LOINC": [
+              "59458-0"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5c06ece3b848466bbc906174"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "assessment",
+          "status": "performed",
+          "title": "FallsScreening",
+          "description": "Assessment, Performed: Falls Screening",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.118.12.1028",
+          "type": "assessments",
+          "id": "FallsScreening_AssessmentPerformed_3296d6d9_085b_4acd_84a9_819c01e4e5cd_source",
+          "start_date": 1341388800000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+          "cms_id": "CMS231v0",
+          "criteria_id": "1677b0b4e9bGs",
+          "codes": {
+            "SNOMED-CT": [
+              "401196007"
+            ],
+            "LOINC": [
+              "52552-7"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5c06ece3b848466bbc906175"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "encounter",
+          "status": "performed",
+          "title": "AnnualWellnessVisit",
+          "description": "Encounter, Performed: Annual Wellness Visit",
+          "code_list_id": "2.16.840.1.113883.3.526.3.1240",
+          "type": "encounters",
+          "id": "AnnualWellnessVisit_EncounterPerformed_d50103e4_3ce4_48e3_9489_68dc37fb0b20_source",
+          "start_date": 1354608000000,
+          "end_date": 1354608900000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+          "cms_id": "CMS231v0",
+          "criteria_id": "1677b0ac53a4Q",
+          "codes": {
+            "HCPCS": [
+              "G0438"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5c06ece3b848466bbc906173"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "id": "MeasurePeriod",
+          "start_date": 0,
+          "end_date": 0,
+          "references": null
+        }
+      ],
+      "is_shared": null,
+      "origin_data": [
+
+      ],
+      "test_id": null,
+      "medical_record_number": "d975a2c11a5dbfa9af64642c349f94b5f5e5b43b211617f5d2992dd0438ca8fd",
+      "medical_record_assigner": "Bonnie",
+      "description": null,
+      "description_category": null,
+      "insurance_providers": "[{\"codes\":{\"SOP\":[\"349\"]},\"description\":null,\"end_time\":null,\"financial_responsibility_type\":{\"code\":\"SELF\",\"codeSystem\":\"HL7 Relationship Code\"},\"health_record_field\":null,\"member_id\":\"1234567890\",\"mood_code\":\"EVN\",\"name\":\"Other\",\"negationInd\":null,\"negationReason\":null,\"oid\":null,\"payer\":{\"name\":\"Other\"},\"reason\":null,\"relationship\":null,\"specifics\":null,\"start_time\":1199145600,\"status_code\":null,\"time\":null,\"type\":\"OT\"}]"
+    },
+    "qdmVersion": "5.4"
+  }
+}

--- a/test/fixtures/patients/CMS233v0/Patient_Test 2.json
+++ b/test/fixtures/patients/CMS233v0/Patient_Test 2.json
@@ -1,0 +1,449 @@
+{
+  "_id": {
+    "$oid": "5c06ecf1b848466bbc906184"
+  },
+  "bundleId": "5a57e977942c6d1e61d32f14",
+  "expectedValues": [
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+      "population_index": 0,
+      "IPP": 1,
+      "DENOM": 1,
+      "DENEX": 0,
+      "NUMER": 1
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC",
+      "population_index": 0,
+      "IPP": 1,
+      "MSRPOPL": 1,
+      "MSRPOPLEX": 0,
+      "OBSERV": [
+        0.25
+      ],
+      "OBSERV_UNIT": ""
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&7B905B21-D904-454F-885B-9CE5D19674E3",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "NUMER": 0,
+      "DENEXCEP": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&5B20AFEA-D4AF-4F7A-A5A3-F1F6165B9E5F",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&3000797E-11B1-4F62-A078-341A4002A11C",
+      "population_index": 0,
+      "IPP": 1,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&920D5B27-DF5A-4770-BD60-FC4EE251C4D2",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&BA108B7B-90B4-4692-B1D0-5DB554D2A1A2",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0,
+      "DENEXCEP": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&F03324C2-9147-457B-BC34-811BB7859C91",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    }
+  ],
+  "familyName": "Test 2",
+  "givenNames": [
+    "Patient"
+  ],
+  "notes": "",
+  "qdmPatient": {
+    "_id": {
+      "$oid": "5c880147d7c8ac4c3e106831"
+    },
+    "birthDatetime": "1940-01-01T08:00:00.000+00:00",
+    "dataElements": [
+      {
+        "_id": {
+          "$oid": "5c880147d7c8ac4c3e106832"
+        },
+        "authorDatetime": "2011-07-04T08:00:00.000+00:00",
+        "components": [
+
+        ],
+        "dataElementCodes": [
+          {
+            "codeSystem": "LOINC",
+            "code": "59458-0"
+          }
+        ],
+        "description": "Assessment, Performed: Ambulatory Status",
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.117",
+        "id": {
+          "_id": {
+            "$oid": "5c880147d7c8ac4c3e106833"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c06ecf1b848466bbc906185"
+        },
+        "method": null,
+        "negationRationale": null,
+        "qdmCategory": "assessment",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "result": null,
+        "_type": "QDM::AssessmentPerformed"
+      },
+      {
+        "_id": {
+          "$oid": "5c880147d7c8ac4c3e106834"
+        },
+        "authorDatetime": "2012-07-04T08:00:00.000+00:00",
+        "components": [
+
+        ],
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "401196007"
+          },
+          {
+            "codeSystem": "LOINC",
+            "code": "52552-7"
+          }
+        ],
+        "description": "Assessment, Performed: Falls Screening",
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.117",
+        "id": {
+          "_id": {
+            "$oid": "5c880147d7c8ac4c3e106835"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c06ecf1b848466bbc906186"
+        },
+        "method": null,
+        "negationRationale": null,
+        "qdmCategory": "assessment",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "result": null,
+        "_type": "QDM::AssessmentPerformed"
+      },
+      {
+        "_id": {
+          "$oid": "5c880147d7c8ac4c3e106836"
+        },
+        "admissionSource": null,
+        "authorDatetime": "2012-12-04T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "HCPCS",
+            "code": "G0438"
+          }
+        ],
+        "description": "Encounter, Performed: Annual Wellness Visit",
+        "diagnoses": [
+
+        ],
+        "dischargeDisposition": null,
+        "facilityLocations": [
+
+        ],
+        "hqmfOid": "2.16.840.1.113883.3.560.1.79",
+        "id": {
+          "_id": {
+            "$oid": "5c880147d7c8ac4c3e106837"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c06ecf1b848466bbc906187"
+        },
+        "lengthOfStay": {
+          "value": 0,
+          "unit": "days"
+        },
+        "negationRationale": null,
+        "principalDiagnosis": null,
+        "qdmCategory": "encounter",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "relevantPeriod": {
+          "low": "2012-12-04T08:00:00.000+00:00",
+          "high": "2012-12-04T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "_type": "QDM::EncounterPerformed"
+      },
+      {
+        "_id": {
+          "$oid": "5c880147d7c8ac4c3e10682c"
+        },
+        "birthDatetime": "1940-01-01T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "code": "21112-8",
+            "codeSystem": "LOINC",
+            "descriptor": null,
+            "codeSystemOid": null,
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.54",
+        "id": {
+          "_id": {
+            "$oid": "5c880147d7c8ac4c3e106838"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880147d7c8ac4c3e10682c"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "birthdate",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicBirthdate"
+      },
+      {
+        "_id": {
+          "$oid": "5c880147d7c8ac4c3e10682d"
+        },
+        "dataElementCodes": [
+          {
+            "code": "2186-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "Not Hispanic or Latino",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.56",
+        "id": {
+          "_id": {
+            "$oid": "5c880147d7c8ac4c3e106839"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880147d7c8ac4c3e10682d"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "ethnicity",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicEthnicity"
+      },
+      {
+        "_id": {
+          "$oid": "5c880147d7c8ac4c3e10682e"
+        },
+        "dataElementCodes": [
+          {
+            "code": "1002-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "American Indian or Alaska Native",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.59",
+        "id": {
+          "_id": {
+            "$oid": "5c880147d7c8ac4c3e10683a"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880147d7c8ac4c3e10682e"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "race",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicRace"
+      },
+      {
+        "_id": {
+          "$oid": "5c880147d7c8ac4c3e10682f"
+        },
+        "dataElementCodes": [
+          {
+            "code": "M",
+            "codeSystem": "AdministrativeGender",
+            "descriptor": "M",
+            "codeSystemOid": "2.16.840.1.113883.5.1",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.55",
+        "id": {
+          "_id": {
+            "$oid": "5c880147d7c8ac4c3e10683b"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880147d7c8ac4c3e10682f"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "gender",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicSex"
+      }
+    ],
+    "extendedData": {
+      "type": null,
+      "measure_ids": [
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&7B905B21-D904-454F-885B-9CE5D19674E3",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&920D5B27-DF5A-4770-BD60-FC4EE251C4D2",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&3000797E-11B1-4F62-A078-341A4002A11C",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&5B20AFEA-D4AF-4F7A-A5A3-F1F6165B9E5F",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&F03324C2-9147-457B-BC34-811BB7859C91",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&BA108B7B-90B4-4692-B1D0-5DB554D2A1A2",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC",
+        null
+      ],
+      "source_data_criteria": [
+        {
+          "negation": false,
+          "definition": "assessment",
+          "status": "performed",
+          "title": "AmbulatoryStatus",
+          "description": "Assessment, Performed: Ambulatory Status",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.118.11.1219",
+          "type": "assessments",
+          "id": "AmbulatoryStatus_AssessmentPerformed_eb84926c_ae80_4768_9f88_ea55ed355df6_source",
+          "start_date": 1309766400000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+          "cms_id": "CMS231v0",
+          "criteria_id": "1677b0af52fFX",
+          "codes": {
+            "LOINC": [
+              "59458-0"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5c06ecf1b848466bbc906185"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "assessment",
+          "status": "performed",
+          "title": "FallsScreening",
+          "description": "Assessment, Performed: Falls Screening",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.118.12.1028",
+          "type": "assessments",
+          "id": "FallsScreening_AssessmentPerformed_3296d6d9_085b_4acd_84a9_819c01e4e5cd_source",
+          "start_date": 1341388800000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+          "cms_id": "CMS231v0",
+          "criteria_id": "1677b0b4e9bGs",
+          "codes": {
+            "SNOMED-CT": [
+              "401196007"
+            ],
+            "LOINC": [
+              "52552-7"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5c06ecf1b848466bbc906186"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "encounter",
+          "status": "performed",
+          "title": "AnnualWellnessVisit",
+          "description": "Encounter, Performed: Annual Wellness Visit",
+          "code_list_id": "2.16.840.1.113883.3.526.3.1240",
+          "type": "encounters",
+          "id": "AnnualWellnessVisit_EncounterPerformed_d50103e4_3ce4_48e3_9489_68dc37fb0b20_source",
+          "start_date": 1354608000000,
+          "end_date": 1354608900000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+          "cms_id": "CMS231v0",
+          "criteria_id": "1677b0ac53a4Q",
+          "codes": {
+            "HCPCS": [
+              "G0438"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5c06ecf1b848466bbc906187"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "id": "MeasurePeriod",
+          "start_date": 0,
+          "end_date": 0,
+          "references": null
+        }
+      ],
+      "is_shared": null,
+      "origin_data": [
+
+      ],
+      "test_id": null,
+      "medical_record_number": "66e7185c846fb50aaff1541a59d0b72284f89f64783a89bb33f9ae0d93f07361",
+      "medical_record_assigner": "Bonnie",
+      "description": null,
+      "description_category": null,
+      "insurance_providers": "[{\"codes\":{\"SOP\":[\"349\"]},\"description\":null,\"end_time\":null,\"financial_responsibility_type\":{\"code\":\"SELF\",\"codeSystem\":\"HL7 Relationship Code\"},\"health_record_field\":null,\"member_id\":\"1234567890\",\"mood_code\":\"EVN\",\"name\":\"Other\",\"negationInd\":null,\"negationReason\":null,\"oid\":null,\"payer\":{\"name\":\"Other\"},\"reason\":null,\"relationship\":null,\"specifics\":null,\"start_time\":1199145600,\"status_code\":null,\"time\":null,\"type\":\"OT\"}]"
+    },
+    "qdmVersion": "5.4"
+  }
+}

--- a/test/fixtures/patients/CMS234v0/Patient_Test 1.json
+++ b/test/fixtures/patients/CMS234v0/Patient_Test 1.json
@@ -1,0 +1,449 @@
+{
+  "_id": {
+    "$oid": "5c06ec72b848466bbc906066"
+  },
+  "bundleId": "5a57e977942c6d1e61d32f14",
+  "expectedValues": [
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+      "population_index": 0,
+      "IPP": 1,
+      "DENOM": 1,
+      "DENEX": 0,
+      "NUMER": 1
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC",
+      "population_index": 0,
+      "IPP": 1,
+      "MSRPOPL": 1,
+      "MSRPOPLEX": 0,
+      "OBSERV": [
+        0.25
+      ],
+      "OBSERV_UNIT": ""
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&7B905B21-D904-454F-885B-9CE5D19674E3",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "NUMER": 0,
+      "DENEXCEP": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&5B20AFEA-D4AF-4F7A-A5A3-F1F6165B9E5F",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&3000797E-11B1-4F62-A078-341A4002A11C",
+      "population_index": 0,
+      "IPP": 1,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&920D5B27-DF5A-4770-BD60-FC4EE251C4D2",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&BA108B7B-90B4-4692-B1D0-5DB554D2A1A2",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0,
+      "DENEXCEP": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&F03324C2-9147-457B-BC34-811BB7859C91",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    }
+  ],
+  "familyName": "Test 1",
+  "givenNames": [
+    "Patient"
+  ],
+  "notes": "",
+  "qdmPatient": {
+    "_id": {
+      "$oid": "5c880147d7c8ac4c3e106841"
+    },
+    "birthDatetime": "1940-01-01T08:00:00.000+00:00",
+    "dataElements": [
+      {
+        "_id": {
+          "$oid": "5c880147d7c8ac4c3e106842"
+        },
+        "authorDatetime": "2011-07-04T08:00:00.000+00:00",
+        "components": [
+
+        ],
+        "dataElementCodes": [
+          {
+            "codeSystem": "LOINC",
+            "code": "59458-0"
+          }
+        ],
+        "description": "Assessment, Performed: Ambulatory Status",
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.117",
+        "id": {
+          "_id": {
+            "$oid": "5c880147d7c8ac4c3e106843"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c06ece3b848466bbc906174"
+        },
+        "method": null,
+        "negationRationale": null,
+        "qdmCategory": "assessment",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "result": null,
+        "_type": "QDM::AssessmentPerformed"
+      },
+      {
+        "_id": {
+          "$oid": "5c880147d7c8ac4c3e106844"
+        },
+        "authorDatetime": "2012-07-04T08:00:00.000+00:00",
+        "components": [
+
+        ],
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "401196007"
+          },
+          {
+            "codeSystem": "LOINC",
+            "code": "52552-7"
+          }
+        ],
+        "description": "Assessment, Performed: Falls Screening",
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.117",
+        "id": {
+          "_id": {
+            "$oid": "5c880147d7c8ac4c3e106845"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c06ece3b848466bbc906175"
+        },
+        "method": null,
+        "negationRationale": null,
+        "qdmCategory": "assessment",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "result": null,
+        "_type": "QDM::AssessmentPerformed"
+      },
+      {
+        "_id": {
+          "$oid": "5c880147d7c8ac4c3e106846"
+        },
+        "admissionSource": null,
+        "authorDatetime": "2012-12-04T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "HCPCS",
+            "code": "G0438"
+          }
+        ],
+        "description": "Encounter, Performed: Annual Wellness Visit",
+        "diagnoses": [
+
+        ],
+        "dischargeDisposition": null,
+        "facilityLocations": [
+
+        ],
+        "hqmfOid": "2.16.840.1.113883.3.560.1.79",
+        "id": {
+          "_id": {
+            "$oid": "5c880147d7c8ac4c3e106847"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c06ece3b848466bbc906173"
+        },
+        "lengthOfStay": {
+          "value": 0,
+          "unit": "days"
+        },
+        "negationRationale": null,
+        "principalDiagnosis": null,
+        "qdmCategory": "encounter",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "relevantPeriod": {
+          "low": "2012-12-04T08:00:00.000+00:00",
+          "high": "2012-12-04T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "_type": "QDM::EncounterPerformed"
+      },
+      {
+        "_id": {
+          "$oid": "5c880147d7c8ac4c3e10683c"
+        },
+        "birthDatetime": "1940-01-01T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "code": "21112-8",
+            "codeSystem": "LOINC",
+            "descriptor": null,
+            "codeSystemOid": null,
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.54",
+        "id": {
+          "_id": {
+            "$oid": "5c880147d7c8ac4c3e106848"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880147d7c8ac4c3e10683c"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "birthdate",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicBirthdate"
+      },
+      {
+        "_id": {
+          "$oid": "5c880147d7c8ac4c3e10683d"
+        },
+        "dataElementCodes": [
+          {
+            "code": "2186-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "Not Hispanic or Latino",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.56",
+        "id": {
+          "_id": {
+            "$oid": "5c880147d7c8ac4c3e106849"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880147d7c8ac4c3e10683d"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "ethnicity",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicEthnicity"
+      },
+      {
+        "_id": {
+          "$oid": "5c880147d7c8ac4c3e10683e"
+        },
+        "dataElementCodes": [
+          {
+            "code": "1002-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "American Indian or Alaska Native",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.59",
+        "id": {
+          "_id": {
+            "$oid": "5c880147d7c8ac4c3e10684a"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880147d7c8ac4c3e10683e"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "race",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicRace"
+      },
+      {
+        "_id": {
+          "$oid": "5c880147d7c8ac4c3e10683f"
+        },
+        "dataElementCodes": [
+          {
+            "code": "M",
+            "codeSystem": "AdministrativeGender",
+            "descriptor": "M",
+            "codeSystemOid": "2.16.840.1.113883.5.1",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.55",
+        "id": {
+          "_id": {
+            "$oid": "5c880147d7c8ac4c3e10684b"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880147d7c8ac4c3e10683f"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "gender",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicSex"
+      }
+    ],
+    "extendedData": {
+      "type": null,
+      "measure_ids": [
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+        null,
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&7B905B21-D904-454F-885B-9CE5D19674E3",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&920D5B27-DF5A-4770-BD60-FC4EE251C4D2",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&3000797E-11B1-4F62-A078-341A4002A11C",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&5B20AFEA-D4AF-4F7A-A5A3-F1F6165B9E5F",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&F03324C2-9147-457B-BC34-811BB7859C91",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&BA108B7B-90B4-4692-B1D0-5DB554D2A1A2",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC"
+      ],
+      "source_data_criteria": [
+        {
+          "negation": false,
+          "definition": "assessment",
+          "status": "performed",
+          "title": "AmbulatoryStatus",
+          "description": "Assessment, Performed: Ambulatory Status",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.118.11.1219",
+          "type": "assessments",
+          "id": "AmbulatoryStatus_AssessmentPerformed_eb84926c_ae80_4768_9f88_ea55ed355df6_source",
+          "start_date": 1309766400000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+          "cms_id": "CMS231v0",
+          "criteria_id": "1677b0af52fFX",
+          "codes": {
+            "LOINC": [
+              "59458-0"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5c06ece3b848466bbc906174"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "assessment",
+          "status": "performed",
+          "title": "FallsScreening",
+          "description": "Assessment, Performed: Falls Screening",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.118.12.1028",
+          "type": "assessments",
+          "id": "FallsScreening_AssessmentPerformed_3296d6d9_085b_4acd_84a9_819c01e4e5cd_source",
+          "start_date": 1341388800000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+          "cms_id": "CMS231v0",
+          "criteria_id": "1677b0b4e9bGs",
+          "codes": {
+            "SNOMED-CT": [
+              "401196007"
+            ],
+            "LOINC": [
+              "52552-7"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5c06ece3b848466bbc906175"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "encounter",
+          "status": "performed",
+          "title": "AnnualWellnessVisit",
+          "description": "Encounter, Performed: Annual Wellness Visit",
+          "code_list_id": "2.16.840.1.113883.3.526.3.1240",
+          "type": "encounters",
+          "id": "AnnualWellnessVisit_EncounterPerformed_d50103e4_3ce4_48e3_9489_68dc37fb0b20_source",
+          "start_date": 1354608000000,
+          "end_date": 1354608900000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+          "cms_id": "CMS231v0",
+          "criteria_id": "1677b0ac53a4Q",
+          "codes": {
+            "HCPCS": [
+              "G0438"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5c06ece3b848466bbc906173"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "id": "MeasurePeriod",
+          "start_date": 0,
+          "end_date": 0,
+          "references": null
+        }
+      ],
+      "is_shared": null,
+      "origin_data": [
+
+      ],
+      "test_id": null,
+      "medical_record_number": "d975a2c11a5dbfa9af64642c349f94b5f5e5b43b211617f5d2992dd0438ca8fd",
+      "medical_record_assigner": "Bonnie",
+      "description": null,
+      "description_category": null,
+      "insurance_providers": "[{\"codes\":{\"SOP\":[\"349\"]},\"description\":null,\"end_time\":null,\"financial_responsibility_type\":{\"code\":\"SELF\",\"codeSystem\":\"HL7 Relationship Code\"},\"health_record_field\":null,\"member_id\":\"1234567890\",\"mood_code\":\"EVN\",\"name\":\"Other\",\"negationInd\":null,\"negationReason\":null,\"oid\":null,\"payer\":{\"name\":\"Other\"},\"reason\":null,\"relationship\":null,\"specifics\":null,\"start_time\":1199145600,\"status_code\":null,\"time\":null,\"type\":\"OT\"}]"
+    },
+    "qdmVersion": "5.4"
+  }
+}

--- a/test/fixtures/patients/CMS234v0/Patient_Test 2.json
+++ b/test/fixtures/patients/CMS234v0/Patient_Test 2.json
@@ -1,0 +1,449 @@
+{
+  "_id": {
+    "$oid": "5c06ecf1b848466bbc906184"
+  },
+  "bundleId": "5a57e977942c6d1e61d32f14",
+  "expectedValues": [
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+      "population_index": 0,
+      "IPP": 1,
+      "DENOM": 1,
+      "DENEX": 0,
+      "NUMER": 1
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC",
+      "population_index": 0,
+      "IPP": 1,
+      "MSRPOPL": 1,
+      "MSRPOPLEX": 0,
+      "OBSERV": [
+        0.25
+      ],
+      "OBSERV_UNIT": ""
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&7B905B21-D904-454F-885B-9CE5D19674E3",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "NUMER": 0,
+      "DENEXCEP": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&5B20AFEA-D4AF-4F7A-A5A3-F1F6165B9E5F",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&3000797E-11B1-4F62-A078-341A4002A11C",
+      "population_index": 0,
+      "IPP": 1,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&920D5B27-DF5A-4770-BD60-FC4EE251C4D2",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&BA108B7B-90B4-4692-B1D0-5DB554D2A1A2",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0,
+      "DENEXCEP": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&F03324C2-9147-457B-BC34-811BB7859C91",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    }
+  ],
+  "familyName": "Test 2",
+  "givenNames": [
+    "Patient"
+  ],
+  "notes": "",
+  "qdmPatient": {
+    "_id": {
+      "$oid": "5c880147d7c8ac4c3e106851"
+    },
+    "birthDatetime": "1940-01-01T08:00:00.000+00:00",
+    "dataElements": [
+      {
+        "_id": {
+          "$oid": "5c880147d7c8ac4c3e106852"
+        },
+        "authorDatetime": "2011-07-04T08:00:00.000+00:00",
+        "components": [
+
+        ],
+        "dataElementCodes": [
+          {
+            "codeSystem": "LOINC",
+            "code": "59458-0"
+          }
+        ],
+        "description": "Assessment, Performed: Ambulatory Status",
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.117",
+        "id": {
+          "_id": {
+            "$oid": "5c880147d7c8ac4c3e106853"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c06ecf1b848466bbc906185"
+        },
+        "method": null,
+        "negationRationale": null,
+        "qdmCategory": "assessment",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "result": null,
+        "_type": "QDM::AssessmentPerformed"
+      },
+      {
+        "_id": {
+          "$oid": "5c880147d7c8ac4c3e106854"
+        },
+        "authorDatetime": "2012-07-04T08:00:00.000+00:00",
+        "components": [
+
+        ],
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "401196007"
+          },
+          {
+            "codeSystem": "LOINC",
+            "code": "52552-7"
+          }
+        ],
+        "description": "Assessment, Performed: Falls Screening",
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.117",
+        "id": {
+          "_id": {
+            "$oid": "5c880147d7c8ac4c3e106855"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c06ecf1b848466bbc906186"
+        },
+        "method": null,
+        "negationRationale": null,
+        "qdmCategory": "assessment",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "result": null,
+        "_type": "QDM::AssessmentPerformed"
+      },
+      {
+        "_id": {
+          "$oid": "5c880147d7c8ac4c3e106856"
+        },
+        "admissionSource": null,
+        "authorDatetime": "2012-12-04T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "HCPCS",
+            "code": "G0438"
+          }
+        ],
+        "description": "Encounter, Performed: Annual Wellness Visit",
+        "diagnoses": [
+
+        ],
+        "dischargeDisposition": null,
+        "facilityLocations": [
+
+        ],
+        "hqmfOid": "2.16.840.1.113883.3.560.1.79",
+        "id": {
+          "_id": {
+            "$oid": "5c880147d7c8ac4c3e106857"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c06ecf1b848466bbc906187"
+        },
+        "lengthOfStay": {
+          "value": 0,
+          "unit": "days"
+        },
+        "negationRationale": null,
+        "principalDiagnosis": null,
+        "qdmCategory": "encounter",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "relevantPeriod": {
+          "low": "2012-12-04T08:00:00.000+00:00",
+          "high": "2012-12-04T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "_type": "QDM::EncounterPerformed"
+      },
+      {
+        "_id": {
+          "$oid": "5c880147d7c8ac4c3e10684c"
+        },
+        "birthDatetime": "1940-01-01T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "code": "21112-8",
+            "codeSystem": "LOINC",
+            "descriptor": null,
+            "codeSystemOid": null,
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.54",
+        "id": {
+          "_id": {
+            "$oid": "5c880147d7c8ac4c3e106858"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880147d7c8ac4c3e10684c"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "birthdate",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicBirthdate"
+      },
+      {
+        "_id": {
+          "$oid": "5c880147d7c8ac4c3e10684d"
+        },
+        "dataElementCodes": [
+          {
+            "code": "2186-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "Not Hispanic or Latino",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.56",
+        "id": {
+          "_id": {
+            "$oid": "5c880147d7c8ac4c3e106859"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880147d7c8ac4c3e10684d"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "ethnicity",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicEthnicity"
+      },
+      {
+        "_id": {
+          "$oid": "5c880147d7c8ac4c3e10684e"
+        },
+        "dataElementCodes": [
+          {
+            "code": "1002-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "American Indian or Alaska Native",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.59",
+        "id": {
+          "_id": {
+            "$oid": "5c880147d7c8ac4c3e10685a"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880147d7c8ac4c3e10684e"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "race",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicRace"
+      },
+      {
+        "_id": {
+          "$oid": "5c880147d7c8ac4c3e10684f"
+        },
+        "dataElementCodes": [
+          {
+            "code": "M",
+            "codeSystem": "AdministrativeGender",
+            "descriptor": "M",
+            "codeSystemOid": "2.16.840.1.113883.5.1",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.55",
+        "id": {
+          "_id": {
+            "$oid": "5c880147d7c8ac4c3e10685b"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880147d7c8ac4c3e10684f"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "gender",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicSex"
+      }
+    ],
+    "extendedData": {
+      "type": null,
+      "measure_ids": [
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&7B905B21-D904-454F-885B-9CE5D19674E3",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&920D5B27-DF5A-4770-BD60-FC4EE251C4D2",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&3000797E-11B1-4F62-A078-341A4002A11C",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&5B20AFEA-D4AF-4F7A-A5A3-F1F6165B9E5F",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&F03324C2-9147-457B-BC34-811BB7859C91",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&BA108B7B-90B4-4692-B1D0-5DB554D2A1A2",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC",
+        null
+      ],
+      "source_data_criteria": [
+        {
+          "negation": false,
+          "definition": "assessment",
+          "status": "performed",
+          "title": "AmbulatoryStatus",
+          "description": "Assessment, Performed: Ambulatory Status",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.118.11.1219",
+          "type": "assessments",
+          "id": "AmbulatoryStatus_AssessmentPerformed_eb84926c_ae80_4768_9f88_ea55ed355df6_source",
+          "start_date": 1309766400000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+          "cms_id": "CMS231v0",
+          "criteria_id": "1677b0af52fFX",
+          "codes": {
+            "LOINC": [
+              "59458-0"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5c06ecf1b848466bbc906185"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "assessment",
+          "status": "performed",
+          "title": "FallsScreening",
+          "description": "Assessment, Performed: Falls Screening",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.118.12.1028",
+          "type": "assessments",
+          "id": "FallsScreening_AssessmentPerformed_3296d6d9_085b_4acd_84a9_819c01e4e5cd_source",
+          "start_date": 1341388800000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+          "cms_id": "CMS231v0",
+          "criteria_id": "1677b0b4e9bGs",
+          "codes": {
+            "SNOMED-CT": [
+              "401196007"
+            ],
+            "LOINC": [
+              "52552-7"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5c06ecf1b848466bbc906186"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "encounter",
+          "status": "performed",
+          "title": "AnnualWellnessVisit",
+          "description": "Encounter, Performed: Annual Wellness Visit",
+          "code_list_id": "2.16.840.1.113883.3.526.3.1240",
+          "type": "encounters",
+          "id": "AnnualWellnessVisit_EncounterPerformed_d50103e4_3ce4_48e3_9489_68dc37fb0b20_source",
+          "start_date": 1354608000000,
+          "end_date": 1354608900000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+          "cms_id": "CMS231v0",
+          "criteria_id": "1677b0ac53a4Q",
+          "codes": {
+            "HCPCS": [
+              "G0438"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5c06ecf1b848466bbc906187"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "id": "MeasurePeriod",
+          "start_date": 0,
+          "end_date": 0,
+          "references": null
+        }
+      ],
+      "is_shared": null,
+      "origin_data": [
+
+      ],
+      "test_id": null,
+      "medical_record_number": "66e7185c846fb50aaff1541a59d0b72284f89f64783a89bb33f9ae0d93f07361",
+      "medical_record_assigner": "Bonnie",
+      "description": null,
+      "description_category": null,
+      "insurance_providers": "[{\"codes\":{\"SOP\":[\"349\"]},\"description\":null,\"end_time\":null,\"financial_responsibility_type\":{\"code\":\"SELF\",\"codeSystem\":\"HL7 Relationship Code\"},\"health_record_field\":null,\"member_id\":\"1234567890\",\"mood_code\":\"EVN\",\"name\":\"Other\",\"negationInd\":null,\"negationReason\":null,\"oid\":null,\"payer\":{\"name\":\"Other\"},\"reason\":null,\"relationship\":null,\"specifics\":null,\"start_time\":1199145600,\"status_code\":null,\"time\":null,\"type\":\"OT\"}]"
+    },
+    "qdmVersion": "5.4"
+  }
+}

--- a/test/fixtures/patients/CMS238v0/Patient_Test 1.json
+++ b/test/fixtures/patients/CMS238v0/Patient_Test 1.json
@@ -1,0 +1,449 @@
+{
+  "_id": {
+    "$oid": "5c06ec72b848466bbc906066"
+  },
+  "bundleId": "5a57e977942c6d1e61d32f14",
+  "expectedValues": [
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+      "population_index": 0,
+      "IPP": 1,
+      "DENOM": 1,
+      "DENEX": 0,
+      "NUMER": 1
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC",
+      "population_index": 0,
+      "IPP": 1,
+      "MSRPOPL": 1,
+      "MSRPOPLEX": 0,
+      "OBSERV": [
+        0.25
+      ],
+      "OBSERV_UNIT": ""
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&7B905B21-D904-454F-885B-9CE5D19674E3",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "NUMER": 0,
+      "DENEXCEP": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&5B20AFEA-D4AF-4F7A-A5A3-F1F6165B9E5F",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&3000797E-11B1-4F62-A078-341A4002A11C",
+      "population_index": 0,
+      "IPP": 1,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&920D5B27-DF5A-4770-BD60-FC4EE251C4D2",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&BA108B7B-90B4-4692-B1D0-5DB554D2A1A2",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0,
+      "DENEXCEP": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&F03324C2-9147-457B-BC34-811BB7859C91",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    }
+  ],
+  "familyName": "Test 1",
+  "givenNames": [
+    "Patient"
+  ],
+  "notes": "",
+  "qdmPatient": {
+    "_id": {
+      "$oid": "5c880148d7c8ac4c3e106861"
+    },
+    "birthDatetime": "1940-01-01T08:00:00.000+00:00",
+    "dataElements": [
+      {
+        "_id": {
+          "$oid": "5c880148d7c8ac4c3e106862"
+        },
+        "authorDatetime": "2011-07-04T08:00:00.000+00:00",
+        "components": [
+
+        ],
+        "dataElementCodes": [
+          {
+            "codeSystem": "LOINC",
+            "code": "59458-0"
+          }
+        ],
+        "description": "Assessment, Performed: Ambulatory Status",
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.117",
+        "id": {
+          "_id": {
+            "$oid": "5c880148d7c8ac4c3e106863"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c06ece3b848466bbc906174"
+        },
+        "method": null,
+        "negationRationale": null,
+        "qdmCategory": "assessment",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "result": null,
+        "_type": "QDM::AssessmentPerformed"
+      },
+      {
+        "_id": {
+          "$oid": "5c880148d7c8ac4c3e106864"
+        },
+        "authorDatetime": "2012-07-04T08:00:00.000+00:00",
+        "components": [
+
+        ],
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "401196007"
+          },
+          {
+            "codeSystem": "LOINC",
+            "code": "52552-7"
+          }
+        ],
+        "description": "Assessment, Performed: Falls Screening",
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.117",
+        "id": {
+          "_id": {
+            "$oid": "5c880148d7c8ac4c3e106865"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c06ece3b848466bbc906175"
+        },
+        "method": null,
+        "negationRationale": null,
+        "qdmCategory": "assessment",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "result": null,
+        "_type": "QDM::AssessmentPerformed"
+      },
+      {
+        "_id": {
+          "$oid": "5c880148d7c8ac4c3e106866"
+        },
+        "admissionSource": null,
+        "authorDatetime": "2012-12-04T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "HCPCS",
+            "code": "G0438"
+          }
+        ],
+        "description": "Encounter, Performed: Annual Wellness Visit",
+        "diagnoses": [
+
+        ],
+        "dischargeDisposition": null,
+        "facilityLocations": [
+
+        ],
+        "hqmfOid": "2.16.840.1.113883.3.560.1.79",
+        "id": {
+          "_id": {
+            "$oid": "5c880148d7c8ac4c3e106867"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c06ece3b848466bbc906173"
+        },
+        "lengthOfStay": {
+          "value": 0,
+          "unit": "days"
+        },
+        "negationRationale": null,
+        "principalDiagnosis": null,
+        "qdmCategory": "encounter",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "relevantPeriod": {
+          "low": "2012-12-04T08:00:00.000+00:00",
+          "high": "2012-12-04T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "_type": "QDM::EncounterPerformed"
+      },
+      {
+        "_id": {
+          "$oid": "5c880148d7c8ac4c3e10685c"
+        },
+        "birthDatetime": "1940-01-01T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "code": "21112-8",
+            "codeSystem": "LOINC",
+            "descriptor": null,
+            "codeSystemOid": null,
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.54",
+        "id": {
+          "_id": {
+            "$oid": "5c880148d7c8ac4c3e106868"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880148d7c8ac4c3e10685c"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "birthdate",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicBirthdate"
+      },
+      {
+        "_id": {
+          "$oid": "5c880148d7c8ac4c3e10685d"
+        },
+        "dataElementCodes": [
+          {
+            "code": "2186-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "Not Hispanic or Latino",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.56",
+        "id": {
+          "_id": {
+            "$oid": "5c880148d7c8ac4c3e106869"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880148d7c8ac4c3e10685d"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "ethnicity",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicEthnicity"
+      },
+      {
+        "_id": {
+          "$oid": "5c880148d7c8ac4c3e10685e"
+        },
+        "dataElementCodes": [
+          {
+            "code": "1002-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "American Indian or Alaska Native",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.59",
+        "id": {
+          "_id": {
+            "$oid": "5c880148d7c8ac4c3e10686a"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880148d7c8ac4c3e10685e"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "race",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicRace"
+      },
+      {
+        "_id": {
+          "$oid": "5c880148d7c8ac4c3e10685f"
+        },
+        "dataElementCodes": [
+          {
+            "code": "M",
+            "codeSystem": "AdministrativeGender",
+            "descriptor": "M",
+            "codeSystemOid": "2.16.840.1.113883.5.1",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.55",
+        "id": {
+          "_id": {
+            "$oid": "5c880148d7c8ac4c3e10686b"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880148d7c8ac4c3e10685f"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "gender",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicSex"
+      }
+    ],
+    "extendedData": {
+      "type": null,
+      "measure_ids": [
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+        null,
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&7B905B21-D904-454F-885B-9CE5D19674E3",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&920D5B27-DF5A-4770-BD60-FC4EE251C4D2",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&3000797E-11B1-4F62-A078-341A4002A11C",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&5B20AFEA-D4AF-4F7A-A5A3-F1F6165B9E5F",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&F03324C2-9147-457B-BC34-811BB7859C91",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&BA108B7B-90B4-4692-B1D0-5DB554D2A1A2",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC"
+      ],
+      "source_data_criteria": [
+        {
+          "negation": false,
+          "definition": "assessment",
+          "status": "performed",
+          "title": "AmbulatoryStatus",
+          "description": "Assessment, Performed: Ambulatory Status",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.118.11.1219",
+          "type": "assessments",
+          "id": "AmbulatoryStatus_AssessmentPerformed_eb84926c_ae80_4768_9f88_ea55ed355df6_source",
+          "start_date": 1309766400000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+          "cms_id": "CMS231v0",
+          "criteria_id": "1677b0af52fFX",
+          "codes": {
+            "LOINC": [
+              "59458-0"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5c06ece3b848466bbc906174"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "assessment",
+          "status": "performed",
+          "title": "FallsScreening",
+          "description": "Assessment, Performed: Falls Screening",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.118.12.1028",
+          "type": "assessments",
+          "id": "FallsScreening_AssessmentPerformed_3296d6d9_085b_4acd_84a9_819c01e4e5cd_source",
+          "start_date": 1341388800000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+          "cms_id": "CMS231v0",
+          "criteria_id": "1677b0b4e9bGs",
+          "codes": {
+            "SNOMED-CT": [
+              "401196007"
+            ],
+            "LOINC": [
+              "52552-7"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5c06ece3b848466bbc906175"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "encounter",
+          "status": "performed",
+          "title": "AnnualWellnessVisit",
+          "description": "Encounter, Performed: Annual Wellness Visit",
+          "code_list_id": "2.16.840.1.113883.3.526.3.1240",
+          "type": "encounters",
+          "id": "AnnualWellnessVisit_EncounterPerformed_d50103e4_3ce4_48e3_9489_68dc37fb0b20_source",
+          "start_date": 1354608000000,
+          "end_date": 1354608900000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+          "cms_id": "CMS231v0",
+          "criteria_id": "1677b0ac53a4Q",
+          "codes": {
+            "HCPCS": [
+              "G0438"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5c06ece3b848466bbc906173"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "id": "MeasurePeriod",
+          "start_date": 0,
+          "end_date": 0,
+          "references": null
+        }
+      ],
+      "is_shared": null,
+      "origin_data": [
+
+      ],
+      "test_id": null,
+      "medical_record_number": "d975a2c11a5dbfa9af64642c349f94b5f5e5b43b211617f5d2992dd0438ca8fd",
+      "medical_record_assigner": "Bonnie",
+      "description": null,
+      "description_category": null,
+      "insurance_providers": "[{\"codes\":{\"SOP\":[\"349\"]},\"description\":null,\"end_time\":null,\"financial_responsibility_type\":{\"code\":\"SELF\",\"codeSystem\":\"HL7 Relationship Code\"},\"health_record_field\":null,\"member_id\":\"1234567890\",\"mood_code\":\"EVN\",\"name\":\"Other\",\"negationInd\":null,\"negationReason\":null,\"oid\":null,\"payer\":{\"name\":\"Other\"},\"reason\":null,\"relationship\":null,\"specifics\":null,\"start_time\":1199145600,\"status_code\":null,\"time\":null,\"type\":\"OT\"}]"
+    },
+    "qdmVersion": "5.4"
+  }
+}

--- a/test/fixtures/patients/CMS238v0/Patient_Test 2.json
+++ b/test/fixtures/patients/CMS238v0/Patient_Test 2.json
@@ -1,0 +1,449 @@
+{
+  "_id": {
+    "$oid": "5c06ecf1b848466bbc906184"
+  },
+  "bundleId": "5a57e977942c6d1e61d32f14",
+  "expectedValues": [
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+      "population_index": 0,
+      "IPP": 1,
+      "DENOM": 1,
+      "DENEX": 0,
+      "NUMER": 1
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC",
+      "population_index": 0,
+      "IPP": 1,
+      "MSRPOPL": 1,
+      "MSRPOPLEX": 0,
+      "OBSERV": [
+        0.25
+      ],
+      "OBSERV_UNIT": ""
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&7B905B21-D904-454F-885B-9CE5D19674E3",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "NUMER": 0,
+      "DENEXCEP": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&5B20AFEA-D4AF-4F7A-A5A3-F1F6165B9E5F",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&3000797E-11B1-4F62-A078-341A4002A11C",
+      "population_index": 0,
+      "IPP": 1,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&920D5B27-DF5A-4770-BD60-FC4EE251C4D2",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&BA108B7B-90B4-4692-B1D0-5DB554D2A1A2",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0,
+      "DENEXCEP": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&F03324C2-9147-457B-BC34-811BB7859C91",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    }
+  ],
+  "familyName": "Test 2",
+  "givenNames": [
+    "Patient"
+  ],
+  "notes": "",
+  "qdmPatient": {
+    "_id": {
+      "$oid": "5c880148d7c8ac4c3e106871"
+    },
+    "birthDatetime": "1940-01-01T08:00:00.000+00:00",
+    "dataElements": [
+      {
+        "_id": {
+          "$oid": "5c880148d7c8ac4c3e106872"
+        },
+        "authorDatetime": "2011-07-04T08:00:00.000+00:00",
+        "components": [
+
+        ],
+        "dataElementCodes": [
+          {
+            "codeSystem": "LOINC",
+            "code": "59458-0"
+          }
+        ],
+        "description": "Assessment, Performed: Ambulatory Status",
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.117",
+        "id": {
+          "_id": {
+            "$oid": "5c880148d7c8ac4c3e106873"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c06ecf1b848466bbc906185"
+        },
+        "method": null,
+        "negationRationale": null,
+        "qdmCategory": "assessment",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "result": null,
+        "_type": "QDM::AssessmentPerformed"
+      },
+      {
+        "_id": {
+          "$oid": "5c880148d7c8ac4c3e106874"
+        },
+        "authorDatetime": "2012-07-04T08:00:00.000+00:00",
+        "components": [
+
+        ],
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "401196007"
+          },
+          {
+            "codeSystem": "LOINC",
+            "code": "52552-7"
+          }
+        ],
+        "description": "Assessment, Performed: Falls Screening",
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.117",
+        "id": {
+          "_id": {
+            "$oid": "5c880148d7c8ac4c3e106875"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c06ecf1b848466bbc906186"
+        },
+        "method": null,
+        "negationRationale": null,
+        "qdmCategory": "assessment",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "result": null,
+        "_type": "QDM::AssessmentPerformed"
+      },
+      {
+        "_id": {
+          "$oid": "5c880148d7c8ac4c3e106876"
+        },
+        "admissionSource": null,
+        "authorDatetime": "2012-12-04T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "HCPCS",
+            "code": "G0438"
+          }
+        ],
+        "description": "Encounter, Performed: Annual Wellness Visit",
+        "diagnoses": [
+
+        ],
+        "dischargeDisposition": null,
+        "facilityLocations": [
+
+        ],
+        "hqmfOid": "2.16.840.1.113883.3.560.1.79",
+        "id": {
+          "_id": {
+            "$oid": "5c880148d7c8ac4c3e106877"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c06ecf1b848466bbc906187"
+        },
+        "lengthOfStay": {
+          "value": 0,
+          "unit": "days"
+        },
+        "negationRationale": null,
+        "principalDiagnosis": null,
+        "qdmCategory": "encounter",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "relevantPeriod": {
+          "low": "2012-12-04T08:00:00.000+00:00",
+          "high": "2012-12-04T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "_type": "QDM::EncounterPerformed"
+      },
+      {
+        "_id": {
+          "$oid": "5c880148d7c8ac4c3e10686c"
+        },
+        "birthDatetime": "1940-01-01T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "code": "21112-8",
+            "codeSystem": "LOINC",
+            "descriptor": null,
+            "codeSystemOid": null,
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.54",
+        "id": {
+          "_id": {
+            "$oid": "5c880148d7c8ac4c3e106878"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880148d7c8ac4c3e10686c"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "birthdate",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicBirthdate"
+      },
+      {
+        "_id": {
+          "$oid": "5c880148d7c8ac4c3e10686d"
+        },
+        "dataElementCodes": [
+          {
+            "code": "2186-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "Not Hispanic or Latino",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.56",
+        "id": {
+          "_id": {
+            "$oid": "5c880148d7c8ac4c3e106879"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880148d7c8ac4c3e10686d"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "ethnicity",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicEthnicity"
+      },
+      {
+        "_id": {
+          "$oid": "5c880148d7c8ac4c3e10686e"
+        },
+        "dataElementCodes": [
+          {
+            "code": "1002-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "American Indian or Alaska Native",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.59",
+        "id": {
+          "_id": {
+            "$oid": "5c880148d7c8ac4c3e10687a"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880148d7c8ac4c3e10686e"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "race",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicRace"
+      },
+      {
+        "_id": {
+          "$oid": "5c880148d7c8ac4c3e10686f"
+        },
+        "dataElementCodes": [
+          {
+            "code": "M",
+            "codeSystem": "AdministrativeGender",
+            "descriptor": "M",
+            "codeSystemOid": "2.16.840.1.113883.5.1",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.55",
+        "id": {
+          "_id": {
+            "$oid": "5c880148d7c8ac4c3e10687b"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880148d7c8ac4c3e10686f"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "gender",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicSex"
+      }
+    ],
+    "extendedData": {
+      "type": null,
+      "measure_ids": [
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&7B905B21-D904-454F-885B-9CE5D19674E3",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&920D5B27-DF5A-4770-BD60-FC4EE251C4D2",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&3000797E-11B1-4F62-A078-341A4002A11C",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&5B20AFEA-D4AF-4F7A-A5A3-F1F6165B9E5F",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&F03324C2-9147-457B-BC34-811BB7859C91",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&BA108B7B-90B4-4692-B1D0-5DB554D2A1A2",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC",
+        null
+      ],
+      "source_data_criteria": [
+        {
+          "negation": false,
+          "definition": "assessment",
+          "status": "performed",
+          "title": "AmbulatoryStatus",
+          "description": "Assessment, Performed: Ambulatory Status",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.118.11.1219",
+          "type": "assessments",
+          "id": "AmbulatoryStatus_AssessmentPerformed_eb84926c_ae80_4768_9f88_ea55ed355df6_source",
+          "start_date": 1309766400000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+          "cms_id": "CMS231v0",
+          "criteria_id": "1677b0af52fFX",
+          "codes": {
+            "LOINC": [
+              "59458-0"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5c06ecf1b848466bbc906185"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "assessment",
+          "status": "performed",
+          "title": "FallsScreening",
+          "description": "Assessment, Performed: Falls Screening",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.118.12.1028",
+          "type": "assessments",
+          "id": "FallsScreening_AssessmentPerformed_3296d6d9_085b_4acd_84a9_819c01e4e5cd_source",
+          "start_date": 1341388800000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+          "cms_id": "CMS231v0",
+          "criteria_id": "1677b0b4e9bGs",
+          "codes": {
+            "SNOMED-CT": [
+              "401196007"
+            ],
+            "LOINC": [
+              "52552-7"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5c06ecf1b848466bbc906186"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "encounter",
+          "status": "performed",
+          "title": "AnnualWellnessVisit",
+          "description": "Encounter, Performed: Annual Wellness Visit",
+          "code_list_id": "2.16.840.1.113883.3.526.3.1240",
+          "type": "encounters",
+          "id": "AnnualWellnessVisit_EncounterPerformed_d50103e4_3ce4_48e3_9489_68dc37fb0b20_source",
+          "start_date": 1354608000000,
+          "end_date": 1354608900000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+          "cms_id": "CMS231v0",
+          "criteria_id": "1677b0ac53a4Q",
+          "codes": {
+            "HCPCS": [
+              "G0438"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5c06ecf1b848466bbc906187"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "id": "MeasurePeriod",
+          "start_date": 0,
+          "end_date": 0,
+          "references": null
+        }
+      ],
+      "is_shared": null,
+      "origin_data": [
+
+      ],
+      "test_id": null,
+      "medical_record_number": "66e7185c846fb50aaff1541a59d0b72284f89f64783a89bb33f9ae0d93f07361",
+      "medical_record_assigner": "Bonnie",
+      "description": null,
+      "description_category": null,
+      "insurance_providers": "[{\"codes\":{\"SOP\":[\"349\"]},\"description\":null,\"end_time\":null,\"financial_responsibility_type\":{\"code\":\"SELF\",\"codeSystem\":\"HL7 Relationship Code\"},\"health_record_field\":null,\"member_id\":\"1234567890\",\"mood_code\":\"EVN\",\"name\":\"Other\",\"negationInd\":null,\"negationReason\":null,\"oid\":null,\"payer\":{\"name\":\"Other\"},\"reason\":null,\"relationship\":null,\"specifics\":null,\"start_time\":1199145600,\"status_code\":null,\"time\":null,\"type\":\"OT\"}]"
+    },
+    "qdmVersion": "5.4"
+  }
+}

--- a/test/fixtures/patients/CMS241v0/Patient_Test 1.json
+++ b/test/fixtures/patients/CMS241v0/Patient_Test 1.json
@@ -1,0 +1,449 @@
+{
+  "_id": {
+    "$oid": "5c06ec72b848466bbc906066"
+  },
+  "bundleId": "5a57e977942c6d1e61d32f14",
+  "expectedValues": [
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+      "population_index": 0,
+      "IPP": 1,
+      "DENOM": 1,
+      "DENEX": 0,
+      "NUMER": 1
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC",
+      "population_index": 0,
+      "IPP": 1,
+      "MSRPOPL": 1,
+      "MSRPOPLEX": 0,
+      "OBSERV": [
+        0.25
+      ],
+      "OBSERV_UNIT": ""
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&7B905B21-D904-454F-885B-9CE5D19674E3",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "NUMER": 0,
+      "DENEXCEP": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&5B20AFEA-D4AF-4F7A-A5A3-F1F6165B9E5F",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&3000797E-11B1-4F62-A078-341A4002A11C",
+      "population_index": 0,
+      "IPP": 1,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&920D5B27-DF5A-4770-BD60-FC4EE251C4D2",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&BA108B7B-90B4-4692-B1D0-5DB554D2A1A2",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0,
+      "DENEXCEP": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&F03324C2-9147-457B-BC34-811BB7859C91",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    }
+  ],
+  "familyName": "Test 1",
+  "givenNames": [
+    "Patient"
+  ],
+  "notes": "",
+  "qdmPatient": {
+    "_id": {
+      "$oid": "5c880148d7c8ac4c3e106881"
+    },
+    "birthDatetime": "1940-01-01T08:00:00.000+00:00",
+    "dataElements": [
+      {
+        "_id": {
+          "$oid": "5c880148d7c8ac4c3e106882"
+        },
+        "authorDatetime": "2011-07-04T08:00:00.000+00:00",
+        "components": [
+
+        ],
+        "dataElementCodes": [
+          {
+            "codeSystem": "LOINC",
+            "code": "59458-0"
+          }
+        ],
+        "description": "Assessment, Performed: Ambulatory Status",
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.117",
+        "id": {
+          "_id": {
+            "$oid": "5c880148d7c8ac4c3e106883"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c06ece3b848466bbc906174"
+        },
+        "method": null,
+        "negationRationale": null,
+        "qdmCategory": "assessment",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "result": null,
+        "_type": "QDM::AssessmentPerformed"
+      },
+      {
+        "_id": {
+          "$oid": "5c880148d7c8ac4c3e106884"
+        },
+        "authorDatetime": "2012-07-04T08:00:00.000+00:00",
+        "components": [
+
+        ],
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "401196007"
+          },
+          {
+            "codeSystem": "LOINC",
+            "code": "52552-7"
+          }
+        ],
+        "description": "Assessment, Performed: Falls Screening",
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.117",
+        "id": {
+          "_id": {
+            "$oid": "5c880148d7c8ac4c3e106885"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c06ece3b848466bbc906175"
+        },
+        "method": null,
+        "negationRationale": null,
+        "qdmCategory": "assessment",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "result": null,
+        "_type": "QDM::AssessmentPerformed"
+      },
+      {
+        "_id": {
+          "$oid": "5c880148d7c8ac4c3e106886"
+        },
+        "admissionSource": null,
+        "authorDatetime": "2012-12-04T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "HCPCS",
+            "code": "G0438"
+          }
+        ],
+        "description": "Encounter, Performed: Annual Wellness Visit",
+        "diagnoses": [
+
+        ],
+        "dischargeDisposition": null,
+        "facilityLocations": [
+
+        ],
+        "hqmfOid": "2.16.840.1.113883.3.560.1.79",
+        "id": {
+          "_id": {
+            "$oid": "5c880148d7c8ac4c3e106887"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c06ece3b848466bbc906173"
+        },
+        "lengthOfStay": {
+          "value": 0,
+          "unit": "days"
+        },
+        "negationRationale": null,
+        "principalDiagnosis": null,
+        "qdmCategory": "encounter",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "relevantPeriod": {
+          "low": "2012-12-04T08:00:00.000+00:00",
+          "high": "2012-12-04T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "_type": "QDM::EncounterPerformed"
+      },
+      {
+        "_id": {
+          "$oid": "5c880148d7c8ac4c3e10687c"
+        },
+        "birthDatetime": "1940-01-01T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "code": "21112-8",
+            "codeSystem": "LOINC",
+            "descriptor": null,
+            "codeSystemOid": null,
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.54",
+        "id": {
+          "_id": {
+            "$oid": "5c880148d7c8ac4c3e106888"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880148d7c8ac4c3e10687c"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "birthdate",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicBirthdate"
+      },
+      {
+        "_id": {
+          "$oid": "5c880148d7c8ac4c3e10687d"
+        },
+        "dataElementCodes": [
+          {
+            "code": "2186-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "Not Hispanic or Latino",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.56",
+        "id": {
+          "_id": {
+            "$oid": "5c880148d7c8ac4c3e106889"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880148d7c8ac4c3e10687d"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "ethnicity",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicEthnicity"
+      },
+      {
+        "_id": {
+          "$oid": "5c880148d7c8ac4c3e10687e"
+        },
+        "dataElementCodes": [
+          {
+            "code": "1002-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "American Indian or Alaska Native",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.59",
+        "id": {
+          "_id": {
+            "$oid": "5c880148d7c8ac4c3e10688a"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880148d7c8ac4c3e10687e"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "race",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicRace"
+      },
+      {
+        "_id": {
+          "$oid": "5c880148d7c8ac4c3e10687f"
+        },
+        "dataElementCodes": [
+          {
+            "code": "M",
+            "codeSystem": "AdministrativeGender",
+            "descriptor": "M",
+            "codeSystemOid": "2.16.840.1.113883.5.1",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.55",
+        "id": {
+          "_id": {
+            "$oid": "5c880148d7c8ac4c3e10688b"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880148d7c8ac4c3e10687f"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "gender",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicSex"
+      }
+    ],
+    "extendedData": {
+      "type": null,
+      "measure_ids": [
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+        null,
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&7B905B21-D904-454F-885B-9CE5D19674E3",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&920D5B27-DF5A-4770-BD60-FC4EE251C4D2",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&3000797E-11B1-4F62-A078-341A4002A11C",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&5B20AFEA-D4AF-4F7A-A5A3-F1F6165B9E5F",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&F03324C2-9147-457B-BC34-811BB7859C91",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&BA108B7B-90B4-4692-B1D0-5DB554D2A1A2",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC"
+      ],
+      "source_data_criteria": [
+        {
+          "negation": false,
+          "definition": "assessment",
+          "status": "performed",
+          "title": "AmbulatoryStatus",
+          "description": "Assessment, Performed: Ambulatory Status",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.118.11.1219",
+          "type": "assessments",
+          "id": "AmbulatoryStatus_AssessmentPerformed_eb84926c_ae80_4768_9f88_ea55ed355df6_source",
+          "start_date": 1309766400000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+          "cms_id": "CMS231v0",
+          "criteria_id": "1677b0af52fFX",
+          "codes": {
+            "LOINC": [
+              "59458-0"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5c06ece3b848466bbc906174"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "assessment",
+          "status": "performed",
+          "title": "FallsScreening",
+          "description": "Assessment, Performed: Falls Screening",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.118.12.1028",
+          "type": "assessments",
+          "id": "FallsScreening_AssessmentPerformed_3296d6d9_085b_4acd_84a9_819c01e4e5cd_source",
+          "start_date": 1341388800000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+          "cms_id": "CMS231v0",
+          "criteria_id": "1677b0b4e9bGs",
+          "codes": {
+            "SNOMED-CT": [
+              "401196007"
+            ],
+            "LOINC": [
+              "52552-7"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5c06ece3b848466bbc906175"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "encounter",
+          "status": "performed",
+          "title": "AnnualWellnessVisit",
+          "description": "Encounter, Performed: Annual Wellness Visit",
+          "code_list_id": "2.16.840.1.113883.3.526.3.1240",
+          "type": "encounters",
+          "id": "AnnualWellnessVisit_EncounterPerformed_d50103e4_3ce4_48e3_9489_68dc37fb0b20_source",
+          "start_date": 1354608000000,
+          "end_date": 1354608900000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+          "cms_id": "CMS231v0",
+          "criteria_id": "1677b0ac53a4Q",
+          "codes": {
+            "HCPCS": [
+              "G0438"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5c06ece3b848466bbc906173"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "id": "MeasurePeriod",
+          "start_date": 0,
+          "end_date": 0,
+          "references": null
+        }
+      ],
+      "is_shared": null,
+      "origin_data": [
+
+      ],
+      "test_id": null,
+      "medical_record_number": "d975a2c11a5dbfa9af64642c349f94b5f5e5b43b211617f5d2992dd0438ca8fd",
+      "medical_record_assigner": "Bonnie",
+      "description": null,
+      "description_category": null,
+      "insurance_providers": "[{\"codes\":{\"SOP\":[\"349\"]},\"description\":null,\"end_time\":null,\"financial_responsibility_type\":{\"code\":\"SELF\",\"codeSystem\":\"HL7 Relationship Code\"},\"health_record_field\":null,\"member_id\":\"1234567890\",\"mood_code\":\"EVN\",\"name\":\"Other\",\"negationInd\":null,\"negationReason\":null,\"oid\":null,\"payer\":{\"name\":\"Other\"},\"reason\":null,\"relationship\":null,\"specifics\":null,\"start_time\":1199145600,\"status_code\":null,\"time\":null,\"type\":\"OT\"}]"
+    },
+    "qdmVersion": "5.4"
+  }
+}

--- a/test/fixtures/patients/CMS241v0/Patient_Test 2.json
+++ b/test/fixtures/patients/CMS241v0/Patient_Test 2.json
@@ -1,0 +1,449 @@
+{
+  "_id": {
+    "$oid": "5c06ecf1b848466bbc906184"
+  },
+  "bundleId": "5a57e977942c6d1e61d32f14",
+  "expectedValues": [
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+      "population_index": 0,
+      "IPP": 1,
+      "DENOM": 1,
+      "DENEX": 0,
+      "NUMER": 1
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC",
+      "population_index": 0,
+      "IPP": 1,
+      "MSRPOPL": 1,
+      "MSRPOPLEX": 0,
+      "OBSERV": [
+        0.25
+      ],
+      "OBSERV_UNIT": ""
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&7B905B21-D904-454F-885B-9CE5D19674E3",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "NUMER": 0,
+      "DENEXCEP": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&5B20AFEA-D4AF-4F7A-A5A3-F1F6165B9E5F",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&3000797E-11B1-4F62-A078-341A4002A11C",
+      "population_index": 0,
+      "IPP": 1,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&920D5B27-DF5A-4770-BD60-FC4EE251C4D2",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&BA108B7B-90B4-4692-B1D0-5DB554D2A1A2",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0,
+      "DENEXCEP": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&F03324C2-9147-457B-BC34-811BB7859C91",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    }
+  ],
+  "familyName": "Test 2",
+  "givenNames": [
+    "Patient"
+  ],
+  "notes": "",
+  "qdmPatient": {
+    "_id": {
+      "$oid": "5c880148d7c8ac4c3e106891"
+    },
+    "birthDatetime": "1940-01-01T08:00:00.000+00:00",
+    "dataElements": [
+      {
+        "_id": {
+          "$oid": "5c880148d7c8ac4c3e106892"
+        },
+        "authorDatetime": "2011-07-04T08:00:00.000+00:00",
+        "components": [
+
+        ],
+        "dataElementCodes": [
+          {
+            "codeSystem": "LOINC",
+            "code": "59458-0"
+          }
+        ],
+        "description": "Assessment, Performed: Ambulatory Status",
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.117",
+        "id": {
+          "_id": {
+            "$oid": "5c880148d7c8ac4c3e106893"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c06ecf1b848466bbc906185"
+        },
+        "method": null,
+        "negationRationale": null,
+        "qdmCategory": "assessment",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "result": null,
+        "_type": "QDM::AssessmentPerformed"
+      },
+      {
+        "_id": {
+          "$oid": "5c880148d7c8ac4c3e106894"
+        },
+        "authorDatetime": "2012-07-04T08:00:00.000+00:00",
+        "components": [
+
+        ],
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "401196007"
+          },
+          {
+            "codeSystem": "LOINC",
+            "code": "52552-7"
+          }
+        ],
+        "description": "Assessment, Performed: Falls Screening",
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.117",
+        "id": {
+          "_id": {
+            "$oid": "5c880148d7c8ac4c3e106895"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c06ecf1b848466bbc906186"
+        },
+        "method": null,
+        "negationRationale": null,
+        "qdmCategory": "assessment",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "result": null,
+        "_type": "QDM::AssessmentPerformed"
+      },
+      {
+        "_id": {
+          "$oid": "5c880148d7c8ac4c3e106896"
+        },
+        "admissionSource": null,
+        "authorDatetime": "2012-12-04T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "HCPCS",
+            "code": "G0438"
+          }
+        ],
+        "description": "Encounter, Performed: Annual Wellness Visit",
+        "diagnoses": [
+
+        ],
+        "dischargeDisposition": null,
+        "facilityLocations": [
+
+        ],
+        "hqmfOid": "2.16.840.1.113883.3.560.1.79",
+        "id": {
+          "_id": {
+            "$oid": "5c880148d7c8ac4c3e106897"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c06ecf1b848466bbc906187"
+        },
+        "lengthOfStay": {
+          "value": 0,
+          "unit": "days"
+        },
+        "negationRationale": null,
+        "principalDiagnosis": null,
+        "qdmCategory": "encounter",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "relevantPeriod": {
+          "low": "2012-12-04T08:00:00.000+00:00",
+          "high": "2012-12-04T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "_type": "QDM::EncounterPerformed"
+      },
+      {
+        "_id": {
+          "$oid": "5c880148d7c8ac4c3e10688c"
+        },
+        "birthDatetime": "1940-01-01T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "code": "21112-8",
+            "codeSystem": "LOINC",
+            "descriptor": null,
+            "codeSystemOid": null,
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.54",
+        "id": {
+          "_id": {
+            "$oid": "5c880148d7c8ac4c3e106898"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880148d7c8ac4c3e10688c"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "birthdate",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicBirthdate"
+      },
+      {
+        "_id": {
+          "$oid": "5c880148d7c8ac4c3e10688d"
+        },
+        "dataElementCodes": [
+          {
+            "code": "2186-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "Not Hispanic or Latino",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.56",
+        "id": {
+          "_id": {
+            "$oid": "5c880148d7c8ac4c3e106899"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880148d7c8ac4c3e10688d"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "ethnicity",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicEthnicity"
+      },
+      {
+        "_id": {
+          "$oid": "5c880148d7c8ac4c3e10688e"
+        },
+        "dataElementCodes": [
+          {
+            "code": "1002-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "American Indian or Alaska Native",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.59",
+        "id": {
+          "_id": {
+            "$oid": "5c880148d7c8ac4c3e10689a"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880148d7c8ac4c3e10688e"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "race",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicRace"
+      },
+      {
+        "_id": {
+          "$oid": "5c880148d7c8ac4c3e10688f"
+        },
+        "dataElementCodes": [
+          {
+            "code": "M",
+            "codeSystem": "AdministrativeGender",
+            "descriptor": "M",
+            "codeSystemOid": "2.16.840.1.113883.5.1",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.55",
+        "id": {
+          "_id": {
+            "$oid": "5c880148d7c8ac4c3e10689b"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880148d7c8ac4c3e10688f"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "gender",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicSex"
+      }
+    ],
+    "extendedData": {
+      "type": null,
+      "measure_ids": [
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&7B905B21-D904-454F-885B-9CE5D19674E3",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&920D5B27-DF5A-4770-BD60-FC4EE251C4D2",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&3000797E-11B1-4F62-A078-341A4002A11C",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&5B20AFEA-D4AF-4F7A-A5A3-F1F6165B9E5F",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&F03324C2-9147-457B-BC34-811BB7859C91",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&BA108B7B-90B4-4692-B1D0-5DB554D2A1A2",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC",
+        null
+      ],
+      "source_data_criteria": [
+        {
+          "negation": false,
+          "definition": "assessment",
+          "status": "performed",
+          "title": "AmbulatoryStatus",
+          "description": "Assessment, Performed: Ambulatory Status",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.118.11.1219",
+          "type": "assessments",
+          "id": "AmbulatoryStatus_AssessmentPerformed_eb84926c_ae80_4768_9f88_ea55ed355df6_source",
+          "start_date": 1309766400000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+          "cms_id": "CMS231v0",
+          "criteria_id": "1677b0af52fFX",
+          "codes": {
+            "LOINC": [
+              "59458-0"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5c06ecf1b848466bbc906185"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "assessment",
+          "status": "performed",
+          "title": "FallsScreening",
+          "description": "Assessment, Performed: Falls Screening",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.118.12.1028",
+          "type": "assessments",
+          "id": "FallsScreening_AssessmentPerformed_3296d6d9_085b_4acd_84a9_819c01e4e5cd_source",
+          "start_date": 1341388800000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+          "cms_id": "CMS231v0",
+          "criteria_id": "1677b0b4e9bGs",
+          "codes": {
+            "SNOMED-CT": [
+              "401196007"
+            ],
+            "LOINC": [
+              "52552-7"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5c06ecf1b848466bbc906186"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "encounter",
+          "status": "performed",
+          "title": "AnnualWellnessVisit",
+          "description": "Encounter, Performed: Annual Wellness Visit",
+          "code_list_id": "2.16.840.1.113883.3.526.3.1240",
+          "type": "encounters",
+          "id": "AnnualWellnessVisit_EncounterPerformed_d50103e4_3ce4_48e3_9489_68dc37fb0b20_source",
+          "start_date": 1354608000000,
+          "end_date": 1354608900000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+          "cms_id": "CMS231v0",
+          "criteria_id": "1677b0ac53a4Q",
+          "codes": {
+            "HCPCS": [
+              "G0438"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5c06ecf1b848466bbc906187"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "id": "MeasurePeriod",
+          "start_date": 0,
+          "end_date": 0,
+          "references": null
+        }
+      ],
+      "is_shared": null,
+      "origin_data": [
+
+      ],
+      "test_id": null,
+      "medical_record_number": "66e7185c846fb50aaff1541a59d0b72284f89f64783a89bb33f9ae0d93f07361",
+      "medical_record_assigner": "Bonnie",
+      "description": null,
+      "description_category": null,
+      "insurance_providers": "[{\"codes\":{\"SOP\":[\"349\"]},\"description\":null,\"end_time\":null,\"financial_responsibility_type\":{\"code\":\"SELF\",\"codeSystem\":\"HL7 Relationship Code\"},\"health_record_field\":null,\"member_id\":\"1234567890\",\"mood_code\":\"EVN\",\"name\":\"Other\",\"negationInd\":null,\"negationReason\":null,\"oid\":null,\"payer\":{\"name\":\"Other\"},\"reason\":null,\"relationship\":null,\"specifics\":null,\"start_time\":1199145600,\"status_code\":null,\"time\":null,\"type\":\"OT\"}]"
+    },
+    "qdmVersion": "5.4"
+  }
+}

--- a/test/fixtures/patients/CMS244v0/Patient_Test 1.json
+++ b/test/fixtures/patients/CMS244v0/Patient_Test 1.json
@@ -1,0 +1,449 @@
+{
+  "_id": {
+    "$oid": "5c06ec72b848466bbc906066"
+  },
+  "bundleId": "5a57e977942c6d1e61d32f14",
+  "expectedValues": [
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+      "population_index": 0,
+      "IPP": 1,
+      "DENOM": 1,
+      "DENEX": 0,
+      "NUMER": 1
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC",
+      "population_index": 0,
+      "IPP": 1,
+      "MSRPOPL": 1,
+      "MSRPOPLEX": 0,
+      "OBSERV": [
+        0.25
+      ],
+      "OBSERV_UNIT": ""
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&7B905B21-D904-454F-885B-9CE5D19674E3",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "NUMER": 0,
+      "DENEXCEP": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&5B20AFEA-D4AF-4F7A-A5A3-F1F6165B9E5F",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&3000797E-11B1-4F62-A078-341A4002A11C",
+      "population_index": 0,
+      "IPP": 1,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&920D5B27-DF5A-4770-BD60-FC4EE251C4D2",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&BA108B7B-90B4-4692-B1D0-5DB554D2A1A2",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0,
+      "DENEXCEP": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&F03324C2-9147-457B-BC34-811BB7859C91",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    }
+  ],
+  "familyName": "Test 1",
+  "givenNames": [
+    "Patient"
+  ],
+  "notes": "",
+  "qdmPatient": {
+    "_id": {
+      "$oid": "5c880148d7c8ac4c3e1068a1"
+    },
+    "birthDatetime": "1940-01-01T08:00:00.000+00:00",
+    "dataElements": [
+      {
+        "_id": {
+          "$oid": "5c880148d7c8ac4c3e1068a2"
+        },
+        "authorDatetime": "2011-07-04T08:00:00.000+00:00",
+        "components": [
+
+        ],
+        "dataElementCodes": [
+          {
+            "codeSystem": "LOINC",
+            "code": "59458-0"
+          }
+        ],
+        "description": "Assessment, Performed: Ambulatory Status",
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.117",
+        "id": {
+          "_id": {
+            "$oid": "5c880148d7c8ac4c3e1068a3"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c06ece3b848466bbc906174"
+        },
+        "method": null,
+        "negationRationale": null,
+        "qdmCategory": "assessment",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "result": null,
+        "_type": "QDM::AssessmentPerformed"
+      },
+      {
+        "_id": {
+          "$oid": "5c880148d7c8ac4c3e1068a4"
+        },
+        "authorDatetime": "2012-07-04T08:00:00.000+00:00",
+        "components": [
+
+        ],
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "401196007"
+          },
+          {
+            "codeSystem": "LOINC",
+            "code": "52552-7"
+          }
+        ],
+        "description": "Assessment, Performed: Falls Screening",
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.117",
+        "id": {
+          "_id": {
+            "$oid": "5c880148d7c8ac4c3e1068a5"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c06ece3b848466bbc906175"
+        },
+        "method": null,
+        "negationRationale": null,
+        "qdmCategory": "assessment",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "result": null,
+        "_type": "QDM::AssessmentPerformed"
+      },
+      {
+        "_id": {
+          "$oid": "5c880148d7c8ac4c3e1068a6"
+        },
+        "admissionSource": null,
+        "authorDatetime": "2012-12-04T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "HCPCS",
+            "code": "G0438"
+          }
+        ],
+        "description": "Encounter, Performed: Annual Wellness Visit",
+        "diagnoses": [
+
+        ],
+        "dischargeDisposition": null,
+        "facilityLocations": [
+
+        ],
+        "hqmfOid": "2.16.840.1.113883.3.560.1.79",
+        "id": {
+          "_id": {
+            "$oid": "5c880148d7c8ac4c3e1068a7"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c06ece3b848466bbc906173"
+        },
+        "lengthOfStay": {
+          "value": 0,
+          "unit": "days"
+        },
+        "negationRationale": null,
+        "principalDiagnosis": null,
+        "qdmCategory": "encounter",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "relevantPeriod": {
+          "low": "2012-12-04T08:00:00.000+00:00",
+          "high": "2012-12-04T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "_type": "QDM::EncounterPerformed"
+      },
+      {
+        "_id": {
+          "$oid": "5c880148d7c8ac4c3e10689c"
+        },
+        "birthDatetime": "1940-01-01T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "code": "21112-8",
+            "codeSystem": "LOINC",
+            "descriptor": null,
+            "codeSystemOid": null,
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.54",
+        "id": {
+          "_id": {
+            "$oid": "5c880148d7c8ac4c3e1068a8"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880148d7c8ac4c3e10689c"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "birthdate",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicBirthdate"
+      },
+      {
+        "_id": {
+          "$oid": "5c880148d7c8ac4c3e10689d"
+        },
+        "dataElementCodes": [
+          {
+            "code": "2186-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "Not Hispanic or Latino",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.56",
+        "id": {
+          "_id": {
+            "$oid": "5c880148d7c8ac4c3e1068a9"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880148d7c8ac4c3e10689d"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "ethnicity",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicEthnicity"
+      },
+      {
+        "_id": {
+          "$oid": "5c880148d7c8ac4c3e10689e"
+        },
+        "dataElementCodes": [
+          {
+            "code": "1002-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "American Indian or Alaska Native",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.59",
+        "id": {
+          "_id": {
+            "$oid": "5c880148d7c8ac4c3e1068aa"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880148d7c8ac4c3e10689e"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "race",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicRace"
+      },
+      {
+        "_id": {
+          "$oid": "5c880148d7c8ac4c3e10689f"
+        },
+        "dataElementCodes": [
+          {
+            "code": "M",
+            "codeSystem": "AdministrativeGender",
+            "descriptor": "M",
+            "codeSystemOid": "2.16.840.1.113883.5.1",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.55",
+        "id": {
+          "_id": {
+            "$oid": "5c880148d7c8ac4c3e1068ab"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880148d7c8ac4c3e10689f"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "gender",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicSex"
+      }
+    ],
+    "extendedData": {
+      "type": null,
+      "measure_ids": [
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+        null,
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&7B905B21-D904-454F-885B-9CE5D19674E3",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&920D5B27-DF5A-4770-BD60-FC4EE251C4D2",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&3000797E-11B1-4F62-A078-341A4002A11C",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&5B20AFEA-D4AF-4F7A-A5A3-F1F6165B9E5F",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&F03324C2-9147-457B-BC34-811BB7859C91",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&BA108B7B-90B4-4692-B1D0-5DB554D2A1A2",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC"
+      ],
+      "source_data_criteria": [
+        {
+          "negation": false,
+          "definition": "assessment",
+          "status": "performed",
+          "title": "AmbulatoryStatus",
+          "description": "Assessment, Performed: Ambulatory Status",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.118.11.1219",
+          "type": "assessments",
+          "id": "AmbulatoryStatus_AssessmentPerformed_eb84926c_ae80_4768_9f88_ea55ed355df6_source",
+          "start_date": 1309766400000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+          "cms_id": "CMS231v0",
+          "criteria_id": "1677b0af52fFX",
+          "codes": {
+            "LOINC": [
+              "59458-0"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5c06ece3b848466bbc906174"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "assessment",
+          "status": "performed",
+          "title": "FallsScreening",
+          "description": "Assessment, Performed: Falls Screening",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.118.12.1028",
+          "type": "assessments",
+          "id": "FallsScreening_AssessmentPerformed_3296d6d9_085b_4acd_84a9_819c01e4e5cd_source",
+          "start_date": 1341388800000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+          "cms_id": "CMS231v0",
+          "criteria_id": "1677b0b4e9bGs",
+          "codes": {
+            "SNOMED-CT": [
+              "401196007"
+            ],
+            "LOINC": [
+              "52552-7"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5c06ece3b848466bbc906175"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "encounter",
+          "status": "performed",
+          "title": "AnnualWellnessVisit",
+          "description": "Encounter, Performed: Annual Wellness Visit",
+          "code_list_id": "2.16.840.1.113883.3.526.3.1240",
+          "type": "encounters",
+          "id": "AnnualWellnessVisit_EncounterPerformed_d50103e4_3ce4_48e3_9489_68dc37fb0b20_source",
+          "start_date": 1354608000000,
+          "end_date": 1354608900000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+          "cms_id": "CMS231v0",
+          "criteria_id": "1677b0ac53a4Q",
+          "codes": {
+            "HCPCS": [
+              "G0438"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5c06ece3b848466bbc906173"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "id": "MeasurePeriod",
+          "start_date": 0,
+          "end_date": 0,
+          "references": null
+        }
+      ],
+      "is_shared": null,
+      "origin_data": [
+
+      ],
+      "test_id": null,
+      "medical_record_number": "d975a2c11a5dbfa9af64642c349f94b5f5e5b43b211617f5d2992dd0438ca8fd",
+      "medical_record_assigner": "Bonnie",
+      "description": null,
+      "description_category": null,
+      "insurance_providers": "[{\"codes\":{\"SOP\":[\"349\"]},\"description\":null,\"end_time\":null,\"financial_responsibility_type\":{\"code\":\"SELF\",\"codeSystem\":\"HL7 Relationship Code\"},\"health_record_field\":null,\"member_id\":\"1234567890\",\"mood_code\":\"EVN\",\"name\":\"Other\",\"negationInd\":null,\"negationReason\":null,\"oid\":null,\"payer\":{\"name\":\"Other\"},\"reason\":null,\"relationship\":null,\"specifics\":null,\"start_time\":1199145600,\"status_code\":null,\"time\":null,\"type\":\"OT\"}]"
+    },
+    "qdmVersion": "5.4"
+  }
+}

--- a/test/fixtures/patients/CMS244v0/Patient_Test 2.json
+++ b/test/fixtures/patients/CMS244v0/Patient_Test 2.json
@@ -1,0 +1,449 @@
+{
+  "_id": {
+    "$oid": "5c06ecf1b848466bbc906184"
+  },
+  "bundleId": "5a57e977942c6d1e61d32f14",
+  "expectedValues": [
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+      "population_index": 0,
+      "IPP": 1,
+      "DENOM": 1,
+      "DENEX": 0,
+      "NUMER": 1
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC",
+      "population_index": 0,
+      "IPP": 1,
+      "MSRPOPL": 1,
+      "MSRPOPLEX": 0,
+      "OBSERV": [
+        0.25
+      ],
+      "OBSERV_UNIT": ""
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&7B905B21-D904-454F-885B-9CE5D19674E3",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "NUMER": 0,
+      "DENEXCEP": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&5B20AFEA-D4AF-4F7A-A5A3-F1F6165B9E5F",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&3000797E-11B1-4F62-A078-341A4002A11C",
+      "population_index": 0,
+      "IPP": 1,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&920D5B27-DF5A-4770-BD60-FC4EE251C4D2",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&BA108B7B-90B4-4692-B1D0-5DB554D2A1A2",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0,
+      "DENEXCEP": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&F03324C2-9147-457B-BC34-811BB7859C91",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    }
+  ],
+  "familyName": "Test 2",
+  "givenNames": [
+    "Patient"
+  ],
+  "notes": "",
+  "qdmPatient": {
+    "_id": {
+      "$oid": "5c880148d7c8ac4c3e1068b1"
+    },
+    "birthDatetime": "1940-01-01T08:00:00.000+00:00",
+    "dataElements": [
+      {
+        "_id": {
+          "$oid": "5c880148d7c8ac4c3e1068b2"
+        },
+        "authorDatetime": "2011-07-04T08:00:00.000+00:00",
+        "components": [
+
+        ],
+        "dataElementCodes": [
+          {
+            "codeSystem": "LOINC",
+            "code": "59458-0"
+          }
+        ],
+        "description": "Assessment, Performed: Ambulatory Status",
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.117",
+        "id": {
+          "_id": {
+            "$oid": "5c880148d7c8ac4c3e1068b3"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c06ecf1b848466bbc906185"
+        },
+        "method": null,
+        "negationRationale": null,
+        "qdmCategory": "assessment",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "result": null,
+        "_type": "QDM::AssessmentPerformed"
+      },
+      {
+        "_id": {
+          "$oid": "5c880148d7c8ac4c3e1068b4"
+        },
+        "authorDatetime": "2012-07-04T08:00:00.000+00:00",
+        "components": [
+
+        ],
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "401196007"
+          },
+          {
+            "codeSystem": "LOINC",
+            "code": "52552-7"
+          }
+        ],
+        "description": "Assessment, Performed: Falls Screening",
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.117",
+        "id": {
+          "_id": {
+            "$oid": "5c880148d7c8ac4c3e1068b5"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c06ecf1b848466bbc906186"
+        },
+        "method": null,
+        "negationRationale": null,
+        "qdmCategory": "assessment",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "result": null,
+        "_type": "QDM::AssessmentPerformed"
+      },
+      {
+        "_id": {
+          "$oid": "5c880148d7c8ac4c3e1068b6"
+        },
+        "admissionSource": null,
+        "authorDatetime": "2012-12-04T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "HCPCS",
+            "code": "G0438"
+          }
+        ],
+        "description": "Encounter, Performed: Annual Wellness Visit",
+        "diagnoses": [
+
+        ],
+        "dischargeDisposition": null,
+        "facilityLocations": [
+
+        ],
+        "hqmfOid": "2.16.840.1.113883.3.560.1.79",
+        "id": {
+          "_id": {
+            "$oid": "5c880148d7c8ac4c3e1068b7"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c06ecf1b848466bbc906187"
+        },
+        "lengthOfStay": {
+          "value": 0,
+          "unit": "days"
+        },
+        "negationRationale": null,
+        "principalDiagnosis": null,
+        "qdmCategory": "encounter",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "relevantPeriod": {
+          "low": "2012-12-04T08:00:00.000+00:00",
+          "high": "2012-12-04T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "_type": "QDM::EncounterPerformed"
+      },
+      {
+        "_id": {
+          "$oid": "5c880148d7c8ac4c3e1068ac"
+        },
+        "birthDatetime": "1940-01-01T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "code": "21112-8",
+            "codeSystem": "LOINC",
+            "descriptor": null,
+            "codeSystemOid": null,
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.54",
+        "id": {
+          "_id": {
+            "$oid": "5c880148d7c8ac4c3e1068b8"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880148d7c8ac4c3e1068ac"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "birthdate",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicBirthdate"
+      },
+      {
+        "_id": {
+          "$oid": "5c880148d7c8ac4c3e1068ad"
+        },
+        "dataElementCodes": [
+          {
+            "code": "2186-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "Not Hispanic or Latino",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.56",
+        "id": {
+          "_id": {
+            "$oid": "5c880148d7c8ac4c3e1068b9"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880148d7c8ac4c3e1068ad"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "ethnicity",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicEthnicity"
+      },
+      {
+        "_id": {
+          "$oid": "5c880148d7c8ac4c3e1068ae"
+        },
+        "dataElementCodes": [
+          {
+            "code": "1002-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "American Indian or Alaska Native",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.59",
+        "id": {
+          "_id": {
+            "$oid": "5c880148d7c8ac4c3e1068ba"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880148d7c8ac4c3e1068ae"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "race",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicRace"
+      },
+      {
+        "_id": {
+          "$oid": "5c880148d7c8ac4c3e1068af"
+        },
+        "dataElementCodes": [
+          {
+            "code": "M",
+            "codeSystem": "AdministrativeGender",
+            "descriptor": "M",
+            "codeSystemOid": "2.16.840.1.113883.5.1",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.55",
+        "id": {
+          "_id": {
+            "$oid": "5c880148d7c8ac4c3e1068bb"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880148d7c8ac4c3e1068af"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "gender",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicSex"
+      }
+    ],
+    "extendedData": {
+      "type": null,
+      "measure_ids": [
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&7B905B21-D904-454F-885B-9CE5D19674E3",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&920D5B27-DF5A-4770-BD60-FC4EE251C4D2",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&3000797E-11B1-4F62-A078-341A4002A11C",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&5B20AFEA-D4AF-4F7A-A5A3-F1F6165B9E5F",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&F03324C2-9147-457B-BC34-811BB7859C91",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&BA108B7B-90B4-4692-B1D0-5DB554D2A1A2",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC",
+        null
+      ],
+      "source_data_criteria": [
+        {
+          "negation": false,
+          "definition": "assessment",
+          "status": "performed",
+          "title": "AmbulatoryStatus",
+          "description": "Assessment, Performed: Ambulatory Status",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.118.11.1219",
+          "type": "assessments",
+          "id": "AmbulatoryStatus_AssessmentPerformed_eb84926c_ae80_4768_9f88_ea55ed355df6_source",
+          "start_date": 1309766400000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+          "cms_id": "CMS231v0",
+          "criteria_id": "1677b0af52fFX",
+          "codes": {
+            "LOINC": [
+              "59458-0"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5c06ecf1b848466bbc906185"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "assessment",
+          "status": "performed",
+          "title": "FallsScreening",
+          "description": "Assessment, Performed: Falls Screening",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.118.12.1028",
+          "type": "assessments",
+          "id": "FallsScreening_AssessmentPerformed_3296d6d9_085b_4acd_84a9_819c01e4e5cd_source",
+          "start_date": 1341388800000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+          "cms_id": "CMS231v0",
+          "criteria_id": "1677b0b4e9bGs",
+          "codes": {
+            "SNOMED-CT": [
+              "401196007"
+            ],
+            "LOINC": [
+              "52552-7"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5c06ecf1b848466bbc906186"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "encounter",
+          "status": "performed",
+          "title": "AnnualWellnessVisit",
+          "description": "Encounter, Performed: Annual Wellness Visit",
+          "code_list_id": "2.16.840.1.113883.3.526.3.1240",
+          "type": "encounters",
+          "id": "AnnualWellnessVisit_EncounterPerformed_d50103e4_3ce4_48e3_9489_68dc37fb0b20_source",
+          "start_date": 1354608000000,
+          "end_date": 1354608900000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+          "cms_id": "CMS231v0",
+          "criteria_id": "1677b0ac53a4Q",
+          "codes": {
+            "HCPCS": [
+              "G0438"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5c06ecf1b848466bbc906187"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "id": "MeasurePeriod",
+          "start_date": 0,
+          "end_date": 0,
+          "references": null
+        }
+      ],
+      "is_shared": null,
+      "origin_data": [
+
+      ],
+      "test_id": null,
+      "medical_record_number": "66e7185c846fb50aaff1541a59d0b72284f89f64783a89bb33f9ae0d93f07361",
+      "medical_record_assigner": "Bonnie",
+      "description": null,
+      "description_category": null,
+      "insurance_providers": "[{\"codes\":{\"SOP\":[\"349\"]},\"description\":null,\"end_time\":null,\"financial_responsibility_type\":{\"code\":\"SELF\",\"codeSystem\":\"HL7 Relationship Code\"},\"health_record_field\":null,\"member_id\":\"1234567890\",\"mood_code\":\"EVN\",\"name\":\"Other\",\"negationInd\":null,\"negationReason\":null,\"oid\":null,\"payer\":{\"name\":\"Other\"},\"reason\":null,\"relationship\":null,\"specifics\":null,\"start_time\":1199145600,\"status_code\":null,\"time\":null,\"type\":\"OT\"}]"
+    },
+    "qdmVersion": "5.4"
+  }
+}

--- a/test/fixtures/patients/CMS321v0/Patient_Test 1.json
+++ b/test/fixtures/patients/CMS321v0/Patient_Test 1.json
@@ -1,0 +1,449 @@
+{
+  "_id": {
+    "$oid": "5c06ec72b848466bbc906066"
+  },
+  "bundleId": "5a57e977942c6d1e61d32f14",
+  "expectedValues": [
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+      "population_index": 0,
+      "IPP": 1,
+      "DENOM": 1,
+      "DENEX": 0,
+      "NUMER": 1
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC",
+      "population_index": 0,
+      "IPP": 1,
+      "MSRPOPL": 1,
+      "MSRPOPLEX": 0,
+      "OBSERV": [
+        0.25
+      ],
+      "OBSERV_UNIT": ""
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&7B905B21-D904-454F-885B-9CE5D19674E3",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "NUMER": 0,
+      "DENEXCEP": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&5B20AFEA-D4AF-4F7A-A5A3-F1F6165B9E5F",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&3000797E-11B1-4F62-A078-341A4002A11C",
+      "population_index": 0,
+      "IPP": 1,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&920D5B27-DF5A-4770-BD60-FC4EE251C4D2",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&BA108B7B-90B4-4692-B1D0-5DB554D2A1A2",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0,
+      "DENEXCEP": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&F03324C2-9147-457B-BC34-811BB7859C91",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    }
+  ],
+  "familyName": "Test 1",
+  "givenNames": [
+    "Patient"
+  ],
+  "notes": "",
+  "qdmPatient": {
+    "_id": {
+      "$oid": "5c880148d7c8ac4c3e1068c1"
+    },
+    "birthDatetime": "1940-01-01T08:00:00.000+00:00",
+    "dataElements": [
+      {
+        "_id": {
+          "$oid": "5c880148d7c8ac4c3e1068c2"
+        },
+        "authorDatetime": "2011-07-04T08:00:00.000+00:00",
+        "components": [
+
+        ],
+        "dataElementCodes": [
+          {
+            "codeSystem": "LOINC",
+            "code": "59458-0"
+          }
+        ],
+        "description": "Assessment, Performed: Ambulatory Status",
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.117",
+        "id": {
+          "_id": {
+            "$oid": "5c880148d7c8ac4c3e1068c3"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c06ece3b848466bbc906174"
+        },
+        "method": null,
+        "negationRationale": null,
+        "qdmCategory": "assessment",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "result": null,
+        "_type": "QDM::AssessmentPerformed"
+      },
+      {
+        "_id": {
+          "$oid": "5c880148d7c8ac4c3e1068c4"
+        },
+        "authorDatetime": "2012-07-04T08:00:00.000+00:00",
+        "components": [
+
+        ],
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "401196007"
+          },
+          {
+            "codeSystem": "LOINC",
+            "code": "52552-7"
+          }
+        ],
+        "description": "Assessment, Performed: Falls Screening",
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.117",
+        "id": {
+          "_id": {
+            "$oid": "5c880148d7c8ac4c3e1068c5"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c06ece3b848466bbc906175"
+        },
+        "method": null,
+        "negationRationale": null,
+        "qdmCategory": "assessment",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "result": null,
+        "_type": "QDM::AssessmentPerformed"
+      },
+      {
+        "_id": {
+          "$oid": "5c880148d7c8ac4c3e1068c6"
+        },
+        "admissionSource": null,
+        "authorDatetime": "2012-12-04T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "HCPCS",
+            "code": "G0438"
+          }
+        ],
+        "description": "Encounter, Performed: Annual Wellness Visit",
+        "diagnoses": [
+
+        ],
+        "dischargeDisposition": null,
+        "facilityLocations": [
+
+        ],
+        "hqmfOid": "2.16.840.1.113883.3.560.1.79",
+        "id": {
+          "_id": {
+            "$oid": "5c880148d7c8ac4c3e1068c7"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c06ece3b848466bbc906173"
+        },
+        "lengthOfStay": {
+          "value": 0,
+          "unit": "days"
+        },
+        "negationRationale": null,
+        "principalDiagnosis": null,
+        "qdmCategory": "encounter",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "relevantPeriod": {
+          "low": "2012-12-04T08:00:00.000+00:00",
+          "high": "2012-12-04T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "_type": "QDM::EncounterPerformed"
+      },
+      {
+        "_id": {
+          "$oid": "5c880148d7c8ac4c3e1068bc"
+        },
+        "birthDatetime": "1940-01-01T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "code": "21112-8",
+            "codeSystem": "LOINC",
+            "descriptor": null,
+            "codeSystemOid": null,
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.54",
+        "id": {
+          "_id": {
+            "$oid": "5c880148d7c8ac4c3e1068c8"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880148d7c8ac4c3e1068bc"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "birthdate",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicBirthdate"
+      },
+      {
+        "_id": {
+          "$oid": "5c880148d7c8ac4c3e1068bd"
+        },
+        "dataElementCodes": [
+          {
+            "code": "2186-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "Not Hispanic or Latino",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.56",
+        "id": {
+          "_id": {
+            "$oid": "5c880148d7c8ac4c3e1068c9"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880148d7c8ac4c3e1068bd"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "ethnicity",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicEthnicity"
+      },
+      {
+        "_id": {
+          "$oid": "5c880148d7c8ac4c3e1068be"
+        },
+        "dataElementCodes": [
+          {
+            "code": "1002-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "American Indian or Alaska Native",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.59",
+        "id": {
+          "_id": {
+            "$oid": "5c880148d7c8ac4c3e1068ca"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880148d7c8ac4c3e1068be"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "race",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicRace"
+      },
+      {
+        "_id": {
+          "$oid": "5c880148d7c8ac4c3e1068bf"
+        },
+        "dataElementCodes": [
+          {
+            "code": "M",
+            "codeSystem": "AdministrativeGender",
+            "descriptor": "M",
+            "codeSystemOid": "2.16.840.1.113883.5.1",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.55",
+        "id": {
+          "_id": {
+            "$oid": "5c880148d7c8ac4c3e1068cb"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880148d7c8ac4c3e1068bf"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "gender",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicSex"
+      }
+    ],
+    "extendedData": {
+      "type": null,
+      "measure_ids": [
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+        null,
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&7B905B21-D904-454F-885B-9CE5D19674E3",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&920D5B27-DF5A-4770-BD60-FC4EE251C4D2",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&3000797E-11B1-4F62-A078-341A4002A11C",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&5B20AFEA-D4AF-4F7A-A5A3-F1F6165B9E5F",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&F03324C2-9147-457B-BC34-811BB7859C91",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&BA108B7B-90B4-4692-B1D0-5DB554D2A1A2",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC"
+      ],
+      "source_data_criteria": [
+        {
+          "negation": false,
+          "definition": "assessment",
+          "status": "performed",
+          "title": "AmbulatoryStatus",
+          "description": "Assessment, Performed: Ambulatory Status",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.118.11.1219",
+          "type": "assessments",
+          "id": "AmbulatoryStatus_AssessmentPerformed_eb84926c_ae80_4768_9f88_ea55ed355df6_source",
+          "start_date": 1309766400000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+          "cms_id": "CMS231v0",
+          "criteria_id": "1677b0af52fFX",
+          "codes": {
+            "LOINC": [
+              "59458-0"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5c06ece3b848466bbc906174"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "assessment",
+          "status": "performed",
+          "title": "FallsScreening",
+          "description": "Assessment, Performed: Falls Screening",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.118.12.1028",
+          "type": "assessments",
+          "id": "FallsScreening_AssessmentPerformed_3296d6d9_085b_4acd_84a9_819c01e4e5cd_source",
+          "start_date": 1341388800000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+          "cms_id": "CMS231v0",
+          "criteria_id": "1677b0b4e9bGs",
+          "codes": {
+            "SNOMED-CT": [
+              "401196007"
+            ],
+            "LOINC": [
+              "52552-7"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5c06ece3b848466bbc906175"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "encounter",
+          "status": "performed",
+          "title": "AnnualWellnessVisit",
+          "description": "Encounter, Performed: Annual Wellness Visit",
+          "code_list_id": "2.16.840.1.113883.3.526.3.1240",
+          "type": "encounters",
+          "id": "AnnualWellnessVisit_EncounterPerformed_d50103e4_3ce4_48e3_9489_68dc37fb0b20_source",
+          "start_date": 1354608000000,
+          "end_date": 1354608900000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+          "cms_id": "CMS231v0",
+          "criteria_id": "1677b0ac53a4Q",
+          "codes": {
+            "HCPCS": [
+              "G0438"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5c06ece3b848466bbc906173"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "id": "MeasurePeriod",
+          "start_date": 0,
+          "end_date": 0,
+          "references": null
+        }
+      ],
+      "is_shared": null,
+      "origin_data": [
+
+      ],
+      "test_id": null,
+      "medical_record_number": "d975a2c11a5dbfa9af64642c349f94b5f5e5b43b211617f5d2992dd0438ca8fd",
+      "medical_record_assigner": "Bonnie",
+      "description": null,
+      "description_category": null,
+      "insurance_providers": "[{\"codes\":{\"SOP\":[\"349\"]},\"description\":null,\"end_time\":null,\"financial_responsibility_type\":{\"code\":\"SELF\",\"codeSystem\":\"HL7 Relationship Code\"},\"health_record_field\":null,\"member_id\":\"1234567890\",\"mood_code\":\"EVN\",\"name\":\"Other\",\"negationInd\":null,\"negationReason\":null,\"oid\":null,\"payer\":{\"name\":\"Other\"},\"reason\":null,\"relationship\":null,\"specifics\":null,\"start_time\":1199145600,\"status_code\":null,\"time\":null,\"type\":\"OT\"}]"
+    },
+    "qdmVersion": "5.4"
+  }
+}

--- a/test/fixtures/patients/CMS321v0/Patient_Test 2.json
+++ b/test/fixtures/patients/CMS321v0/Patient_Test 2.json
@@ -1,0 +1,449 @@
+{
+  "_id": {
+    "$oid": "5c06ecf1b848466bbc906184"
+  },
+  "bundleId": "5a57e977942c6d1e61d32f14",
+  "expectedValues": [
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+      "population_index": 0,
+      "IPP": 1,
+      "DENOM": 1,
+      "DENEX": 0,
+      "NUMER": 1
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC",
+      "population_index": 0,
+      "IPP": 1,
+      "MSRPOPL": 1,
+      "MSRPOPLEX": 0,
+      "OBSERV": [
+        0.25
+      ],
+      "OBSERV_UNIT": ""
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&7B905B21-D904-454F-885B-9CE5D19674E3",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "NUMER": 0,
+      "DENEXCEP": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&5B20AFEA-D4AF-4F7A-A5A3-F1F6165B9E5F",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&3000797E-11B1-4F62-A078-341A4002A11C",
+      "population_index": 0,
+      "IPP": 1,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&920D5B27-DF5A-4770-BD60-FC4EE251C4D2",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&BA108B7B-90B4-4692-B1D0-5DB554D2A1A2",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0,
+      "DENEXCEP": 0
+    },
+    {
+      "measure_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&F03324C2-9147-457B-BC34-811BB7859C91",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    }
+  ],
+  "familyName": "Test 2",
+  "givenNames": [
+    "Patient"
+  ],
+  "notes": "",
+  "qdmPatient": {
+    "_id": {
+      "$oid": "5c880149d7c8ac4c3e1068d1"
+    },
+    "birthDatetime": "1940-01-01T08:00:00.000+00:00",
+    "dataElements": [
+      {
+        "_id": {
+          "$oid": "5c880149d7c8ac4c3e1068d2"
+        },
+        "authorDatetime": "2011-07-04T08:00:00.000+00:00",
+        "components": [
+
+        ],
+        "dataElementCodes": [
+          {
+            "codeSystem": "LOINC",
+            "code": "59458-0"
+          }
+        ],
+        "description": "Assessment, Performed: Ambulatory Status",
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.117",
+        "id": {
+          "_id": {
+            "$oid": "5c880149d7c8ac4c3e1068d3"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c06ecf1b848466bbc906185"
+        },
+        "method": null,
+        "negationRationale": null,
+        "qdmCategory": "assessment",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "result": null,
+        "_type": "QDM::AssessmentPerformed"
+      },
+      {
+        "_id": {
+          "$oid": "5c880149d7c8ac4c3e1068d4"
+        },
+        "authorDatetime": "2012-07-04T08:00:00.000+00:00",
+        "components": [
+
+        ],
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "401196007"
+          },
+          {
+            "codeSystem": "LOINC",
+            "code": "52552-7"
+          }
+        ],
+        "description": "Assessment, Performed: Falls Screening",
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.117",
+        "id": {
+          "_id": {
+            "$oid": "5c880149d7c8ac4c3e1068d5"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c06ecf1b848466bbc906186"
+        },
+        "method": null,
+        "negationRationale": null,
+        "qdmCategory": "assessment",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "result": null,
+        "_type": "QDM::AssessmentPerformed"
+      },
+      {
+        "_id": {
+          "$oid": "5c880149d7c8ac4c3e1068d6"
+        },
+        "admissionSource": null,
+        "authorDatetime": "2012-12-04T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "HCPCS",
+            "code": "G0438"
+          }
+        ],
+        "description": "Encounter, Performed: Annual Wellness Visit",
+        "diagnoses": [
+
+        ],
+        "dischargeDisposition": null,
+        "facilityLocations": [
+
+        ],
+        "hqmfOid": "2.16.840.1.113883.3.560.1.79",
+        "id": {
+          "_id": {
+            "$oid": "5c880149d7c8ac4c3e1068d7"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c06ecf1b848466bbc906187"
+        },
+        "lengthOfStay": {
+          "value": 0,
+          "unit": "days"
+        },
+        "negationRationale": null,
+        "principalDiagnosis": null,
+        "qdmCategory": "encounter",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "relevantPeriod": {
+          "low": "2012-12-04T08:00:00.000+00:00",
+          "high": "2012-12-04T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "_type": "QDM::EncounterPerformed"
+      },
+      {
+        "_id": {
+          "$oid": "5c880149d7c8ac4c3e1068cc"
+        },
+        "birthDatetime": "1940-01-01T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "code": "21112-8",
+            "codeSystem": "LOINC",
+            "descriptor": null,
+            "codeSystemOid": null,
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.54",
+        "id": {
+          "_id": {
+            "$oid": "5c880149d7c8ac4c3e1068d8"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880149d7c8ac4c3e1068cc"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "birthdate",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicBirthdate"
+      },
+      {
+        "_id": {
+          "$oid": "5c880149d7c8ac4c3e1068cd"
+        },
+        "dataElementCodes": [
+          {
+            "code": "2186-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "Not Hispanic or Latino",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.56",
+        "id": {
+          "_id": {
+            "$oid": "5c880149d7c8ac4c3e1068d9"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880149d7c8ac4c3e1068cd"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "ethnicity",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicEthnicity"
+      },
+      {
+        "_id": {
+          "$oid": "5c880149d7c8ac4c3e1068ce"
+        },
+        "dataElementCodes": [
+          {
+            "code": "1002-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "American Indian or Alaska Native",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.59",
+        "id": {
+          "_id": {
+            "$oid": "5c880149d7c8ac4c3e1068da"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880149d7c8ac4c3e1068ce"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "race",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicRace"
+      },
+      {
+        "_id": {
+          "$oid": "5c880149d7c8ac4c3e1068cf"
+        },
+        "dataElementCodes": [
+          {
+            "code": "M",
+            "codeSystem": "AdministrativeGender",
+            "descriptor": "M",
+            "codeSystemOid": "2.16.840.1.113883.5.1",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.55",
+        "id": {
+          "_id": {
+            "$oid": "5c880149d7c8ac4c3e1068db"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880149d7c8ac4c3e1068cf"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "gender",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicSex"
+      }
+    ],
+    "extendedData": {
+      "type": null,
+      "measure_ids": [
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&7B905B21-D904-454F-885B-9CE5D19674E3",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&920D5B27-DF5A-4770-BD60-FC4EE251C4D2",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&3000797E-11B1-4F62-A078-341A4002A11C",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&5B20AFEA-D4AF-4F7A-A5A3-F1F6165B9E5F",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&F03324C2-9147-457B-BC34-811BB7859C91",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&BA108B7B-90B4-4692-B1D0-5DB554D2A1A2",
+        "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC",
+        null
+      ],
+      "source_data_criteria": [
+        {
+          "negation": false,
+          "definition": "assessment",
+          "status": "performed",
+          "title": "AmbulatoryStatus",
+          "description": "Assessment, Performed: Ambulatory Status",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.118.11.1219",
+          "type": "assessments",
+          "id": "AmbulatoryStatus_AssessmentPerformed_eb84926c_ae80_4768_9f88_ea55ed355df6_source",
+          "start_date": 1309766400000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+          "cms_id": "CMS231v0",
+          "criteria_id": "1677b0af52fFX",
+          "codes": {
+            "LOINC": [
+              "59458-0"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5c06ecf1b848466bbc906185"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "assessment",
+          "status": "performed",
+          "title": "FallsScreening",
+          "description": "Assessment, Performed: Falls Screening",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.118.12.1028",
+          "type": "assessments",
+          "id": "FallsScreening_AssessmentPerformed_3296d6d9_085b_4acd_84a9_819c01e4e5cd_source",
+          "start_date": 1341388800000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+          "cms_id": "CMS231v0",
+          "criteria_id": "1677b0b4e9bGs",
+          "codes": {
+            "SNOMED-CT": [
+              "401196007"
+            ],
+            "LOINC": [
+              "52552-7"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5c06ecf1b848466bbc906186"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "encounter",
+          "status": "performed",
+          "title": "AnnualWellnessVisit",
+          "description": "Encounter, Performed: Annual Wellness Visit",
+          "code_list_id": "2.16.840.1.113883.3.526.3.1240",
+          "type": "encounters",
+          "id": "AnnualWellnessVisit_EncounterPerformed_d50103e4_3ce4_48e3_9489_68dc37fb0b20_source",
+          "start_date": 1354608000000,
+          "end_date": 1354608900000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "244B4F52-C9CA-45AA-8BDB-2F005DA05BFC&E22EA997-4EC1-4ED2-876C-3671099CB325",
+          "cms_id": "CMS231v0",
+          "criteria_id": "1677b0ac53a4Q",
+          "codes": {
+            "HCPCS": [
+              "G0438"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5c06ecf1b848466bbc906187"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "id": "MeasurePeriod",
+          "start_date": 0,
+          "end_date": 0,
+          "references": null
+        }
+      ],
+      "is_shared": null,
+      "origin_data": [
+
+      ],
+      "test_id": null,
+      "medical_record_number": "66e7185c846fb50aaff1541a59d0b72284f89f64783a89bb33f9ae0d93f07361",
+      "medical_record_assigner": "Bonnie",
+      "description": null,
+      "description_category": null,
+      "insurance_providers": "[{\"codes\":{\"SOP\":[\"349\"]},\"description\":null,\"end_time\":null,\"financial_responsibility_type\":{\"code\":\"SELF\",\"codeSystem\":\"HL7 Relationship Code\"},\"health_record_field\":null,\"member_id\":\"1234567890\",\"mood_code\":\"EVN\",\"name\":\"Other\",\"negationInd\":null,\"negationReason\":null,\"oid\":null,\"payer\":{\"name\":\"Other\"},\"reason\":null,\"relationship\":null,\"specifics\":null,\"start_time\":1199145600,\"status_code\":null,\"time\":null,\"type\":\"OT\"}]"
+    },
+    "qdmVersion": "5.4"
+  }
+}

--- a/test/fixtures/patients/CMS32v7/Visit_1 ED.json
+++ b/test/fixtures/patients/CMS32v7/Visit_1 ED.json
@@ -1,0 +1,376 @@
+{
+  "_id": {
+    "$oid": "5a58e9b6942c6d4bb26bb2f6"
+  },
+  "bundleId": "5a57e977942c6d1e61d32f14",
+  "expectedValues": [
+    {
+      "measure_id": "3FD13096-2C8F-40B5-9297-B714E8DE9133",
+      "population_index": 0,
+      "IPP": 1,
+      "MSRPOPL": 1,
+      "MSRPOPLEX": 0,
+      "OBSERV_UNIT": " mins",
+      "OBSERV": [
+        15
+      ]
+    },
+    {
+      "measure_id": "3FD13096-2C8F-40B5-9297-B714E8DE9133",
+      "population_index": 1,
+      "STRAT": 1,
+      "IPP": 1,
+      "MSRPOPL": 1,
+      "MSRPOPLEX": 0,
+      "OBSERV_UNIT": " mins",
+      "OBSERV": [
+        15
+      ]
+    },
+    {
+      "measure_id": "3FD13096-2C8F-40B5-9297-B714E8DE9133",
+      "population_index": 2,
+      "STRAT": 0,
+      "IPP": 0,
+      "MSRPOPL": 0,
+      "MSRPOPLEX": 0,
+      "OBSERV_UNIT": " mins"
+    },
+    {
+      "measure_id": "3FD13096-2C8F-40B5-9297-B714E8DE9133",
+      "population_index": 3,
+      "STRAT": 0,
+      "IPP": 0,
+      "MSRPOPL": 0,
+      "MSRPOPLEX": 0,
+      "OBSERV_UNIT": " mins"
+    }
+  ],
+  "familyName": "1 ED",
+  "givenNames": [
+    "Visit"
+  ],
+  "notes": "",
+  "qdmPatient": {
+    "_id": {
+      "$oid": "5c88013cd7c8ac4c3e10664d"
+    },
+    "birthDatetime": "1994-01-01T08:00:00.000+00:00",
+    "dataElements": [
+      {
+        "_id": {
+          "$oid": "5c88013cd7c8ac4c3e10664e"
+        },
+        "admissionSource": null,
+        "authorDatetime": "2012-06-10T05:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "4525004"
+          }
+        ],
+        "description": "Encounter, Performed: Emergency Department Visit",
+        "diagnoses": [
+          {
+            "code": "10278007",
+            "codeSystem": "SNOMED-CT",
+            "version": null,
+            "descriptor": "Psychiatric/Mental Health Diagnosis"
+          }
+        ],
+        "dischargeDisposition": null,
+        "facilityLocations": [
+
+        ],
+        "hqmfOid": "2.16.840.1.113883.3.560.1.79",
+        "id": {
+          "_id": {
+            "$oid": "5c88013cd7c8ac4c3e10664f"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5aeb7763b848463d625b33cf"
+        },
+        "lengthOfStay": {
+          "value": 0,
+          "unit": "days"
+        },
+        "negationRationale": null,
+        "principalDiagnosis": {
+          "code": "10278007",
+          "codeSystem": "SNOMED-CT",
+          "descriptor": "Psychiatric/Mental Health Diagnosis",
+          "codeSystemOid": null,
+          "version": null
+        },
+        "qdmCategory": "encounter",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "relevantPeriod": {
+          "low": "2012-06-10T05:00:00.000+00:00",
+          "high": "2012-06-10T05:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "_type": "QDM::EncounterPerformed"
+      },
+      {
+        "_id": {
+          "$oid": "5c88013cd7c8ac4c3e106650"
+        },
+        "admissionSource": null,
+        "authorDatetime": "2012-06-11T09:15:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "183452005"
+          }
+        ],
+        "description": "Encounter, Performed: Encounter Inpatient",
+        "diagnoses": [
+
+        ],
+        "dischargeDisposition": null,
+        "facilityLocations": [
+
+        ],
+        "hqmfOid": "2.16.840.1.113883.3.560.1.79",
+        "id": {
+          "_id": {
+            "$oid": "5c88013cd7c8ac4c3e106651"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5aeb7763b848463d625b33d1"
+        },
+        "lengthOfStay": {
+          "value": 3,
+          "unit": "days"
+        },
+        "negationRationale": null,
+        "principalDiagnosis": null,
+        "qdmCategory": "encounter",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "relevantPeriod": {
+          "low": "2012-06-11T09:15:00.000+00:00",
+          "high": "2012-06-14T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "_type": "QDM::EncounterPerformed"
+      },
+      {
+        "_id": {
+          "$oid": "5c88013cd7c8ac4c3e106648"
+        },
+        "birthDatetime": "1994-01-01T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "code": "21112-8",
+            "codeSystem": "LOINC",
+            "descriptor": null,
+            "codeSystemOid": null,
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.54",
+        "id": {
+          "_id": {
+            "$oid": "5c88013cd7c8ac4c3e106652"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013cd7c8ac4c3e106648"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "birthdate",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicBirthdate"
+      },
+      {
+        "_id": {
+          "$oid": "5c88013cd7c8ac4c3e106649"
+        },
+        "dataElementCodes": [
+          {
+            "code": "2186-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "Not Hispanic or Latino",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.56",
+        "id": {
+          "_id": {
+            "$oid": "5c88013cd7c8ac4c3e106653"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013cd7c8ac4c3e106649"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "ethnicity",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicEthnicity"
+      },
+      {
+        "_id": {
+          "$oid": "5c88013cd7c8ac4c3e10664a"
+        },
+        "dataElementCodes": [
+          {
+            "code": "1002-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "American Indian or Alaska Native",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.59",
+        "id": {
+          "_id": {
+            "$oid": "5c88013cd7c8ac4c3e106654"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013cd7c8ac4c3e10664a"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "race",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicRace"
+      },
+      {
+        "_id": {
+          "$oid": "5c88013cd7c8ac4c3e10664b"
+        },
+        "dataElementCodes": [
+          {
+            "code": "M",
+            "codeSystem": "AdministrativeGender",
+            "descriptor": "M",
+            "codeSystemOid": "2.16.840.1.113883.5.1",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.55",
+        "id": {
+          "_id": {
+            "$oid": "5c88013cd7c8ac4c3e106655"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013cd7c8ac4c3e10664b"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "gender",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicSex"
+      }
+    ],
+    "extendedData": {
+      "type": null,
+      "measure_ids": [
+        "3FD13096-2C8F-40B5-9297-B714E8DE9133",
+        null
+      ],
+      "source_data_criteria": [
+        {
+          "negation": false,
+          "definition": "encounter",
+          "status": "performed",
+          "title": "EmergencyDepartmentVisit",
+          "description": "Encounter, Performed: Emergency Department Visit",
+          "code_list_id": "2.16.840.1.113883.3.117.1.7.1.292",
+          "type": "encounters",
+          "id": "EmergencyDepartmentVisit_EncounterPerformed_e9dfea5a_0011_42cc_b048_3a8748c1c4b0_source",
+          "start_date": 1339304400000,
+          "end_date": 1339305300000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+            "PRINCIPAL_DIAGNOSIS": {
+              "type": "CD",
+              "code_list_id": "2.16.840.1.113883.3.117.1.7.1.299",
+              "field_title": "Principal Diagnosis",
+              "title": "Psychiatric/Mental Health Patient"
+            }
+          },
+          "hqmf_set_id": "3FD13096-2C8F-40B5-9297-B714E8DE9133",
+          "cms_id": "CMS32v7",
+          "criteria_id": "160eb4e203aVV",
+          "codes": {
+            "SNOMED-CT": [
+              "4525004"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5aeb7763b848463d625b33cf"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "encounter",
+          "status": "performed",
+          "title": "EncounterInpatient",
+          "description": "Encounter, Performed: Encounter Inpatient",
+          "code_list_id": "2.16.840.1.113883.3.666.5.307",
+          "type": "encounters",
+          "id": "EncounterInpatient_EncounterPerformed_2f356da9_9e4f_442a_9232_4a10ae95334c_source",
+          "start_date": 1339406100000,
+          "end_date": 1339661700000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "3FD13096-2C8F-40B5-9297-B714E8DE9133",
+          "cms_id": "CMS32v7",
+          "criteria_id": "160eb4f4767dk",
+          "codes": {
+            "SNOMED-CT": [
+              "183452005"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5aeb7763b848463d625b33d1"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "id": "MeasurePeriod",
+          "start_date": 0,
+          "end_date": 0,
+          "references": null
+        }
+      ],
+      "is_shared": null,
+      "origin_data": [
+
+      ],
+      "test_id": null,
+      "medical_record_number": "ae884d4ce89724e1ec3c435032e573ae1433d5c257b3c4755178898fdbab8abd",
+      "medical_record_assigner": "Bonnie",
+      "description": null,
+      "description_category": null,
+      "insurance_providers": "[]"
+    },
+    "qdmVersion": "5.4"
+  }
+}

--- a/test/fixtures/patients/CMS32v7/Visits 1 Excl_2 ED.json
+++ b/test/fixtures/patients/CMS32v7/Visits 1 Excl_2 ED.json
@@ -1,0 +1,484 @@
+{
+  "_id": {
+    "$oid": "5a593ff0942c6d0773593dff"
+  },
+  "bundleId": "5a57e977942c6d1e61d32f14",
+  "expectedValues": [
+    {
+      "measure_id": "3FD13096-2C8F-40B5-9297-B714E8DE9133",
+      "population_index": 0,
+      "IPP": 2,
+      "MSRPOPL": 2,
+      "MSRPOPLEX": 1,
+      "OBSERV_UNIT": " mins",
+      "OBSERV": [
+        15,
+        25
+      ]
+    },
+    {
+      "measure_id": "3FD13096-2C8F-40B5-9297-B714E8DE9133",
+      "population_index": 1,
+      "STRAT": 2,
+      "IPP": 2,
+      "MSRPOPL": 2,
+      "MSRPOPLEX": 1,
+      "OBSERV_UNIT": " mins",
+      "OBSERV": [
+        15,
+        25
+      ]
+    },
+    {
+      "measure_id": "3FD13096-2C8F-40B5-9297-B714E8DE9133",
+      "population_index": 2,
+      "STRAT": 0,
+      "IPP": 0,
+      "MSRPOPL": 0,
+      "MSRPOPLEX": 0,
+      "OBSERV_UNIT": " mins"
+    },
+    {
+      "measure_id": "3FD13096-2C8F-40B5-9297-B714E8DE9133",
+      "population_index": 3,
+      "STRAT": 0,
+      "IPP": 0,
+      "MSRPOPL": 0,
+      "MSRPOPLEX": 0,
+      "OBSERV_UNIT": " mins"
+    }
+  ],
+  "familyName": "2 ED",
+  "givenNames": [
+    "Visits 1 Excl"
+  ],
+  "notes": "",
+  "qdmPatient": {
+    "_id": {
+      "$oid": "5c88013dd7c8ac4c3e10666b"
+    },
+    "birthDatetime": "1994-01-01T08:00:00.000+00:00",
+    "dataElements": [
+      {
+        "_id": {
+          "$oid": "5c88013dd7c8ac4c3e10666c"
+        },
+        "admissionSource": null,
+        "authorDatetime": "2012-06-10T05:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "4525004"
+          }
+        ],
+        "description": "Encounter, Performed: Emergency Department Visit",
+        "diagnoses": [
+          {
+            "code": "10278007",
+            "codeSystem": "SNOMED-CT",
+            "version": null,
+            "descriptor": "Psychiatric/Mental Health Diagnosis"
+          }
+        ],
+        "dischargeDisposition": null,
+        "facilityLocations": [
+
+        ],
+        "hqmfOid": "2.16.840.1.113883.3.560.1.79",
+        "id": {
+          "_id": {
+            "$oid": "5c88013dd7c8ac4c3e10666d"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5aeb77ccb848463d625b5d4d"
+        },
+        "lengthOfStay": {
+          "value": 0,
+          "unit": "days"
+        },
+        "negationRationale": null,
+        "principalDiagnosis": {
+          "code": "10278007",
+          "codeSystem": "SNOMED-CT",
+          "descriptor": "Psychiatric/Mental Health Diagnosis",
+          "codeSystemOid": null,
+          "version": null
+        },
+        "qdmCategory": "encounter",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "relevantPeriod": {
+          "low": "2012-06-10T05:00:00.000+00:00",
+          "high": "2012-06-10T05:25:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "_type": "QDM::EncounterPerformed"
+      },
+      {
+        "_id": {
+          "$oid": "5c88013dd7c8ac4c3e10666e"
+        },
+        "admissionSource": null,
+        "authorDatetime": "2012-06-10T09:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "4525004"
+          }
+        ],
+        "description": "Encounter, Performed: Emergency Department Visit",
+        "diagnoses": [
+          {
+            "code": "10278007",
+            "codeSystem": "SNOMED-CT",
+            "version": null,
+            "descriptor": "Psychiatric/Mental Health Diagnosis"
+          }
+        ],
+        "dischargeDisposition": {
+          "code": "371828006",
+          "codeSystem": "SNOMED-CT",
+          "descriptor": "Patient deceased during stay (discharge status = dead) (finding)",
+          "codeSystemOid": null,
+          "version": null
+        },
+        "facilityLocations": [
+
+        ],
+        "hqmfOid": "2.16.840.1.113883.3.560.1.79",
+        "id": {
+          "_id": {
+            "$oid": "5c88013dd7c8ac4c3e10666f"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5aeb77ccb848463d625b5d4f"
+        },
+        "lengthOfStay": {
+          "value": 0,
+          "unit": "days"
+        },
+        "negationRationale": null,
+        "principalDiagnosis": {
+          "code": "10278007",
+          "codeSystem": "SNOMED-CT",
+          "descriptor": "Psychiatric/Mental Health Diagnosis",
+          "codeSystemOid": null,
+          "version": null
+        },
+        "qdmCategory": "encounter",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "relevantPeriod": {
+          "low": "2012-06-10T09:00:00.000+00:00",
+          "high": "2012-06-10T09:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "_type": "QDM::EncounterPerformed"
+      },
+      {
+        "_id": {
+          "$oid": "5c88013dd7c8ac4c3e106670"
+        },
+        "admissionSource": null,
+        "authorDatetime": "2012-06-11T09:15:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "183452005"
+          }
+        ],
+        "description": "Encounter, Performed: Encounter Inpatient",
+        "diagnoses": [
+
+        ],
+        "dischargeDisposition": null,
+        "facilityLocations": [
+
+        ],
+        "hqmfOid": "2.16.840.1.113883.3.560.1.79",
+        "id": {
+          "_id": {
+            "$oid": "5c88013dd7c8ac4c3e106671"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5aeb77ccb848463d625b5d51"
+        },
+        "lengthOfStay": {
+          "value": 3,
+          "unit": "days"
+        },
+        "negationRationale": null,
+        "principalDiagnosis": null,
+        "qdmCategory": "encounter",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "relevantPeriod": {
+          "low": "2012-06-11T09:15:00.000+00:00",
+          "high": "2012-06-14T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "_type": "QDM::EncounterPerformed"
+      },
+      {
+        "_id": {
+          "$oid": "5c88013dd7c8ac4c3e106666"
+        },
+        "birthDatetime": "1994-01-01T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "code": "21112-8",
+            "codeSystem": "LOINC",
+            "descriptor": null,
+            "codeSystemOid": null,
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.54",
+        "id": {
+          "_id": {
+            "$oid": "5c88013dd7c8ac4c3e106672"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013dd7c8ac4c3e106666"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "birthdate",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicBirthdate"
+      },
+      {
+        "_id": {
+          "$oid": "5c88013dd7c8ac4c3e106667"
+        },
+        "dataElementCodes": [
+          {
+            "code": "2186-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "Not Hispanic or Latino",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.56",
+        "id": {
+          "_id": {
+            "$oid": "5c88013dd7c8ac4c3e106673"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013dd7c8ac4c3e106667"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "ethnicity",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicEthnicity"
+      },
+      {
+        "_id": {
+          "$oid": "5c88013dd7c8ac4c3e106668"
+        },
+        "dataElementCodes": [
+          {
+            "code": "1002-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "American Indian or Alaska Native",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.59",
+        "id": {
+          "_id": {
+            "$oid": "5c88013dd7c8ac4c3e106674"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013dd7c8ac4c3e106668"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "race",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicRace"
+      },
+      {
+        "_id": {
+          "$oid": "5c88013dd7c8ac4c3e106669"
+        },
+        "dataElementCodes": [
+          {
+            "code": "M",
+            "codeSystem": "AdministrativeGender",
+            "descriptor": "M",
+            "codeSystemOid": "2.16.840.1.113883.5.1",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.55",
+        "id": {
+          "_id": {
+            "$oid": "5c88013dd7c8ac4c3e106675"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013dd7c8ac4c3e106669"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "gender",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicSex"
+      }
+    ],
+    "extendedData": {
+      "type": null,
+      "measure_ids": [
+        "3FD13096-2C8F-40B5-9297-B714E8DE9133",
+        null
+      ],
+      "source_data_criteria": [
+        {
+          "negation": false,
+          "definition": "encounter",
+          "status": "performed",
+          "title": "EmergencyDepartmentVisit",
+          "description": "Encounter, Performed: Emergency Department Visit",
+          "code_list_id": "2.16.840.1.113883.3.117.1.7.1.292",
+          "type": "encounters",
+          "id": "EmergencyDepartmentVisit_EncounterPerformed_e9dfea5a_0011_42cc_b048_3a8748c1c4b0_source",
+          "start_date": 1339304400000,
+          "end_date": 1339305900000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+            "PRINCIPAL_DIAGNOSIS": {
+              "type": "CD",
+              "code_list_id": "2.16.840.1.113883.3.117.1.7.1.299",
+              "field_title": "Principal Diagnosis",
+              "title": "Psychiatric/Mental Health Patient"
+            }
+          },
+          "hqmf_set_id": "3FD13096-2C8F-40B5-9297-B714E8DE9133",
+          "cms_id": "CMS32v7",
+          "criteria_id": "160eb4e203aVV",
+          "codes": {
+            "SNOMED-CT": [
+              "4525004"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5aeb77ccb848463d625b5d4d"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "encounter",
+          "status": "performed",
+          "title": "EmergencyDepartmentVisit",
+          "description": "Encounter, Performed: Emergency Department Visit",
+          "code_list_id": "2.16.840.1.113883.3.117.1.7.1.292",
+          "type": "encounters",
+          "id": "EmergencyDepartmentVisit_EncounterPerformed_e9dfea5a_0011_42cc_b048_3a8748c1c4b0_source",
+          "start_date": 1339318800000,
+          "end_date": 1339319700000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+            "DISCHARGE_STATUS": {
+              "type": "CD",
+              "code_list_id": "30e1af73-5672-4e74-ab09-dab8b4aac67f",
+              "field_title": "Discharge Disposition",
+              "title": "Patient deceased during stay (discharge status = dead) (finding)"
+            },
+            "PRINCIPAL_DIAGNOSIS": {
+              "type": "CD",
+              "code_list_id": "2.16.840.1.113883.3.117.1.7.1.299",
+              "field_title": "Principal Diagnosis",
+              "title": "Psychiatric/Mental Health Patient"
+            }
+          },
+          "hqmf_set_id": "3FD13096-2C8F-40B5-9297-B714E8DE9133",
+          "cms_id": "CMS32v7",
+          "criteria_id": "160ec970f24Bn",
+          "codes": {
+            "SNOMED-CT": [
+              "4525004"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5aeb77ccb848463d625b5d4f"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "encounter",
+          "status": "performed",
+          "title": "EncounterInpatient",
+          "description": "Encounter, Performed: Encounter Inpatient",
+          "code_list_id": "2.16.840.1.113883.3.666.5.307",
+          "type": "encounters",
+          "id": "EncounterInpatient_EncounterPerformed_2f356da9_9e4f_442a_9232_4a10ae95334c_source",
+          "start_date": 1339406100000,
+          "end_date": 1339661700000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "3FD13096-2C8F-40B5-9297-B714E8DE9133",
+          "cms_id": "CMS32v7",
+          "criteria_id": "160eb4f4767dk",
+          "codes": {
+            "SNOMED-CT": [
+              "183452005"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5aeb77ccb848463d625b5d51"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "id": "MeasurePeriod",
+          "start_date": 0,
+          "end_date": 0,
+          "references": null
+        }
+      ],
+      "is_shared": null,
+      "origin_data": [
+
+      ],
+      "test_id": null,
+      "medical_record_number": "a383f8861def778cbcb41cb8db2830b3a11316b90a849cc1b2591ce8d5f7c8d3",
+      "medical_record_assigner": "Bonnie",
+      "description": null,
+      "description_category": null,
+      "insurance_providers": "[]"
+    },
+    "qdmVersion": "5.4"
+  }
+}

--- a/test/fixtures/patients/CMS32v7/Visits 2 Excl_2 ED.json
+++ b/test/fixtures/patients/CMS32v7/Visits 2 Excl_2 ED.json
@@ -1,0 +1,496 @@
+{
+  "_id": {
+    "$oid": "5a5940ba942c6d0c717eeece"
+  },
+  "bundleId": "5a57e977942c6d1e61d32f14",
+  "expectedValues": [
+    {
+      "measure_id": "3FD13096-2C8F-40B5-9297-B714E8DE9133",
+      "population_index": 0,
+      "IPP": 2,
+      "MSRPOPL": 2,
+      "MSRPOPLEX": 2,
+      "OBSERV_UNIT": " mins",
+      "OBSERV": [
+        15,
+        25
+      ]
+    },
+    {
+      "measure_id": "3FD13096-2C8F-40B5-9297-B714E8DE9133",
+      "population_index": 1,
+      "STRAT": 2,
+      "IPP": 2,
+      "MSRPOPL": 2,
+      "MSRPOPLEX": 2,
+      "OBSERV_UNIT": " mins",
+      "OBSERV": [
+        15,
+        25
+      ]
+    },
+    {
+      "measure_id": "3FD13096-2C8F-40B5-9297-B714E8DE9133",
+      "population_index": 2,
+      "STRAT": 0,
+      "IPP": 0,
+      "MSRPOPL": 0,
+      "MSRPOPLEX": 0,
+      "OBSERV_UNIT": " mins"
+    },
+    {
+      "measure_id": "3FD13096-2C8F-40B5-9297-B714E8DE9133",
+      "population_index": 3,
+      "STRAT": 0,
+      "IPP": 0,
+      "MSRPOPL": 0,
+      "MSRPOPLEX": 0,
+      "OBSERV_UNIT": " mins"
+    }
+  ],
+  "familyName": "2 ED",
+  "givenNames": [
+    "Visits 2 Excl"
+  ],
+  "notes": "",
+  "qdmPatient": {
+    "_id": {
+      "$oid": "5c88013dd7c8ac4c3e10667b"
+    },
+    "birthDatetime": "1994-01-01T08:00:00.000+00:00",
+    "dataElements": [
+      {
+        "_id": {
+          "$oid": "5c88013dd7c8ac4c3e10667c"
+        },
+        "admissionSource": null,
+        "authorDatetime": "2012-06-10T05:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "4525004"
+          }
+        ],
+        "description": "Encounter, Performed: Emergency Department Visit",
+        "diagnoses": [
+          {
+            "code": "10278007",
+            "codeSystem": "SNOMED-CT",
+            "version": null,
+            "descriptor": "Psychiatric/Mental Health Diagnosis"
+          }
+        ],
+        "dischargeDisposition": {
+          "code": "371828006",
+          "codeSystem": "SNOMED-CT",
+          "descriptor": "Patient deceased during stay (discharge status = dead) (finding)",
+          "codeSystemOid": null,
+          "version": null
+        },
+        "facilityLocations": [
+
+        ],
+        "hqmfOid": "2.16.840.1.113883.3.560.1.79",
+        "id": {
+          "_id": {
+            "$oid": "5c88013dd7c8ac4c3e10667d"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5aeb77cdb848463d625b5d52"
+        },
+        "lengthOfStay": {
+          "value": 0,
+          "unit": "days"
+        },
+        "negationRationale": null,
+        "principalDiagnosis": {
+          "code": "10278007",
+          "codeSystem": "SNOMED-CT",
+          "descriptor": "Psychiatric/Mental Health Diagnosis",
+          "codeSystemOid": null,
+          "version": null
+        },
+        "qdmCategory": "encounter",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "relevantPeriod": {
+          "low": "2012-06-10T05:00:00.000+00:00",
+          "high": "2012-06-10T05:25:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "_type": "QDM::EncounterPerformed"
+      },
+      {
+        "_id": {
+          "$oid": "5c88013dd7c8ac4c3e10667e"
+        },
+        "admissionSource": null,
+        "authorDatetime": "2012-06-10T09:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "4525004"
+          }
+        ],
+        "description": "Encounter, Performed: Emergency Department Visit",
+        "diagnoses": [
+          {
+            "code": "10278007",
+            "codeSystem": "SNOMED-CT",
+            "version": null,
+            "descriptor": "Psychiatric/Mental Health Diagnosis"
+          }
+        ],
+        "dischargeDisposition": {
+          "code": "371828006",
+          "codeSystem": "SNOMED-CT",
+          "descriptor": "Patient deceased during stay (discharge status = dead) (finding)",
+          "codeSystemOid": null,
+          "version": null
+        },
+        "facilityLocations": [
+
+        ],
+        "hqmfOid": "2.16.840.1.113883.3.560.1.79",
+        "id": {
+          "_id": {
+            "$oid": "5c88013dd7c8ac4c3e10667f"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5aeb77cdb848463d625b5d54"
+        },
+        "lengthOfStay": {
+          "value": 0,
+          "unit": "days"
+        },
+        "negationRationale": null,
+        "principalDiagnosis": {
+          "code": "10278007",
+          "codeSystem": "SNOMED-CT",
+          "descriptor": "Psychiatric/Mental Health Diagnosis",
+          "codeSystemOid": null,
+          "version": null
+        },
+        "qdmCategory": "encounter",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "relevantPeriod": {
+          "low": "2012-06-10T09:00:00.000+00:00",
+          "high": "2012-06-10T09:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "_type": "QDM::EncounterPerformed"
+      },
+      {
+        "_id": {
+          "$oid": "5c88013dd7c8ac4c3e106680"
+        },
+        "admissionSource": null,
+        "authorDatetime": "2012-06-11T09:15:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "183452005"
+          }
+        ],
+        "description": "Encounter, Performed: Encounter Inpatient",
+        "diagnoses": [
+
+        ],
+        "dischargeDisposition": null,
+        "facilityLocations": [
+
+        ],
+        "hqmfOid": "2.16.840.1.113883.3.560.1.79",
+        "id": {
+          "_id": {
+            "$oid": "5c88013dd7c8ac4c3e106681"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5aeb77cdb848463d625b5d56"
+        },
+        "lengthOfStay": {
+          "value": 3,
+          "unit": "days"
+        },
+        "negationRationale": null,
+        "principalDiagnosis": null,
+        "qdmCategory": "encounter",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "relevantPeriod": {
+          "low": "2012-06-11T09:15:00.000+00:00",
+          "high": "2012-06-14T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "_type": "QDM::EncounterPerformed"
+      },
+      {
+        "_id": {
+          "$oid": "5c88013dd7c8ac4c3e106676"
+        },
+        "birthDatetime": "1994-01-01T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "code": "21112-8",
+            "codeSystem": "LOINC",
+            "descriptor": null,
+            "codeSystemOid": null,
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.54",
+        "id": {
+          "_id": {
+            "$oid": "5c88013dd7c8ac4c3e106682"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013dd7c8ac4c3e106676"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "birthdate",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicBirthdate"
+      },
+      {
+        "_id": {
+          "$oid": "5c88013dd7c8ac4c3e106677"
+        },
+        "dataElementCodes": [
+          {
+            "code": "2186-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "Not Hispanic or Latino",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.56",
+        "id": {
+          "_id": {
+            "$oid": "5c88013dd7c8ac4c3e106683"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013dd7c8ac4c3e106677"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "ethnicity",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicEthnicity"
+      },
+      {
+        "_id": {
+          "$oid": "5c88013dd7c8ac4c3e106678"
+        },
+        "dataElementCodes": [
+          {
+            "code": "1002-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "American Indian or Alaska Native",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.59",
+        "id": {
+          "_id": {
+            "$oid": "5c88013dd7c8ac4c3e106684"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013dd7c8ac4c3e106678"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "race",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicRace"
+      },
+      {
+        "_id": {
+          "$oid": "5c88013dd7c8ac4c3e106679"
+        },
+        "dataElementCodes": [
+          {
+            "code": "M",
+            "codeSystem": "AdministrativeGender",
+            "descriptor": "M",
+            "codeSystemOid": "2.16.840.1.113883.5.1",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.55",
+        "id": {
+          "_id": {
+            "$oid": "5c88013dd7c8ac4c3e106685"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013dd7c8ac4c3e106679"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "gender",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicSex"
+      }
+    ],
+    "extendedData": {
+      "type": null,
+      "measure_ids": [
+        "3FD13096-2C8F-40B5-9297-B714E8DE9133",
+        null
+      ],
+      "source_data_criteria": [
+        {
+          "negation": false,
+          "definition": "encounter",
+          "status": "performed",
+          "title": "EmergencyDepartmentVisit",
+          "description": "Encounter, Performed: Emergency Department Visit",
+          "code_list_id": "2.16.840.1.113883.3.117.1.7.1.292",
+          "type": "encounters",
+          "id": "EmergencyDepartmentVisit_EncounterPerformed_e9dfea5a_0011_42cc_b048_3a8748c1c4b0_source",
+          "start_date": 1339304400000,
+          "end_date": 1339305900000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+            "PRINCIPAL_DIAGNOSIS": {
+              "type": "CD",
+              "code_list_id": "2.16.840.1.113883.3.117.1.7.1.299",
+              "field_title": "Principal Diagnosis",
+              "title": "Psychiatric/Mental Health Patient"
+            },
+            "DISCHARGE_STATUS": {
+              "type": "CD",
+              "code_list_id": "30e1af73-5672-4e74-ab09-dab8b4aac67f",
+              "field_title": "Discharge Disposition",
+              "title": "Patient deceased during stay (discharge status = dead) (finding)"
+            }
+          },
+          "hqmf_set_id": "3FD13096-2C8F-40B5-9297-B714E8DE9133",
+          "cms_id": "CMS32v7",
+          "criteria_id": "160eb4e203aVV",
+          "codes": {
+            "SNOMED-CT": [
+              "4525004"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5aeb77cdb848463d625b5d52"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "encounter",
+          "status": "performed",
+          "title": "EmergencyDepartmentVisit",
+          "description": "Encounter, Performed: Emergency Department Visit",
+          "code_list_id": "2.16.840.1.113883.3.117.1.7.1.292",
+          "type": "encounters",
+          "id": "EmergencyDepartmentVisit_EncounterPerformed_e9dfea5a_0011_42cc_b048_3a8748c1c4b0_source",
+          "start_date": 1339318800000,
+          "end_date": 1339319700000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+            "DISCHARGE_STATUS": {
+              "type": "CD",
+              "code_list_id": "30e1af73-5672-4e74-ab09-dab8b4aac67f",
+              "field_title": "Discharge Disposition",
+              "title": "Patient deceased during stay (discharge status = dead) (finding)"
+            },
+            "PRINCIPAL_DIAGNOSIS": {
+              "type": "CD",
+              "code_list_id": "2.16.840.1.113883.3.117.1.7.1.299",
+              "field_title": "Principal Diagnosis",
+              "title": "Psychiatric/Mental Health Patient"
+            }
+          },
+          "hqmf_set_id": "3FD13096-2C8F-40B5-9297-B714E8DE9133",
+          "cms_id": "CMS32v7",
+          "criteria_id": "160ec970f24Bn",
+          "codes": {
+            "SNOMED-CT": [
+              "4525004"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5aeb77cdb848463d625b5d54"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "encounter",
+          "status": "performed",
+          "title": "EncounterInpatient",
+          "description": "Encounter, Performed: Encounter Inpatient",
+          "code_list_id": "2.16.840.1.113883.3.666.5.307",
+          "type": "encounters",
+          "id": "EncounterInpatient_EncounterPerformed_2f356da9_9e4f_442a_9232_4a10ae95334c_source",
+          "start_date": 1339406100000,
+          "end_date": 1339661700000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "3FD13096-2C8F-40B5-9297-B714E8DE9133",
+          "cms_id": "CMS32v7",
+          "criteria_id": "160eb4f4767dk",
+          "codes": {
+            "SNOMED-CT": [
+              "183452005"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5aeb77cdb848463d625b5d56"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "id": "MeasurePeriod",
+          "start_date": 0,
+          "end_date": 0,
+          "references": null
+        }
+      ],
+      "is_shared": null,
+      "origin_data": [
+
+      ],
+      "test_id": null,
+      "medical_record_number": "f9eccf228da7e4bc5f5d35593a8226c9e9a00ce8993e522f0054d0be91b705d6",
+      "medical_record_assigner": "Bonnie",
+      "description": null,
+      "description_category": null,
+      "insurance_providers": "[]"
+    },
+    "qdmVersion": "5.4"
+  }
+}

--- a/test/fixtures/patients/CMS32v7/Visits_2 ED.json
+++ b/test/fixtures/patients/CMS32v7/Visits_2 ED.json
@@ -1,0 +1,472 @@
+{
+  "_id": {
+    "$oid": "5a593d66942c6d0773593d97"
+  },
+  "bundleId": "5a57e977942c6d1e61d32f14",
+  "expectedValues": [
+    {
+      "measure_id": "3FD13096-2C8F-40B5-9297-B714E8DE9133",
+      "population_index": 0,
+      "IPP": 2,
+      "MSRPOPL": 2,
+      "MSRPOPLEX": 0,
+      "OBSERV_UNIT": " mins",
+      "OBSERV": [
+        15,
+        25
+      ]
+    },
+    {
+      "measure_id": "3FD13096-2C8F-40B5-9297-B714E8DE9133",
+      "population_index": 1,
+      "STRAT": 2,
+      "IPP": 2,
+      "MSRPOPL": 2,
+      "MSRPOPLEX": 0,
+      "OBSERV_UNIT": " mins",
+      "OBSERV": [
+        15,
+        25
+      ]
+    },
+    {
+      "measure_id": "3FD13096-2C8F-40B5-9297-B714E8DE9133",
+      "population_index": 2,
+      "STRAT": 0,
+      "IPP": 0,
+      "MSRPOPL": 0,
+      "MSRPOPLEX": 0,
+      "OBSERV_UNIT": " mins"
+    },
+    {
+      "measure_id": "3FD13096-2C8F-40B5-9297-B714E8DE9133",
+      "population_index": 3,
+      "STRAT": 0,
+      "IPP": 0,
+      "MSRPOPL": 0,
+      "MSRPOPLEX": 0,
+      "OBSERV_UNIT": " mins"
+    }
+  ],
+  "familyName": "2 ED",
+  "givenNames": [
+    "Visits"
+  ],
+  "notes": "",
+  "qdmPatient": {
+    "_id": {
+      "$oid": "5c88013dd7c8ac4c3e10665b"
+    },
+    "birthDatetime": "1994-01-01T08:00:00.000+00:00",
+    "dataElements": [
+      {
+        "_id": {
+          "$oid": "5c88013dd7c8ac4c3e10665c"
+        },
+        "admissionSource": null,
+        "authorDatetime": "2012-06-10T05:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "4525004"
+          }
+        ],
+        "description": "Encounter, Performed: Emergency Department Visit",
+        "diagnoses": [
+          {
+            "code": "10278007",
+            "codeSystem": "SNOMED-CT",
+            "version": null,
+            "descriptor": "Psychiatric/Mental Health Diagnosis"
+          }
+        ],
+        "dischargeDisposition": null,
+        "facilityLocations": [
+
+        ],
+        "hqmfOid": "2.16.840.1.113883.3.560.1.79",
+        "id": {
+          "_id": {
+            "$oid": "5c88013dd7c8ac4c3e10665d"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5aeb77ccb848463d625b5d48"
+        },
+        "lengthOfStay": {
+          "value": 0,
+          "unit": "days"
+        },
+        "negationRationale": null,
+        "principalDiagnosis": {
+          "code": "10278007",
+          "codeSystem": "SNOMED-CT",
+          "descriptor": "Psychiatric/Mental Health Diagnosis",
+          "codeSystemOid": null,
+          "version": null
+        },
+        "qdmCategory": "encounter",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "relevantPeriod": {
+          "low": "2012-06-10T05:00:00.000+00:00",
+          "high": "2012-06-10T05:25:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "_type": "QDM::EncounterPerformed"
+      },
+      {
+        "_id": {
+          "$oid": "5c88013dd7c8ac4c3e10665e"
+        },
+        "admissionSource": null,
+        "authorDatetime": "2012-06-10T09:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "4525004"
+          }
+        ],
+        "description": "Encounter, Performed: Emergency Department Visit",
+        "diagnoses": [
+          {
+            "code": "10278007",
+            "codeSystem": "SNOMED-CT",
+            "version": null,
+            "descriptor": "Psychiatric/Mental Health Diagnosis"
+          }
+        ],
+        "dischargeDisposition": null,
+        "facilityLocations": [
+
+        ],
+        "hqmfOid": "2.16.840.1.113883.3.560.1.79",
+        "id": {
+          "_id": {
+            "$oid": "5c88013dd7c8ac4c3e10665f"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5aeb77ccb848463d625b5d4a"
+        },
+        "lengthOfStay": {
+          "value": 0,
+          "unit": "days"
+        },
+        "negationRationale": null,
+        "principalDiagnosis": {
+          "code": "10278007",
+          "codeSystem": "SNOMED-CT",
+          "descriptor": "Psychiatric/Mental Health Diagnosis",
+          "codeSystemOid": null,
+          "version": null
+        },
+        "qdmCategory": "encounter",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "relevantPeriod": {
+          "low": "2012-06-10T09:00:00.000+00:00",
+          "high": "2012-06-10T09:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "_type": "QDM::EncounterPerformed"
+      },
+      {
+        "_id": {
+          "$oid": "5c88013dd7c8ac4c3e106660"
+        },
+        "admissionSource": null,
+        "authorDatetime": "2012-06-11T09:15:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "183452005"
+          }
+        ],
+        "description": "Encounter, Performed: Encounter Inpatient",
+        "diagnoses": [
+
+        ],
+        "dischargeDisposition": null,
+        "facilityLocations": [
+
+        ],
+        "hqmfOid": "2.16.840.1.113883.3.560.1.79",
+        "id": {
+          "_id": {
+            "$oid": "5c88013dd7c8ac4c3e106661"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5aeb77ccb848463d625b5d4c"
+        },
+        "lengthOfStay": {
+          "value": 3,
+          "unit": "days"
+        },
+        "negationRationale": null,
+        "principalDiagnosis": null,
+        "qdmCategory": "encounter",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "relevantPeriod": {
+          "low": "2012-06-11T09:15:00.000+00:00",
+          "high": "2012-06-14T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "_type": "QDM::EncounterPerformed"
+      },
+      {
+        "_id": {
+          "$oid": "5c88013dd7c8ac4c3e106656"
+        },
+        "birthDatetime": "1994-01-01T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "code": "21112-8",
+            "codeSystem": "LOINC",
+            "descriptor": null,
+            "codeSystemOid": null,
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.54",
+        "id": {
+          "_id": {
+            "$oid": "5c88013dd7c8ac4c3e106662"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013dd7c8ac4c3e106656"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "birthdate",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicBirthdate"
+      },
+      {
+        "_id": {
+          "$oid": "5c88013dd7c8ac4c3e106657"
+        },
+        "dataElementCodes": [
+          {
+            "code": "2186-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "Not Hispanic or Latino",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.56",
+        "id": {
+          "_id": {
+            "$oid": "5c88013dd7c8ac4c3e106663"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013dd7c8ac4c3e106657"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "ethnicity",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicEthnicity"
+      },
+      {
+        "_id": {
+          "$oid": "5c88013dd7c8ac4c3e106658"
+        },
+        "dataElementCodes": [
+          {
+            "code": "1002-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "American Indian or Alaska Native",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.59",
+        "id": {
+          "_id": {
+            "$oid": "5c88013dd7c8ac4c3e106664"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013dd7c8ac4c3e106658"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "race",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicRace"
+      },
+      {
+        "_id": {
+          "$oid": "5c88013dd7c8ac4c3e106659"
+        },
+        "dataElementCodes": [
+          {
+            "code": "M",
+            "codeSystem": "AdministrativeGender",
+            "descriptor": "M",
+            "codeSystemOid": "2.16.840.1.113883.5.1",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.55",
+        "id": {
+          "_id": {
+            "$oid": "5c88013dd7c8ac4c3e106665"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013dd7c8ac4c3e106659"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "gender",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicSex"
+      }
+    ],
+    "extendedData": {
+      "type": null,
+      "measure_ids": [
+        "3FD13096-2C8F-40B5-9297-B714E8DE9133",
+        null
+      ],
+      "source_data_criteria": [
+        {
+          "negation": false,
+          "definition": "encounter",
+          "status": "performed",
+          "title": "EmergencyDepartmentVisit",
+          "description": "Encounter, Performed: Emergency Department Visit",
+          "code_list_id": "2.16.840.1.113883.3.117.1.7.1.292",
+          "type": "encounters",
+          "id": "EmergencyDepartmentVisit_EncounterPerformed_e9dfea5a_0011_42cc_b048_3a8748c1c4b0_source",
+          "start_date": 1339304400000,
+          "end_date": 1339305900000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+            "PRINCIPAL_DIAGNOSIS": {
+              "type": "CD",
+              "code_list_id": "2.16.840.1.113883.3.117.1.7.1.299",
+              "field_title": "Principal Diagnosis",
+              "title": "Psychiatric/Mental Health Patient"
+            }
+          },
+          "hqmf_set_id": "3FD13096-2C8F-40B5-9297-B714E8DE9133",
+          "cms_id": "CMS32v7",
+          "criteria_id": "160eb4e203aVV",
+          "codes": {
+            "SNOMED-CT": [
+              "4525004"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5aeb77ccb848463d625b5d48"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "encounter",
+          "status": "performed",
+          "title": "EmergencyDepartmentVisit",
+          "description": "Encounter, Performed: Emergency Department Visit",
+          "code_list_id": "2.16.840.1.113883.3.117.1.7.1.292",
+          "type": "encounters",
+          "id": "EmergencyDepartmentVisit_EncounterPerformed_e9dfea5a_0011_42cc_b048_3a8748c1c4b0_source",
+          "start_date": 1339318800000,
+          "end_date": 1339319700000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+            "PRINCIPAL_DIAGNOSIS": {
+              "type": "CD",
+              "code_list_id": "2.16.840.1.113883.3.117.1.7.1.299",
+              "field_title": "Principal Diagnosis",
+              "title": "Psychiatric/Mental Health Patient"
+            }
+          },
+          "hqmf_set_id": "3FD13096-2C8F-40B5-9297-B714E8DE9133",
+          "cms_id": "CMS32v7",
+          "criteria_id": "160ec970f24Bn",
+          "codes": {
+            "SNOMED-CT": [
+              "4525004"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5aeb77ccb848463d625b5d4a"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "encounter",
+          "status": "performed",
+          "title": "EncounterInpatient",
+          "description": "Encounter, Performed: Encounter Inpatient",
+          "code_list_id": "2.16.840.1.113883.3.666.5.307",
+          "type": "encounters",
+          "id": "EncounterInpatient_EncounterPerformed_2f356da9_9e4f_442a_9232_4a10ae95334c_source",
+          "start_date": 1339406100000,
+          "end_date": 1339661700000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "3FD13096-2C8F-40B5-9297-B714E8DE9133",
+          "cms_id": "CMS32v7",
+          "criteria_id": "160eb4f4767dk",
+          "codes": {
+            "SNOMED-CT": [
+              "183452005"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5aeb77ccb848463d625b5d4c"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "id": "MeasurePeriod",
+          "start_date": 0,
+          "end_date": 0,
+          "references": null
+        }
+      ],
+      "is_shared": null,
+      "origin_data": [
+
+      ],
+      "test_id": null,
+      "medical_record_number": "612454107a524e3f58c27db45630314da51689f4f33965288175657a991416b5",
+      "medical_record_assigner": "Bonnie",
+      "description": null,
+      "description_category": null,
+      "insurance_providers": "[]"
+    },
+    "qdmVersion": "5.4"
+  }
+}

--- a/test/fixtures/patients/CMS460v0/MethadoneLessThan90MME_NUMERFail.json
+++ b/test/fixtures/patients/CMS460v0/MethadoneLessThan90MME_NUMERFail.json
@@ -1,0 +1,351 @@
+{
+  "_id": {
+    "$oid": "5b9ff2fcb8484609a984561f"
+  },
+  "bundleId": "5a57e977942c6d1e61d32f14",
+  "expectedValues": [
+    {
+      "measure_id": "442EDEF2-7347-4080-988F-16C9D1998803",
+      "population_index": 0,
+      "IPP": 1,
+      "DENOM": 1,
+      "DENEX": 0,
+      "NUMER": 0
+    }
+  ],
+  "familyName": "NUMERFail",
+  "givenNames": [
+    "MethadoneLessThan90MME"
+  ],
+  "notes": "methadone 40 mg oral tab does not exceed 90 MME (total daily dose is half a tablet (20 mg) which is 80 MME). Case does not meet NUMER criteria since MME is less than 90.",
+  "qdmPatient": {
+    "_id": {
+      "$oid": "5c880142d7c8ac4c3e106745"
+    },
+    "birthDatetime": "1958-05-14T08:00:00.000+00:00",
+    "dataElements": [
+      {
+        "_id": {
+          "$oid": "5c880142d7c8ac4c3e106746"
+        },
+        "admissionSource": null,
+        "authorDatetime": "2012-05-04T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "17436001"
+          },
+          {
+            "codeSystem": "CPT",
+            "code": "99241"
+          }
+        ],
+        "description": "Encounter, Performed: Outpatient Consultation",
+        "diagnoses": [
+
+        ],
+        "dischargeDisposition": null,
+        "facilityLocations": [
+
+        ],
+        "hqmfOid": "2.16.840.1.113883.3.560.1.79",
+        "id": {
+          "_id": {
+            "$oid": "5c880142d7c8ac4c3e106747"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5b9ff2fcb8484609a9845620"
+        },
+        "lengthOfStay": {
+          "value": 0,
+          "unit": "days"
+        },
+        "negationRationale": null,
+        "principalDiagnosis": null,
+        "qdmCategory": "encounter",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "relevantPeriod": {
+          "low": "2012-05-04T08:00:00.000+00:00",
+          "high": "2012-05-04T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "_type": "QDM::EncounterPerformed"
+      },
+      {
+        "_id": {
+          "$oid": "5c880142d7c8ac4c3e106748"
+        },
+        "authorDatetime": "2012-05-04T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "RxNorm",
+            "code": "864978"
+          }
+        ],
+        "daysSupplied": null,
+        "description": "Medication, Order: Opioid Medications",
+        "dosage": {
+          "value": 20,
+          "unit": "mg"
+        },
+        "frequency": {
+          "code": "229797004",
+          "codeSystem": "SNOMED-CT",
+          "descriptor": "Once daily (qualifier value)",
+          "codeSystemOid": null,
+          "version": null
+        },
+        "hqmfOid": "2.16.840.1.113883.3.560.1.17",
+        "id": {
+          "_id": {
+            "$oid": "5c880142d7c8ac4c3e106749"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5b9ff2fcb8484609a9845621"
+        },
+        "negationRationale": null,
+        "prescriberId": null,
+        "qdmCategory": "medication",
+        "qdmStatus": "order",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "refills": null,
+        "relevantPeriod": {
+          "low": "2012-05-04T08:00:00.000+00:00",
+          "high": "2012-09-03T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "route": null,
+        "setting": null,
+        "supply": null,
+        "_type": "QDM::MedicationOrder"
+      },
+      {
+        "_id": {
+          "$oid": "5c880142d7c8ac4c3e106740"
+        },
+        "birthDatetime": "1958-05-14T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "code": "21112-8",
+            "codeSystem": "LOINC",
+            "descriptor": null,
+            "codeSystemOid": null,
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.54",
+        "id": {
+          "_id": {
+            "$oid": "5c880142d7c8ac4c3e10674a"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880142d7c8ac4c3e106740"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "birthdate",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicBirthdate"
+      },
+      {
+        "_id": {
+          "$oid": "5c880142d7c8ac4c3e106741"
+        },
+        "dataElementCodes": [
+          {
+            "code": "2186-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "Not Hispanic or Latino",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.56",
+        "id": {
+          "_id": {
+            "$oid": "5c880142d7c8ac4c3e10674b"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880142d7c8ac4c3e106741"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "ethnicity",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicEthnicity"
+      },
+      {
+        "_id": {
+          "$oid": "5c880142d7c8ac4c3e106742"
+        },
+        "dataElementCodes": [
+          {
+            "code": "1002-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "American Indian or Alaska Native",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.59",
+        "id": {
+          "_id": {
+            "$oid": "5c880142d7c8ac4c3e10674c"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880142d7c8ac4c3e106742"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "race",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicRace"
+      },
+      {
+        "_id": {
+          "$oid": "5c880142d7c8ac4c3e106743"
+        },
+        "dataElementCodes": [
+          {
+            "code": "M",
+            "codeSystem": "AdministrativeGender",
+            "descriptor": "M",
+            "codeSystemOid": "2.16.840.1.113883.5.1",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.55",
+        "id": {
+          "_id": {
+            "$oid": "5c880142d7c8ac4c3e10674d"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880142d7c8ac4c3e106743"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "gender",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicSex"
+      }
+    ],
+    "extendedData": {
+      "type": null,
+      "measure_ids": [
+        "442EDEF2-7347-4080-988F-16C9D1998803",
+        null
+      ],
+      "source_data_criteria": [
+        {
+          "negation": false,
+          "definition": "encounter",
+          "status": "performed",
+          "title": "OutpatientConsultation",
+          "description": "Encounter, Performed: Outpatient Consultation",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.101.12.1008",
+          "type": "encounters",
+          "id": "OutpatientConsultation_EncounterPerformed_48dc260e_53e9_4934_91fc_958ce91f1008_source",
+          "start_date": 1336118400000,
+          "end_date": 1336119300000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "442EDEF2-7347-4080-988F-16C9D1998803",
+          "cms_id": "CMS460v0",
+          "criteria_id": "165e8cb9dc6mt",
+          "codes": {
+            "SNOMED-CT": [
+              "17436001"
+            ],
+            "CPT": [
+              "99241"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5b9ff2fcb8484609a9845620"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "medication",
+          "status": "ordered",
+          "title": "OpioidMedications",
+          "description": "Medication, Order: Opioid Medications",
+          "code_list_id": "2.16.840.1.113883.3.3157.1004.26",
+          "type": "medications",
+          "id": "OpioidMedications_MedicationOrder_9fa72c11_9e0b_481f_a2bb_5ac13e6ddd90_source",
+          "start_date": 1336118400000,
+          "end_date": 1346660100000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+            "FREQUENCY": {
+              "type": "CD",
+              "code_list_id": "drc-e6b5e12d54357f2eff60055d5aa19fbe4c458e863b9a4bb551a5ba5b3c8ca1c5",
+              "field_title": "Frequency",
+              "title": "Once daily (qualifier value)"
+            },
+            "DOSE": {
+              "type": "PQ",
+              "code_list_id": "",
+              "field_title": "Dosage",
+              "value": "20",
+              "unit": "mg"
+            }
+          },
+          "hqmf_set_id": "442EDEF2-7347-4080-988F-16C9D1998803",
+          "cms_id": "CMS460v0",
+          "criteria_id": "165e8cbce30A9",
+          "codes": {
+            "RxNorm": [
+              "864978"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5b9ff2fcb8484609a9845621"
+          },
+          "code_source": "USER_DEFINED"
+        },
+        {
+          "id": "MeasurePeriod",
+          "start_date": 0,
+          "end_date": 0,
+          "references": null
+        }
+      ],
+      "is_shared": null,
+      "origin_data": [
+
+      ],
+      "test_id": null,
+      "medical_record_number": "db7212399f648c5126c4f02acb51e1ecb64b4c24252752a1d730c7341861aa7d",
+      "medical_record_assigner": "Bonnie",
+      "description": null,
+      "description_category": null,
+      "insurance_providers": "[{\"codes\":{\"SOP\":[\"349\"]},\"description\":null,\"end_time\":null,\"financial_responsibility_type\":{\"code\":\"SELF\",\"codeSystem\":\"HL7 Relationship Code\"},\"health_record_field\":null,\"member_id\":\"1234567890\",\"mood_code\":\"EVN\",\"name\":\"Other\",\"negationInd\":null,\"negationReason\":null,\"oid\":null,\"payer\":{\"name\":\"Other\"},\"reason\":null,\"relationship\":null,\"specifics\":null,\"start_time\":1199145600,\"status_code\":null,\"time\":null,\"type\":\"OT\"}]"
+    },
+    "qdmVersion": "5.4"
+  }
+}

--- a/test/fixtures/patients/CMS460v0/Opioid_Test.json
+++ b/test/fixtures/patients/CMS460v0/Opioid_Test.json
@@ -1,0 +1,368 @@
+{
+  "_id": {
+    "$oid": "5af346c3b848465f42b0acf3"
+  },
+  "bundleId": "5a57e977942c6d1e61d32f14",
+  "expectedValues": [
+    {
+      "measure_id": "442EDEF2-7347-4080-988F-16C9D1998803",
+      "population_index": 0,
+      "IPP": 1,
+      "DENOM": 1,
+      "DENEX": 0,
+      "NUMER": 0
+    }
+  ],
+  "familyName": "Test",
+  "givenNames": [
+    "Opioid"
+  ],
+  "notes": "",
+  "qdmPatient": {
+    "_id": {
+      "$oid": "5c880142d7c8ac4c3e106737"
+    },
+    "birthDatetime": "1980-06-10T08:00:00.000+00:00",
+    "dataElements": [
+      {
+        "_id": {
+          "$oid": "5c880142d7c8ac4c3e106738"
+        },
+        "admissionSource": null,
+        "authorDatetime": "2012-05-09T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "17436001"
+          },
+          {
+            "codeSystem": "CPT",
+            "code": "99241"
+          }
+        ],
+        "description": "Encounter, Performed: Outpatient Consultation",
+        "diagnoses": [
+
+        ],
+        "dischargeDisposition": null,
+        "facilityLocations": [
+
+        ],
+        "hqmfOid": "2.16.840.1.113883.3.560.1.79",
+        "id": {
+          "_id": {
+            "$oid": "5c880142d7c8ac4c3e106739"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5b2a7bfeb8484678da8c686c"
+        },
+        "lengthOfStay": {
+          "value": 0,
+          "unit": "days"
+        },
+        "negationRationale": null,
+        "principalDiagnosis": null,
+        "qdmCategory": "encounter",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "relevantPeriod": {
+          "low": "2012-05-09T08:00:00.000+00:00",
+          "high": "2012-05-09T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "_type": "QDM::EncounterPerformed"
+      },
+      {
+        "_id": {
+          "$oid": "5c880142d7c8ac4c3e10673a"
+        },
+        "authorDatetime": "2012-05-09T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "RxNorm",
+            "code": "1053647"
+          }
+        ],
+        "daysSupplied": null,
+        "description": "Medication, Order: Opioid Medications",
+        "dosage": {
+          "value": 0.5,
+          "unit": "mg"
+        },
+        "frequency": {
+          "code": "229799001",
+          "codeSystem": "SNOMED-CT",
+          "descriptor": "Twice a day (qualifier value)",
+          "codeSystemOid": null,
+          "version": null
+        },
+        "hqmfOid": "2.16.840.1.113883.3.560.1.17",
+        "id": {
+          "_id": {
+            "$oid": "5c880142d7c8ac4c3e10673b"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5b2a7bfeb8484678da8c686d"
+        },
+        "negationRationale": null,
+        "prescriberId": null,
+        "qdmCategory": "medication",
+        "qdmStatus": "order",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "refills": 2,
+        "relevantPeriod": {
+          "low": "2012-05-09T08:00:00.000+00:00",
+          "high": "2012-12-28T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "route": null,
+        "setting": null,
+        "supply": {
+          "value": 120,
+          "unit": ""
+        },
+        "_type": "QDM::MedicationOrder"
+      },
+      {
+        "_id": {
+          "$oid": "5c880142d7c8ac4c3e106732"
+        },
+        "birthDatetime": "1980-06-10T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "code": "21112-8",
+            "codeSystem": "LOINC",
+            "descriptor": null,
+            "codeSystemOid": null,
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.54",
+        "id": {
+          "_id": {
+            "$oid": "5c880142d7c8ac4c3e10673c"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880142d7c8ac4c3e106732"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "birthdate",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicBirthdate"
+      },
+      {
+        "_id": {
+          "$oid": "5c880142d7c8ac4c3e106733"
+        },
+        "dataElementCodes": [
+          {
+            "code": "2186-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "Not Hispanic or Latino",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.56",
+        "id": {
+          "_id": {
+            "$oid": "5c880142d7c8ac4c3e10673d"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880142d7c8ac4c3e106733"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "ethnicity",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicEthnicity"
+      },
+      {
+        "_id": {
+          "$oid": "5c880142d7c8ac4c3e106734"
+        },
+        "dataElementCodes": [
+          {
+            "code": "1002-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "American Indian or Alaska Native",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.59",
+        "id": {
+          "_id": {
+            "$oid": "5c880142d7c8ac4c3e10673e"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880142d7c8ac4c3e106734"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "race",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicRace"
+      },
+      {
+        "_id": {
+          "$oid": "5c880142d7c8ac4c3e106735"
+        },
+        "dataElementCodes": [
+          {
+            "code": "M",
+            "codeSystem": "AdministrativeGender",
+            "descriptor": "M",
+            "codeSystemOid": "2.16.840.1.113883.5.1",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.55",
+        "id": {
+          "_id": {
+            "$oid": "5c880142d7c8ac4c3e10673f"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880142d7c8ac4c3e106735"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "gender",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicSex"
+      }
+    ],
+    "extendedData": {
+      "type": null,
+      "measure_ids": [
+        "442EDEF2-7347-4080-988F-16C9D1998803",
+        null
+      ],
+      "source_data_criteria": [
+        {
+          "negation": false,
+          "definition": "encounter",
+          "status": "performed",
+          "title": "OutpatientConsultation",
+          "description": "Encounter, Performed: Outpatient Consultation",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.101.12.1008",
+          "type": "encounters",
+          "id": "OutpatientConsultation_EncounterPerformed_48dc260e_53e9_4934_91fc_958ce91f1008_source",
+          "start_date": 1336550400000,
+          "end_date": 1336551300000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "442EDEF2-7347-4080-988F-16C9D1998803",
+          "cms_id": "CMS460v0",
+          "criteria_id": "1634649dc54ED",
+          "codes": {
+            "SNOMED-CT": [
+              "17436001"
+            ],
+            "CPT": [
+              "99241"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5b2a7bfeb8484678da8c686c"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "medication",
+          "status": "ordered",
+          "title": "OpioidMedications",
+          "description": "Medication, Order: Opioid Medications",
+          "code_list_id": "2.16.840.1.113762.1.4.1111.144",
+          "type": "medications",
+          "id": "OpioidMedications_MedicationOrder_9fa72c11_9e0b_481f_a2bb_5ac13e6ddd90_source",
+          "start_date": 1336550400000,
+          "end_date": 1356682500000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+            "DOSE": {
+              "type": "PQ",
+              "value": "0.5",
+              "unit": "mg",
+              "field_title": "Dosage"
+            },
+            "FREQUENCY": {
+              "type": "CD",
+              "code_list_id": "drc-5d724671c39b58f85c450e49e712099c7c7ddc12096bd8b026a451dc75735b45",
+              "field_title": "Frequency",
+              "title": "Twice a day (qualifier value)"
+            },
+            "SUPPLY": {
+              "type": "PQ",
+              "code_list_id": "",
+              "field_title": "Supply",
+              "value": "120",
+              "unit": ""
+            },
+            "REFILLS": {
+              "type": "PQ",
+              "code_list_id": "",
+              "field_title": "Refills",
+              "value": "2",
+              "unit": ""
+            }
+          },
+          "hqmf_set_id": "442EDEF2-7347-4080-988F-16C9D1998803",
+          "cms_id": "CMS460v0",
+          "criteria_id": "163464a0518ET",
+          "codes": {
+            "RxNorm": [
+              "1053647"
+            ]
+          },
+          "fulfillments": null,
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5b2a7bfeb8484678da8c686d"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "id": "MeasurePeriod",
+          "start_date": 0,
+          "end_date": 0,
+          "references": null
+        }
+      ],
+      "is_shared": null,
+      "origin_data": [
+
+      ],
+      "test_id": null,
+      "medical_record_number": "5c9bee7e9c8628990b49657d9314673e61f3c211d838a8ae7d4ec8042c6966b6",
+      "medical_record_assigner": "Bonnie",
+      "description": null,
+      "description_category": null,
+      "insurance_providers": "[]"
+    },
+    "qdmVersion": "5.4"
+  }
+}

--- a/test/fixtures/patients/CMS529v0/Pass_IPP/DENOM/NUMER.json
+++ b/test/fixtures/patients/CMS529v0/Pass_IPP/DENOM/NUMER.json
@@ -1,0 +1,301 @@
+{
+  "_id": {
+    "$oid": "5b05a7f8b84846736b81b847"
+  },
+  "bundleId": "5a57e977942c6d1e61d32f14",
+  "expectedValues": [
+    {
+      "measure_id": "FA75DE85-A934-45D7-A2F7-C700A756078B",
+      "population_index": 0,
+      "IPP": 1,
+      "DENOM": 1,
+      "NUMER": 1
+    }
+  ],
+  "familyName": "IPP/DENOM/NUMER",
+  "givenNames": [
+    "Pass"
+  ],
+  "notes": "",
+  "qdmPatient": {
+    "_id": {
+      "$oid": "5c880142d7c8ac4c3e106729"
+    },
+    "birthDatetime": "1930-05-01T08:00:00.000+00:00",
+    "dataElements": [
+      {
+        "_id": {
+          "$oid": "5c880142d7c8ac4c3e10672a"
+        },
+        "authorDatetime": "2012-05-22T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "Source of Payment Typology",
+            "code": "1"
+          }
+        ],
+        "description": "Patient Characteristic: Payer",
+        "hqmfOid": "2.16.840.1.113883.3.560.1.1001",
+        "id": {
+          "_id": {
+            "$oid": "5c880142d7c8ac4c3e10672b"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5b05a7f8b84846736b81b848"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristic"
+      },
+      {
+        "_id": {
+          "$oid": "5c880142d7c8ac4c3e10672c"
+        },
+        "admissionSource": null,
+        "authorDatetime": "2012-05-22T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "112689000"
+          }
+        ],
+        "description": "Encounter, Performed: Acute care hospital Inpatient Encounter",
+        "diagnoses": [
+
+        ],
+        "dischargeDisposition": null,
+        "facilityLocations": [
+
+        ],
+        "hqmfOid": "2.16.840.1.113883.3.560.1.79",
+        "id": {
+          "_id": {
+            "$oid": "5c880142d7c8ac4c3e10672d"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5b05a7f8b84846736b81b849"
+        },
+        "lengthOfStay": {
+          "value": 0,
+          "unit": "days"
+        },
+        "negationRationale": null,
+        "principalDiagnosis": null,
+        "qdmCategory": "encounter",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "relevantPeriod": {
+          "low": "2012-05-22T08:00:00.000+00:00",
+          "high": "2012-05-22T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "_type": "QDM::EncounterPerformed"
+      },
+      {
+        "_id": {
+          "$oid": "5c880142d7c8ac4c3e106724"
+        },
+        "birthDatetime": "1930-05-01T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "code": "21112-8",
+            "codeSystem": "LOINC",
+            "descriptor": null,
+            "codeSystemOid": null,
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.54",
+        "id": {
+          "_id": {
+            "$oid": "5c880142d7c8ac4c3e10672e"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880142d7c8ac4c3e106724"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "birthdate",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicBirthdate"
+      },
+      {
+        "_id": {
+          "$oid": "5c880142d7c8ac4c3e106725"
+        },
+        "dataElementCodes": [
+          {
+            "code": "2186-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "Not Hispanic or Latino",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.56",
+        "id": {
+          "_id": {
+            "$oid": "5c880142d7c8ac4c3e10672f"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880142d7c8ac4c3e106725"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "ethnicity",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicEthnicity"
+      },
+      {
+        "_id": {
+          "$oid": "5c880142d7c8ac4c3e106726"
+        },
+        "dataElementCodes": [
+          {
+            "code": "1002-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "American Indian or Alaska Native",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.59",
+        "id": {
+          "_id": {
+            "$oid": "5c880142d7c8ac4c3e106730"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880142d7c8ac4c3e106726"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "race",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicRace"
+      },
+      {
+        "_id": {
+          "$oid": "5c880142d7c8ac4c3e106727"
+        },
+        "dataElementCodes": [
+          {
+            "code": "M",
+            "codeSystem": "AdministrativeGender",
+            "descriptor": "M",
+            "codeSystemOid": "2.16.840.1.113883.5.1",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.55",
+        "id": {
+          "_id": {
+            "$oid": "5c880142d7c8ac4c3e106731"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880142d7c8ac4c3e106727"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "gender",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicSex"
+      }
+    ],
+    "extendedData": {
+      "type": null,
+      "measure_ids": [
+        "FA75DE85-A934-45D7-A2F7-C700A756078B",
+        null
+      ],
+      "source_data_criteria": [
+        {
+          "negation": false,
+          "definition": "patient_characteristic",
+          "title": "Payer",
+          "description": "Patient Characteristic: Payer",
+          "code_list_id": "2.16.840.1.114222.4.11.3591",
+          "type": "characteristic",
+          "id": "Payer_PatientCharacteristic_41dc8804_cc7b_413d_9a39_e815347fcb46_source",
+          "start_date": 1337673600000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "FA75DE85-A934-45D7-A2F7-C700A756078B",
+          "cms_id": "CMS529v0",
+          "criteria_id": "1638e17af2fnT",
+          "codes": {
+            "Source of Payment Typology": [
+              "1"
+            ]
+          },
+          "coded_entry_id": {
+            "$oid": "5b05a7f8b84846736b81b848"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "encounter",
+          "status": "performed",
+          "title": "AcutecarehospitalInpatientEncounter",
+          "description": "Encounter, Performed: Acute care hospital Inpatient Encounter",
+          "code_list_id": "2.16.840.1.113883.3.666.5.2289",
+          "type": "encounters",
+          "id": "AcutecarehospitalInpatientEncounter_EncounterPerformed_cb0e4615_4bf7_47ca_8f0a_6f68ce9643a4_source",
+          "start_date": 1337673600000,
+          "end_date": 1337674500000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "FA75DE85-A934-45D7-A2F7-C700A756078B",
+          "cms_id": "CMS529v0",
+          "criteria_id": "1638e17d6c4fh",
+          "codes": {
+            "SNOMED-CT": [
+              "112689000"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5b05a7f8b84846736b81b849"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "id": "MeasurePeriod",
+          "start_date": 0,
+          "end_date": 0,
+          "references": null
+        }
+      ],
+      "is_shared": null,
+      "origin_data": [
+
+      ],
+      "test_id": null,
+      "medical_record_number": "d0db3db3f32ea2ea554b57e86370635d4c4ae1cfaa247d44e1fe2797320f1cb1",
+      "medical_record_assigner": "Bonnie",
+      "description": null,
+      "description_category": null,
+      "insurance_providers": "[{\"codes\":{\"SOP\":[\"349\"]},\"description\":null,\"end_time\":null,\"financial_responsibility_type\":{\"code\":\"SELF\",\"codeSystem\":\"HL7 Relationship Code\"},\"health_record_field\":null,\"member_id\":\"1234567890\",\"mood_code\":\"EVN\",\"name\":\"Other\",\"negationInd\":null,\"negationReason\":null,\"oid\":null,\"payer\":{\"name\":\"Other\"},\"reason\":null,\"relationship\":null,\"specifics\":null,\"start_time\":1199145600,\"status_code\":null,\"time\":null,\"type\":\"OT\"}]"
+    },
+    "qdmVersion": "5.4"
+  }
+}

--- a/test/fixtures/patients/CMS52v7/Element_Direct Reference Code.json
+++ b/test/fixtures/patients/CMS52v7/Element_Direct Reference Code.json
@@ -1,0 +1,593 @@
+{
+  "_id": {
+    "$oid": "5ac279c4b848462af8fef319"
+  },
+  "bundleId": "5a57e977942c6d1e61d32f14",
+  "expectedValues": [
+    {
+      "measure_id": "1CDD20DE-5DE9-4759-8A93-31F1F8BAAAA2",
+      "population_index": 0,
+      "IPP": 1,
+      "DENOM": 1,
+      "DENEX": 0,
+      "NUMER": 0,
+      "DENEXCEP": 0
+    },
+    {
+      "measure_id": "1CDD20DE-5DE9-4759-8A93-31F1F8BAAAA2",
+      "population_index": 1,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0,
+      "DENEXCEP": 0
+    },
+    {
+      "measure_id": "1CDD20DE-5DE9-4759-8A93-31F1F8BAAAA2",
+      "population_index": 2,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    }
+  ],
+  "familyName": "Direct Reference Code",
+  "givenNames": [
+    "Element"
+  ],
+  "notes": "",
+  "qdmPatient": {
+    "_id": {
+      "$oid": "5c880140d7c8ac4c3e1066f1"
+    },
+    "birthDatetime": "1970-01-01T08:00:00.000+00:00",
+    "dataElements": [
+      {
+        "_id": {
+          "$oid": "5c880140d7c8ac4c3e1066f2"
+        },
+        "anatomicalLocationSite": null,
+        "authorDatetime": "2012-03-30T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "ICD-9-CM",
+            "code": "042"
+          },
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "111880001"
+          },
+          {
+            "codeSystem": "ICD-10-CM",
+            "code": "B20"
+          }
+        ],
+        "description": "Diagnosis: HIV 1",
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.110",
+        "id": {
+          "_id": {
+            "$oid": "5c880140d7c8ac4c3e1066f3"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5aeb77e6b848463d625b667e"
+        },
+        "prevalencePeriod": {
+          "low": "2012-03-30T08:00:00.000+00:00",
+          "high": "2012-03-30T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "qdmCategory": "condition",
+        "qdmVersion": "5.4",
+        "qrdaOid": "2.16.840.1.113883.10.20.24.3.135",
+        "severity": null,
+        "_type": "QDM::Diagnosis"
+      },
+      {
+        "_id": {
+          "$oid": "5c880140d7c8ac4c3e1066f4"
+        },
+        "admissionSource": null,
+        "authorDatetime": "2012-03-30T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "185463005"
+          },
+          {
+            "codeSystem": "CPT",
+            "code": "99201"
+          }
+        ],
+        "description": "Encounter, Performed: Office Visit",
+        "diagnoses": [
+
+        ],
+        "dischargeDisposition": null,
+        "facilityLocations": [
+
+        ],
+        "hqmfOid": "2.16.840.1.113883.3.560.1.79",
+        "id": {
+          "_id": {
+            "$oid": "5c880140d7c8ac4c3e1066f5"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5aeb77e6b848463d625b667f"
+        },
+        "lengthOfStay": {
+          "value": 0,
+          "unit": "days"
+        },
+        "negationRationale": null,
+        "principalDiagnosis": null,
+        "qdmCategory": "encounter",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "relevantPeriod": {
+          "low": "2012-03-30T08:00:00.000+00:00",
+          "high": "2012-03-30T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "_type": "QDM::EncounterPerformed"
+      },
+      {
+        "_id": {
+          "$oid": "5c880140d7c8ac4c3e1066f6"
+        },
+        "admissionSource": null,
+        "authorDatetime": "2012-07-30T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "185463005"
+          },
+          {
+            "codeSystem": "CPT",
+            "code": "99201"
+          }
+        ],
+        "description": "Encounter, Performed: Office Visit",
+        "diagnoses": [
+
+        ],
+        "dischargeDisposition": null,
+        "facilityLocations": [
+
+        ],
+        "hqmfOid": "2.16.840.1.113883.3.560.1.79",
+        "id": {
+          "_id": {
+            "$oid": "5c880140d7c8ac4c3e1066f7"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5aeb77e6b848463d625b6680"
+        },
+        "lengthOfStay": {
+          "value": 0,
+          "unit": "days"
+        },
+        "negationRationale": null,
+        "principalDiagnosis": null,
+        "qdmCategory": "encounter",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "relevantPeriod": {
+          "low": "2012-07-30T08:00:00.000+00:00",
+          "high": "2012-07-30T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "_type": "QDM::EncounterPerformed"
+      },
+      {
+        "_id": {
+          "$oid": "5c880140d7c8ac4c3e1066f8"
+        },
+        "authorDatetime": "2012-03-30T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "RxNorm",
+            "code": "105337"
+          }
+        ],
+        "daysSupplied": null,
+        "description": "Medication, Order: Dapsone 100 MG / Pyrimethamine 12.5 MG Oral Tablet",
+        "dosage": null,
+        "frequency": null,
+        "hqmfOid": "2.16.840.1.113883.3.560.1.17",
+        "id": {
+          "_id": {
+            "$oid": "5c880140d7c8ac4c3e1066f9"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5aeb77e6b848463d625b6681"
+        },
+        "negationRationale": null,
+        "prescriberId": null,
+        "qdmCategory": "medication",
+        "qdmStatus": "order",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "refills": null,
+        "relevantPeriod": {
+          "low": "2012-03-30T08:00:00.000+00:00",
+          "high": "2012-03-30T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "route": null,
+        "setting": null,
+        "supply": null,
+        "_type": "QDM::MedicationOrder"
+      },
+      {
+        "_id": {
+          "$oid": "5c880140d7c8ac4c3e1066fa"
+        },
+        "authorDatetime": "2012-03-30T08:00:00.000+00:00",
+        "components": [
+
+        ],
+        "dataElementCodes": [
+          {
+            "codeSystem": "LOINC",
+            "code": "24467-3"
+          }
+        ],
+        "description": "Laboratory Test, Performed: CD4+ Count",
+        "hqmfOid": "2.16.840.1.113883.3.560.1.5",
+        "id": {
+          "_id": {
+            "$oid": "5c880140d7c8ac4c3e1066fb"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5aeb77e6b848463d625b6682"
+        },
+        "method": null,
+        "negationRationale": null,
+        "qdmCategory": "laboratory_test",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "referenceRange": null,
+        "relevantPeriod": {
+          "low": "2012-03-30T08:00:00.000+00:00",
+          "high": "2012-03-30T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "result": {
+          "unit": "/mm3",
+          "value": 199
+        },
+        "resultDatetime": null,
+        "status": null,
+        "_type": "QDM::LaboratoryTestPerformed"
+      },
+      {
+        "_id": {
+          "$oid": "5c880140d7c8ac4c3e1066ec"
+        },
+        "birthDatetime": "1970-01-01T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "code": "21112-8",
+            "codeSystem": "LOINC",
+            "descriptor": null,
+            "codeSystemOid": null,
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.54",
+        "id": {
+          "_id": {
+            "$oid": "5c880140d7c8ac4c3e1066fc"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880140d7c8ac4c3e1066ec"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "birthdate",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicBirthdate"
+      },
+      {
+        "_id": {
+          "$oid": "5c880140d7c8ac4c3e1066ed"
+        },
+        "dataElementCodes": [
+          {
+            "code": "2186-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "Not Hispanic or Latino",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.56",
+        "id": {
+          "_id": {
+            "$oid": "5c880140d7c8ac4c3e1066fd"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880140d7c8ac4c3e1066ed"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "ethnicity",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicEthnicity"
+      },
+      {
+        "_id": {
+          "$oid": "5c880140d7c8ac4c3e1066ee"
+        },
+        "dataElementCodes": [
+          {
+            "code": "1002-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "American Indian or Alaska Native",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.59",
+        "id": {
+          "_id": {
+            "$oid": "5c880140d7c8ac4c3e1066fe"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880140d7c8ac4c3e1066ee"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "race",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicRace"
+      },
+      {
+        "_id": {
+          "$oid": "5c880140d7c8ac4c3e1066ef"
+        },
+        "dataElementCodes": [
+          {
+            "code": "M",
+            "codeSystem": "AdministrativeGender",
+            "descriptor": "M",
+            "codeSystemOid": "2.16.840.1.113883.5.1",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.55",
+        "id": {
+          "_id": {
+            "$oid": "5c880140d7c8ac4c3e1066ff"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880140d7c8ac4c3e1066ef"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "gender",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicSex"
+      }
+    ],
+    "extendedData": {
+      "type": null,
+      "measure_ids": [
+        "1CDD20DE-5DE9-4759-8A93-31F1F8BAAAA2",
+        null
+      ],
+      "source_data_criteria": [
+        {
+          "negation": false,
+          "definition": "medication",
+          "status": "ordered",
+          "title": "Medication, Order: Medication, Order",
+          "description": "Medication, Order: Dapsone 100 MG / Pyrimethamine 12.5 MG Oral Tablet",
+          "code_list_id": "drc-e7bcd5fe05acffa0b0210240916ebdd5cb263ec9e30c7f943a055e4f406b38c4",
+          "type": "medications",
+          "id": "prefix_105337_MedicationOrder_0EC8DFB2_C7B5_4C69_92A3_F517CCD2FF8C_source",
+          "start_date": 1333094400000,
+          "end_date": 1333095300000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "1CDD20DE-5DE9-4759-8A93-31F1F8BAAAA2",
+          "cms_id": "CMS52v7",
+          "criteria_id": "16287aa2af4G0",
+          "codes": {
+            "RxNorm": [
+              "105337"
+            ]
+          },
+          "fulfillments": null,
+          "administrations_value": "",
+          "frequency_value": "",
+          "frequency_unit": "min",
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5aeb77e6b848463d625b6681"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "diagnosis",
+          "title": "HIV1",
+          "description": "Diagnosis: HIV 1",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.120.12.1004",
+          "type": "conditions",
+          "id": "HIV1_Diagnosis_abf5cb1c_6014_4c16_9991_f0af2322bf3d_source",
+          "start_date": 1333094400000,
+          "end_date": 1333095300000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "1CDD20DE-5DE9-4759-8A93-31F1F8BAAAA2",
+          "cms_id": "CMS52v7",
+          "criteria_id": "16287aa7788lA",
+          "codes": {
+            "ICD-9-CM": [
+              "042"
+            ],
+            "SNOMED-CT": [
+              "111880001"
+            ],
+            "ICD-10-CM": [
+              "B20"
+            ]
+          },
+          "coded_entry_id": {
+            "$oid": "5aeb77e6b848463d625b667e"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "encounter",
+          "status": "performed",
+          "title": "OfficeVisit",
+          "description": "Encounter, Performed: Office Visit",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.101.12.1001",
+          "type": "encounters",
+          "id": "OfficeVisit_EncounterPerformed_53ac9eca_bdc8_4a25_bb93_f88e7282c0b0_source",
+          "start_date": 1333094400000,
+          "end_date": 1333095300000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "1CDD20DE-5DE9-4759-8A93-31F1F8BAAAA2",
+          "cms_id": "CMS52v7",
+          "criteria_id": "16287aaa0ecs1",
+          "codes": {
+            "SNOMED-CT": [
+              "185463005"
+            ],
+            "CPT": [
+              "99201"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5aeb77e6b848463d625b667f"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "laboratory_test",
+          "status": "performed",
+          "title": "CD4+Count",
+          "description": "Laboratory Test, Performed: CD4+ Count",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.121.12.1004",
+          "type": "laboratory_tests",
+          "id": "CD4_Count_LaboratoryTestPerformed_fe396d84_5c2c_448e_84b9_e6c4b7064c0d_source",
+          "start_date": 1333094400000,
+          "end_date": 1333095300000,
+          "value": [
+            {
+              "type": "PQ",
+              "type_cmp": "CD",
+              "value": "199",
+              "unit": "/mm3"
+            }
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "1CDD20DE-5DE9-4759-8A93-31F1F8BAAAA2",
+          "cms_id": "CMS52v7",
+          "criteria_id": "16287aae234Db",
+          "codes": {
+            "LOINC": [
+              "24467-3"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5aeb77e6b848463d625b6682"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "encounter",
+          "status": "performed",
+          "title": "OfficeVisit",
+          "description": "Encounter, Performed: Office Visit",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.101.12.1001",
+          "type": "encounters",
+          "id": "OfficeVisit_EncounterPerformed_53ac9eca_bdc8_4a25_bb93_f88e7282c0b0_source",
+          "start_date": 1343635200000,
+          "end_date": 1343636100000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "1CDD20DE-5DE9-4759-8A93-31F1F8BAAAA2",
+          "cms_id": "CMS52v7",
+          "criteria_id": "16287ab2336Cq",
+          "codes": {
+            "SNOMED-CT": [
+              "185463005"
+            ],
+            "CPT": [
+              "99201"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5aeb77e6b848463d625b6680"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "id": "MeasurePeriod",
+          "start_date": 0,
+          "end_date": 0,
+          "references": null
+        }
+      ],
+      "is_shared": null,
+      "origin_data": [
+
+      ],
+      "test_id": null,
+      "medical_record_number": "7368f43d63c27db2e2516cc8cc97fdf89a58a9ed2318ca3ecc90fb0656657f6a",
+      "medical_record_assigner": "Bonnie",
+      "description": null,
+      "description_category": null,
+      "insurance_providers": "[]"
+    },
+    "qdmVersion": "5.4"
+  }
+}

--- a/test/fixtures/patients/CMS53v7/PCIat60min_NUMERPass.json
+++ b/test/fixtures/patients/CMS53v7/PCIat60min_NUMERPass.json
@@ -1,0 +1,532 @@
+{
+  "_id": {
+    "$oid": "5b758aa7b8484609983b84a6"
+  },
+  "bundleId": "5a57e977942c6d1e61d32f14",
+  "expectedValues": [
+    {
+      "measure_id": "84B9D0B5-0CAF-4E41-B345-3492A23C2E9F",
+      "population_index": 0,
+      "IPP": 1,
+      "DENOM": 1,
+      "DENEX": 0,
+      "NUMER": 1,
+      "DENEXCEP": 0
+    }
+  ],
+  "familyName": "NUMERPass",
+  "givenNames": [
+    "PCIat60min"
+  ],
+  "notes": "Correct age, enc., MP, ECG, PCI done at 60 minutes of arrival ",
+  "qdmPatient": {
+    "_id": {
+      "$oid": "5c880145d7c8ac4c3e1067b5"
+    },
+    "birthDatetime": "1955-11-24T08:00:00.000+00:00",
+    "dataElements": [
+      {
+        "_id": {
+          "$oid": "5c880145d7c8ac4c3e1067b6"
+        },
+        "admissionSource": null,
+        "authorDatetime": "2012-11-12T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "183452005"
+          }
+        ],
+        "description": "Encounter, Performed: Encounter Inpatient",
+        "diagnoses": [
+          {
+            "code": "10273003",
+            "codeSystem": "SNOMED-CT",
+            "version": null,
+            "descriptor": "Acute or Evolving MI"
+          }
+        ],
+        "dischargeDisposition": null,
+        "facilityLocations": [
+          {
+            "_id": {
+              "$oid": "5c880145d7c8ac4c3e1067af"
+            },
+            "dataElementCodes": [
+
+            ],
+            "description": null,
+            "_type": "QDM::FacilityLocation",
+            "code": {
+              "code": "183452005",
+              "codeSystem": "SNOMED-CT",
+              "descriptor": "Encounter Inpatient",
+              "codeSystemOid": null,
+              "version": null,
+              "_type": "QDM::Code"
+            },
+            "locationPeriod": {
+              "low": "2012-11-12T08:00:00.000+00:00",
+              "high": null,
+              "lowClosed": true,
+              "highClosed": true,
+              "_type": "QDM::Interval"
+            },
+            "qdmVersion": "5.4"
+          }
+        ],
+        "hqmfOid": "2.16.840.1.113883.3.560.1.79",
+        "id": {
+          "_id": {
+            "$oid": "5c880145d7c8ac4c3e1067b7"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5b758aa7b8484609983b84a7"
+        },
+        "lengthOfStay": {
+          "value": 0,
+          "unit": "days"
+        },
+        "negationRationale": null,
+        "principalDiagnosis": {
+          "code": "10273003",
+          "codeSystem": "SNOMED-CT",
+          "descriptor": "Acute or Evolving MI",
+          "codeSystemOid": null,
+          "version": null
+        },
+        "qdmCategory": "encounter",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "relevantPeriod": {
+          "low": "2012-11-12T08:00:00.000+00:00",
+          "high": "2012-11-12T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "_type": "QDM::EncounterPerformed"
+      },
+      {
+        "_id": {
+          "$oid": "5c880145d7c8ac4c3e1067b8"
+        },
+        "authorDatetime": "2012-11-12T09:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "RxNorm",
+            "code": "1804799"
+          }
+        ],
+        "description": "Medication, Administered: Fibrinolytic Therapy",
+        "dosage": null,
+        "frequency": null,
+        "hqmfOid": "2.16.840.1.113883.3.560.1.14",
+        "id": {
+          "_id": {
+            "$oid": "5c880145d7c8ac4c3e1067b9"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5b758aa7b8484609983b84aa"
+        },
+        "negationRationale": null,
+        "qdmCategory": "medication",
+        "qdmStatus": "administered",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "relevantPeriod": {
+          "low": "2012-11-12T09:00:00.000+00:00",
+          "high": "2012-11-12T09:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "route": null,
+        "_type": "QDM::MedicationAdministered"
+      },
+      {
+        "_id": {
+          "$oid": "5c880145d7c8ac4c3e1067ba"
+        },
+        "authorDatetime": "2012-11-12T08:00:00.000+00:00",
+        "components": [
+
+        ],
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "164847006"
+          }
+        ],
+        "description": "Diagnostic Study, Performed: Electrocardiogram (ECG)",
+        "facilityLocation": null,
+        "hqmfOid": "2.16.840.1.113883.3.560.1.3",
+        "id": {
+          "_id": {
+            "$oid": "5c880145d7c8ac4c3e1067bb"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5b758aa7b8484609983b84a8"
+        },
+        "method": null,
+        "negationRationale": null,
+        "qdmCategory": "diagnostic_study",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "relevantPeriod": {
+          "low": "2012-11-12T08:00:00.000+00:00",
+          "high": "2012-11-12T08:30:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "result": null,
+        "resultDatetime": null,
+        "status": null,
+        "_type": "QDM::DiagnosticStudyPerformed"
+      },
+      {
+        "_id": {
+          "$oid": "5c880145d7c8ac4c3e1067bc"
+        },
+        "anatomicalLocationSite": null,
+        "authorDatetime": "2012-11-12T09:00:00.000+00:00",
+        "components": [
+
+        ],
+        "dataElementCodes": [
+          {
+            "codeSystem": "ICD-10-PCS",
+            "code": "0270346"
+          },
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "11101003"
+          }
+        ],
+        "description": "Procedure, Performed: PCI",
+        "hqmfOid": "2.16.840.1.113883.3.560.1.6",
+        "id": {
+          "_id": {
+            "$oid": "5c880145d7c8ac4c3e1067bd"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5b758aa7b8484609983b84a9"
+        },
+        "incisionDatetime": null,
+        "method": null,
+        "negationRationale": null,
+        "ordinality": null,
+        "qdmCategory": "procedure",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "relevantPeriod": {
+          "low": "2012-11-12T09:00:00.000+00:00",
+          "high": "2012-11-12T09:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "result": null,
+        "status": null,
+        "_type": "QDM::ProcedurePerformed"
+      },
+      {
+        "_id": {
+          "$oid": "5c880145d7c8ac4c3e1067b0"
+        },
+        "birthDatetime": "1955-11-24T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "code": "21112-8",
+            "codeSystem": "LOINC",
+            "descriptor": null,
+            "codeSystemOid": null,
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.54",
+        "id": {
+          "_id": {
+            "$oid": "5c880145d7c8ac4c3e1067be"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880145d7c8ac4c3e1067b0"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "birthdate",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicBirthdate"
+      },
+      {
+        "_id": {
+          "$oid": "5c880145d7c8ac4c3e1067b1"
+        },
+        "dataElementCodes": [
+          {
+            "code": "2186-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "Not Hispanic or Latino",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.56",
+        "id": {
+          "_id": {
+            "$oid": "5c880145d7c8ac4c3e1067bf"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880145d7c8ac4c3e1067b1"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "ethnicity",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicEthnicity"
+      },
+      {
+        "_id": {
+          "$oid": "5c880145d7c8ac4c3e1067b2"
+        },
+        "dataElementCodes": [
+          {
+            "code": "1002-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "American Indian or Alaska Native",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.59",
+        "id": {
+          "_id": {
+            "$oid": "5c880145d7c8ac4c3e1067c0"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880145d7c8ac4c3e1067b2"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "race",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicRace"
+      },
+      {
+        "_id": {
+          "$oid": "5c880145d7c8ac4c3e1067b3"
+        },
+        "dataElementCodes": [
+          {
+            "code": "M",
+            "codeSystem": "AdministrativeGender",
+            "descriptor": "M",
+            "codeSystemOid": "2.16.840.1.113883.5.1",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.55",
+        "id": {
+          "_id": {
+            "$oid": "5c880145d7c8ac4c3e1067c1"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880145d7c8ac4c3e1067b3"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "gender",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicSex"
+      }
+    ],
+    "extendedData": {
+      "type": null,
+      "measure_ids": [
+        "84B9D0B5-0CAF-4E41-B345-3492A23C2E9F",
+        null
+      ],
+      "source_data_criteria": [
+        {
+          "negation": false,
+          "definition": "encounter",
+          "status": "performed",
+          "title": "EncounterInpatient",
+          "description": "Encounter, Performed: Encounter Inpatient",
+          "code_list_id": "2.16.840.1.113883.3.666.5.307",
+          "type": "encounters",
+          "id": "EncounterInpatient_EncounterPerformed_8ee8cc7d_b1d8_4e88_b02c_6be2f448bbd7_source",
+          "start_date": 1352707200000,
+          "end_date": 1352708100000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+            "PRINCIPAL_DIAGNOSIS": {
+              "type": "CD",
+              "code_list_id": "2.16.840.1.113883.3.666.5.3022",
+              "field_title": "Principal Diagnosis",
+              "title": "Acute or Evolving MI"
+            },
+            "FACILITY_LOCATION": {
+              "type": "COL",
+              "values": [
+                {
+                  "type": "FAC",
+                  "key": "FACILITY_LOCATION",
+                  "code_list_id": "2.16.840.1.113883.3.666.5.307",
+                  "field_title": "Facility Location",
+                  "start_date": "11/12/2012",
+                  "start_time": "8:00 AM",
+                  "end_date": "",
+                  "end_time": "8:00 AM",
+                  "value": 1352707200000,
+                  "locationPeriodLow": "11/12/2012 8:00 AM",
+                  "title": "Encounter Inpatient"
+                }
+              ]
+            }
+          },
+          "hqmf_set_id": "84B9D0B5-0CAF-4E41-B345-3492A23C2E9F",
+          "cms_id": "CMS53v7",
+          "criteria_id": "16543231611VC",
+          "codes": {
+            "SNOMED-CT": [
+              "183452005"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5b758aa7b8484609983b84a7"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "diagnostic_study",
+          "status": "performed",
+          "title": "Electrocardiogram(ECG)",
+          "description": "Diagnostic Study, Performed: Electrocardiogram (ECG)",
+          "code_list_id": "2.16.840.1.113883.3.666.5.735",
+          "type": "diagnostic_studies",
+          "id": "Electrocardiogram_ECG__DiagnosticStudyPerformed_fce36416_5e59_44e2_991d_78fc3f716dd8_source",
+          "start_date": 1352707200000,
+          "end_date": 1352709000000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "84B9D0B5-0CAF-4E41-B345-3492A23C2E9F",
+          "cms_id": "CMS53v7",
+          "criteria_id": "1654324cea7uz",
+          "codes": {
+            "SNOMED-CT": [
+              "164847006"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5b758aa7b8484609983b84a8"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "procedure",
+          "status": "performed",
+          "title": "PCI",
+          "description": "Procedure, Performed: PCI",
+          "code_list_id": "2.16.840.1.113762.1.4.1045.67",
+          "type": "procedures",
+          "id": "PCI_ProcedurePerformed_2f2d2de7_89fd_47a3_8060_527a9c5dcabb_source",
+          "start_date": 1352710800000,
+          "end_date": 1352711700000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "84B9D0B5-0CAF-4E41-B345-3492A23C2E9F",
+          "cms_id": "CMS53v7",
+          "criteria_id": "16543253e0338",
+          "codes": {
+            "ICD-10-PCS": [
+              "0270346"
+            ],
+            "SNOMED-CT": [
+              "11101003"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5b758aa7b8484609983b84a9"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "medication",
+          "status": "administered",
+          "title": "FibrinolyticTherapy",
+          "description": "Medication, Administered: Fibrinolytic Therapy",
+          "code_list_id": "2.16.840.1.113883.3.666.5.736",
+          "type": "medications",
+          "id": "FibrinolyticTherapy_MedicationAdministered_9cc94634_2acc_4c2f_89c4_b7bdad109448_source",
+          "start_date": 1352710800000,
+          "end_date": 1352711700000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "84B9D0B5-0CAF-4E41-B345-3492A23C2E9F",
+          "cms_id": "CMS53v7",
+          "criteria_id": "16543259103M9",
+          "codes": {
+            "RxNorm": [
+              "1804799"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5b758aa7b8484609983b84aa"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "id": "MeasurePeriod",
+          "start_date": 0,
+          "end_date": 0,
+          "references": null
+        }
+      ],
+      "is_shared": null,
+      "origin_data": [
+
+      ],
+      "test_id": null,
+      "medical_record_number": "04a1acfa4c0b99f5ce00e36ccadc7691af7cd2bf7d03944ff31634daed2f2f82",
+      "medical_record_assigner": "Bonnie",
+      "description": null,
+      "description_category": null,
+      "insurance_providers": "[{\"codes\":{\"SOP\":[\"349\"]},\"description\":null,\"end_time\":null,\"financial_responsibility_type\":{\"code\":\"SELF\",\"codeSystem\":\"HL7 Relationship Code\"},\"health_record_field\":null,\"member_id\":\"1234567890\",\"mood_code\":\"EVN\",\"name\":\"Other\",\"negationInd\":null,\"negationReason\":null,\"oid\":null,\"payer\":{\"name\":\"Other\"},\"reason\":null,\"relationship\":null,\"specifics\":null,\"start_time\":1199145600,\"status_code\":null,\"time\":null,\"type\":\"OT\"}]"
+    },
+    "qdmVersion": "5.4"
+  }
+}

--- a/test/fixtures/patients/CMS722v0/Patient With Code_Test.json
+++ b/test/fixtures/patients/CMS722v0/Patient With Code_Test.json
@@ -1,0 +1,402 @@
+{
+  "_id": {
+    "$oid": "5abe36f0b848462862fdcae8"
+  },
+  "bundleId": "5a57e977942c6d1e61d32f14",
+  "expectedValues": [
+    {
+      "measure_id": "189C1035-C86E-419B-A034-AE55FA4C04F9",
+      "population_index": 0,
+      "IPP": 1,
+      "DENOM": 1,
+      "DENEX": 0,
+      "NUMER": 0
+    }
+  ],
+  "familyName": "Test",
+  "givenNames": [
+    "Patient With Code"
+  ],
+  "notes": "",
+  "qdmPatient": {
+    "_id": {
+      "$oid": "5c880140d7c8ac4c3e1066d7"
+    },
+    "birthDatetime": "1970-01-01T08:00:00.000+00:00",
+    "dataElements": [
+      {
+        "_id": {
+          "$oid": "5c880140d7c8ac4c3e1066d8"
+        },
+        "anatomicalLocationSite": null,
+        "authorDatetime": "2012-03-22T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "17561000119102"
+          },
+          {
+            "codeSystem": "ICD-10-CM",
+            "code": "Z38.00"
+          }
+        ],
+        "description": "Diagnosis: Live Birth Newborn Born in Hospital",
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.110",
+        "id": {
+          "_id": {
+            "$oid": "5c880140d7c8ac4c3e1066d9"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5aeb77f7b848463d625b71e4"
+        },
+        "prevalencePeriod": {
+          "low": "2012-03-22T08:00:00.000+00:00",
+          "high": "2012-03-22T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "qdmCategory": "condition",
+        "qdmVersion": "5.4",
+        "qrdaOid": "2.16.840.1.113883.10.20.24.3.135",
+        "severity": null,
+        "_type": "QDM::Diagnosis"
+      },
+      {
+        "_id": {
+          "$oid": "5c880140d7c8ac4c3e1066da"
+        },
+        "admissionSource": null,
+        "authorDatetime": "2012-03-22T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "183452005"
+          }
+        ],
+        "description": "Encounter, Performed: Encounter Inpatient",
+        "diagnoses": [
+
+        ],
+        "dischargeDisposition": null,
+        "facilityLocations": [
+
+        ],
+        "hqmfOid": "2.16.840.1.113883.3.560.1.79",
+        "id": {
+          "_id": {
+            "$oid": "5c880140d7c8ac4c3e1066db"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5aeb77f7b848463d625b71e5"
+        },
+        "lengthOfStay": {
+          "value": 0,
+          "unit": "days"
+        },
+        "negationRationale": null,
+        "principalDiagnosis": null,
+        "qdmCategory": "encounter",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "relevantPeriod": {
+          "low": "2012-03-22T08:00:00.000+00:00",
+          "high": "2012-03-22T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "_type": "QDM::EncounterPerformed"
+      },
+      {
+        "_id": {
+          "$oid": "5c880140d7c8ac4c3e1066dc"
+        },
+        "authorDatetime": "2012-03-22T08:00:00.000+00:00",
+        "components": [
+
+        ],
+        "dataElementCodes": [
+          {
+            "codeSystem": "LOINC",
+            "code": "54109-4"
+          }
+        ],
+        "description": "Diagnostic Study, Performed: Newborn Hearing Screen Right",
+        "facilityLocation": null,
+        "hqmfOid": "2.16.840.1.113883.3.560.1.3",
+        "id": {
+          "_id": {
+            "$oid": "5c880140d7c8ac4c3e1066dd"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5aeb77f7b848463d625b71e6"
+        },
+        "method": null,
+        "negationRationale": null,
+        "qdmCategory": "diagnostic_study",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "relevantPeriod": {
+          "low": "2012-03-22T08:00:00.000+00:00",
+          "high": "2012-03-22T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "result": {
+          "code": "164059009",
+          "codeSystem": "SNOMED-CT",
+          "version": null,
+          "descriptor": "Pass Or Refer"
+        },
+        "resultDatetime": null,
+        "status": null,
+        "_type": "QDM::DiagnosticStudyPerformed"
+      },
+      {
+        "_id": {
+          "$oid": "5c880140d7c8ac4c3e1066d2"
+        },
+        "birthDatetime": "1970-01-01T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "code": "21112-8",
+            "codeSystem": "LOINC",
+            "descriptor": null,
+            "codeSystemOid": null,
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.54",
+        "id": {
+          "_id": {
+            "$oid": "5c880140d7c8ac4c3e1066de"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880140d7c8ac4c3e1066d2"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "birthdate",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicBirthdate"
+      },
+      {
+        "_id": {
+          "$oid": "5c880140d7c8ac4c3e1066d3"
+        },
+        "dataElementCodes": [
+          {
+            "code": "2186-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "Not Hispanic or Latino",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.56",
+        "id": {
+          "_id": {
+            "$oid": "5c880140d7c8ac4c3e1066df"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880140d7c8ac4c3e1066d3"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "ethnicity",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicEthnicity"
+      },
+      {
+        "_id": {
+          "$oid": "5c880140d7c8ac4c3e1066d4"
+        },
+        "dataElementCodes": [
+          {
+            "code": "1002-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "American Indian or Alaska Native",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.59",
+        "id": {
+          "_id": {
+            "$oid": "5c880140d7c8ac4c3e1066e0"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880140d7c8ac4c3e1066d4"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "race",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicRace"
+      },
+      {
+        "_id": {
+          "$oid": "5c880140d7c8ac4c3e1066d5"
+        },
+        "dataElementCodes": [
+          {
+            "code": "M",
+            "codeSystem": "AdministrativeGender",
+            "descriptor": "M",
+            "codeSystemOid": "2.16.840.1.113883.5.1",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.55",
+        "id": {
+          "_id": {
+            "$oid": "5c880140d7c8ac4c3e1066e1"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880140d7c8ac4c3e1066d5"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "gender",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicSex"
+      }
+    ],
+    "extendedData": {
+      "type": null,
+      "measure_ids": [
+        "189C1035-C86E-419B-A034-AE55FA4C04F9",
+        null
+      ],
+      "source_data_criteria": [
+        {
+          "negation": false,
+          "definition": "diagnostic_study",
+          "status": "performed",
+          "title": "Newborn Hearing Screen Right",
+          "description": "Diagnostic Study, Performed: Newborn Hearing Screen Right",
+          "code_list_id": "2.16.840.1.114222.4.1.214079.1.1.4",
+          "type": "diagnostic_studies",
+          "id": "NewbornHearingScreenRight_DiagnosticStudyPerformed_4d13fe89_db63_4397_9080_4168c8c8d26c_source",
+          "start_date": 1332403200000,
+          "end_date": 1332404100000,
+          "value": [
+            {
+              "type": "CD",
+              "type_cmp": "CD",
+              "code_list_id": "2.16.840.1.114222.4.1.214079.1.1.6",
+              "title": "Pass Or Refer"
+            }
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "189C1035-C86E-419B-A034-AE55FA4C04F9",
+          "cms_id": "CMS722v0",
+          "criteria_id": "1624e31e6618u",
+          "codes": {
+            "LOINC": [
+              "54109-4"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5aeb77f7b848463d625b71e6"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "encounter",
+          "status": "performed",
+          "title": "Encounter Inpatient",
+          "description": "Encounter, Performed: Encounter Inpatient",
+          "code_list_id": "2.16.840.1.113883.3.666.5.307",
+          "type": "encounters",
+          "id": "EncounterInpatient_EncounterPerformed_7b37876d_70f3_4879_a168_6dd822107f1c_source",
+          "start_date": 1332403200000,
+          "end_date": 1332404100000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "189C1035-C86E-419B-A034-AE55FA4C04F9",
+          "cms_id": "CMS722v0",
+          "criteria_id": "1624e3236f27z",
+          "codes": {
+            "SNOMED-CT": [
+              "183452005"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5aeb77f7b848463d625b71e5"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "diagnosis",
+          "title": "Live Birth Newborn Born in Hospital",
+          "description": "Diagnosis: Live Birth Newborn Born in Hospital",
+          "code_list_id": "2.16.840.1.113762.1.4.1046.6",
+          "type": "conditions",
+          "id": "LiveBirthNewbornBorninHospital_Diagnosis_d7f4c89d_3a0d_4426_80d8_ca1a5b92df24_source",
+          "start_date": 1332403200000,
+          "end_date": 1332404100000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "189C1035-C86E-419B-A034-AE55FA4C04F9",
+          "cms_id": "CMS722v0",
+          "criteria_id": "1624e32724a3o",
+          "codes": {
+            "SNOMED-CT": [
+              "17561000119102"
+            ],
+            "ICD-10-CM": [
+              "Z38.00"
+            ]
+          },
+          "coded_entry_id": {
+            "$oid": "5aeb77f7b848463d625b71e4"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "id": "MeasurePeriod",
+          "start_date": 0,
+          "end_date": 0,
+          "references": null
+        }
+      ],
+      "is_shared": null,
+      "origin_data": [
+
+      ],
+      "test_id": null,
+      "medical_record_number": "2fa973962474da8dfe89cbb7144fb11f2333f421eec112156776303cbedc2e64",
+      "medical_record_assigner": "Bonnie",
+      "description": null,
+      "description_category": null,
+      "insurance_providers": "[]"
+    },
+    "qdmVersion": "5.4"
+  }
+}

--- a/test/fixtures/patients/CMS722v0/Patient_Test.json
+++ b/test/fixtures/patients/CMS722v0/Patient_Test.json
@@ -1,0 +1,392 @@
+{
+  "_id": {
+    "$oid": "5ab3c32db8484626ce364ebe"
+  },
+  "bundleId": "5a57e977942c6d1e61d32f14",
+  "expectedValues": [
+    {
+      "measure_id": "189C1035-C86E-419B-A034-AE55FA4C04F9",
+      "population_index": 0,
+      "IPP": 1,
+      "DENOM": 1,
+      "DENEX": 0,
+      "NUMER": 0
+    }
+  ],
+  "familyName": "Test",
+  "givenNames": [
+    "Patient"
+  ],
+  "notes": "",
+  "qdmPatient": {
+    "_id": {
+      "$oid": "5c88013fd7c8ac4c3e1066c7"
+    },
+    "birthDatetime": "1970-01-01T08:00:00.000+00:00",
+    "dataElements": [
+      {
+        "_id": {
+          "$oid": "5c88013fd7c8ac4c3e1066c8"
+        },
+        "anatomicalLocationSite": null,
+        "authorDatetime": "2012-03-22T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "17561000119102"
+          },
+          {
+            "codeSystem": "ICD-10-CM",
+            "code": "Z38.00"
+          }
+        ],
+        "description": "Diagnosis: Live Birth Newborn Born in Hospital",
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.110",
+        "id": {
+          "_id": {
+            "$oid": "5c88013fd7c8ac4c3e1066c9"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5aeb77f2b848463d625b6dbe"
+        },
+        "prevalencePeriod": {
+          "low": "2012-03-22T08:00:00.000+00:00",
+          "high": "2012-03-22T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "qdmCategory": "condition",
+        "qdmVersion": "5.4",
+        "qrdaOid": "2.16.840.1.113883.10.20.24.3.135",
+        "severity": null,
+        "_type": "QDM::Diagnosis"
+      },
+      {
+        "_id": {
+          "$oid": "5c88013fd7c8ac4c3e1066ca"
+        },
+        "admissionSource": null,
+        "authorDatetime": "2012-03-22T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "183452005"
+          }
+        ],
+        "description": "Encounter, Performed: Encounter Inpatient",
+        "diagnoses": [
+
+        ],
+        "dischargeDisposition": null,
+        "facilityLocations": [
+
+        ],
+        "hqmfOid": "2.16.840.1.113883.3.560.1.79",
+        "id": {
+          "_id": {
+            "$oid": "5c88013fd7c8ac4c3e1066cb"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5aeb77f2b848463d625b6dbf"
+        },
+        "lengthOfStay": {
+          "value": 0,
+          "unit": "days"
+        },
+        "negationRationale": null,
+        "principalDiagnosis": null,
+        "qdmCategory": "encounter",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "relevantPeriod": {
+          "low": "2012-03-22T08:00:00.000+00:00",
+          "high": "2012-03-22T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "_type": "QDM::EncounterPerformed"
+      },
+      {
+        "_id": {
+          "$oid": "5c88013fd7c8ac4c3e1066cc"
+        },
+        "authorDatetime": "2012-03-22T08:00:00.000+00:00",
+        "components": [
+
+        ],
+        "dataElementCodes": [
+          {
+            "codeSystem": "LOINC",
+            "code": "54109-4"
+          }
+        ],
+        "description": "Diagnostic Study, Performed: Newborn Hearing Screen Right",
+        "facilityLocation": null,
+        "hqmfOid": "2.16.840.1.113883.3.560.1.3",
+        "id": {
+          "_id": {
+            "$oid": "5c88013fd7c8ac4c3e1066cd"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5aeb77f2b848463d625b6dc0"
+        },
+        "method": null,
+        "negationRationale": null,
+        "qdmCategory": "diagnostic_study",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "relevantPeriod": {
+          "low": "2012-03-22T08:00:00.000+00:00",
+          "high": "2012-03-22T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "result": null,
+        "resultDatetime": null,
+        "status": null,
+        "_type": "QDM::DiagnosticStudyPerformed"
+      },
+      {
+        "_id": {
+          "$oid": "5c88013fd7c8ac4c3e1066c2"
+        },
+        "birthDatetime": "1970-01-01T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "code": "21112-8",
+            "codeSystem": "LOINC",
+            "descriptor": null,
+            "codeSystemOid": null,
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.54",
+        "id": {
+          "_id": {
+            "$oid": "5c88013fd7c8ac4c3e1066ce"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013fd7c8ac4c3e1066c2"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "birthdate",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicBirthdate"
+      },
+      {
+        "_id": {
+          "$oid": "5c88013fd7c8ac4c3e1066c3"
+        },
+        "dataElementCodes": [
+          {
+            "code": "2186-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "Not Hispanic or Latino",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.56",
+        "id": {
+          "_id": {
+            "$oid": "5c88013fd7c8ac4c3e1066cf"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013fd7c8ac4c3e1066c3"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "ethnicity",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicEthnicity"
+      },
+      {
+        "_id": {
+          "$oid": "5c88013fd7c8ac4c3e1066c4"
+        },
+        "dataElementCodes": [
+          {
+            "code": "1002-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "American Indian or Alaska Native",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.59",
+        "id": {
+          "_id": {
+            "$oid": "5c88013fd7c8ac4c3e1066d0"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013fd7c8ac4c3e1066c4"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "race",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicRace"
+      },
+      {
+        "_id": {
+          "$oid": "5c88013fd7c8ac4c3e1066c5"
+        },
+        "dataElementCodes": [
+          {
+            "code": "M",
+            "codeSystem": "AdministrativeGender",
+            "descriptor": "M",
+            "codeSystemOid": "2.16.840.1.113883.5.1",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.55",
+        "id": {
+          "_id": {
+            "$oid": "5c88013fd7c8ac4c3e1066d1"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013fd7c8ac4c3e1066c5"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "gender",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicSex"
+      }
+    ],
+    "extendedData": {
+      "type": null,
+      "measure_ids": [
+        "189C1035-C86E-419B-A034-AE55FA4C04F9",
+        null
+      ],
+      "source_data_criteria": [
+        {
+          "negation": false,
+          "definition": "diagnostic_study",
+          "status": "performed",
+          "title": "Newborn Hearing Screen Right",
+          "description": "Diagnostic Study, Performed: Newborn Hearing Screen Right",
+          "code_list_id": "2.16.840.1.114222.4.1.214079.1.1.4",
+          "type": "diagnostic_studies",
+          "id": "NewbornHearingScreenRight_DiagnosticStudyPerformed_4d13fe89_db63_4397_9080_4168c8c8d26c_source",
+          "start_date": 1332403200000,
+          "end_date": 1332404100000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "189C1035-C86E-419B-A034-AE55FA4C04F9",
+          "cms_id": "CMS722v0",
+          "criteria_id": "1624e31e6618u",
+          "codes": {
+            "LOINC": [
+              "54109-4"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5aeb77f2b848463d625b6dc0"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "encounter",
+          "status": "performed",
+          "title": "Encounter Inpatient",
+          "description": "Encounter, Performed: Encounter Inpatient",
+          "code_list_id": "2.16.840.1.113883.3.666.5.307",
+          "type": "encounters",
+          "id": "EncounterInpatient_EncounterPerformed_7b37876d_70f3_4879_a168_6dd822107f1c_source",
+          "start_date": 1332403200000,
+          "end_date": 1332404100000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "189C1035-C86E-419B-A034-AE55FA4C04F9",
+          "cms_id": "CMS722v0",
+          "criteria_id": "1624e3236f27z",
+          "codes": {
+            "SNOMED-CT": [
+              "183452005"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5aeb77f2b848463d625b6dbf"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "diagnosis",
+          "title": "Live Birth Newborn Born in Hospital",
+          "description": "Diagnosis: Live Birth Newborn Born in Hospital",
+          "code_list_id": "2.16.840.1.113762.1.4.1046.6",
+          "type": "conditions",
+          "id": "LiveBirthNewbornBorninHospital_Diagnosis_d7f4c89d_3a0d_4426_80d8_ca1a5b92df24_source",
+          "start_date": 1332403200000,
+          "end_date": 1332404100000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "189C1035-C86E-419B-A034-AE55FA4C04F9",
+          "cms_id": "CMS722v0",
+          "criteria_id": "1624e32724a3o",
+          "codes": {
+            "SNOMED-CT": [
+              "17561000119102"
+            ],
+            "ICD-10-CM": [
+              "Z38.00"
+            ]
+          },
+          "coded_entry_id": {
+            "$oid": "5aeb77f2b848463d625b6dbe"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "id": "MeasurePeriod",
+          "start_date": 0,
+          "end_date": 0,
+          "references": null
+        }
+      ],
+      "is_shared": null,
+      "origin_data": [
+
+      ],
+      "test_id": null,
+      "medical_record_number": "5ebc5fc9b1b269147bfb156f278ec48504ee98f9949659eadf256f9c955c9bdf",
+      "medical_record_assigner": "Bonnie",
+      "description": null,
+      "description_category": null,
+      "insurance_providers": "[]"
+    },
+    "qdmVersion": "5.4"
+  }
+}

--- a/test/fixtures/patients/CMS759v1/Numer_PASS.json
+++ b/test/fixtures/patients/CMS759v1/Numer_PASS.json
@@ -1,0 +1,308 @@
+{
+  "_id": {
+    "$oid": "5aa98404b8484606bc493901"
+  },
+  "bundleId": "5a57e977942c6d1e61d32f14",
+  "expectedValues": [
+    {
+      "measure_id": "36C5FDB4-EC16-4B75-96B4-CCBC9C7B0473",
+      "population_index": 0,
+      "IPP": 1,
+      "DENOM": 1,
+      "NUMER": 1
+    }
+  ],
+  "familyName": "PASS",
+  "givenNames": [
+    "Numer"
+  ],
+  "notes": "",
+  "qdmPatient": {
+    "_id": {
+      "$oid": "5c88013fd7c8ac4c3e1066b9"
+    },
+    "birthDatetime": "1990-01-01T08:00:00.000+00:00",
+    "dataElements": [
+      {
+        "_id": {
+          "$oid": "5c88013fd7c8ac4c3e1066ba"
+        },
+        "dataElementCodes": [
+          {
+            "codeSystem": "Source of Payment Typology",
+            "code": "121"
+          }
+        ],
+        "description": "Patient Characteristic Payer: Medicare Fee For Service",
+        "hqmfOid": "2.16.840.1.113883.3.560.1.405",
+        "id": {
+          "_id": {
+            "$oid": "5c88013fd7c8ac4c3e1066bb"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5aeb7736b848463d625b2155"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "payer",
+        "qdmVersion": "5.4",
+        "relevantPeriod": {
+          "low": "2012-03-14T08:00:00.000+00:00",
+          "high": "2012-03-14T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "_type": "QDM::PatientCharacteristicPayer"
+      },
+      {
+        "_id": {
+          "$oid": "5c88013fd7c8ac4c3e1066bc"
+        },
+        "admissionSource": null,
+        "authorDatetime": "2012-03-14T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "10378005"
+          }
+        ],
+        "description": "Encounter, Performed: Inpatient Encounter",
+        "diagnoses": [
+
+        ],
+        "dischargeDisposition": null,
+        "facilityLocations": [
+
+        ],
+        "hqmfOid": "2.16.840.1.113883.3.560.1.79",
+        "id": {
+          "_id": {
+            "$oid": "5c88013fd7c8ac4c3e1066bd"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5aeb7736b848463d625b2156"
+        },
+        "lengthOfStay": {
+          "value": 0,
+          "unit": "days"
+        },
+        "negationRationale": null,
+        "principalDiagnosis": null,
+        "qdmCategory": "encounter",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "relevantPeriod": {
+          "low": "2012-03-14T08:00:00.000+00:00",
+          "high": "2012-03-14T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "_type": "QDM::EncounterPerformed"
+      },
+      {
+        "_id": {
+          "$oid": "5c88013fd7c8ac4c3e1066b4"
+        },
+        "birthDatetime": "1990-01-01T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "code": "21112-8",
+            "codeSystem": "LOINC",
+            "descriptor": null,
+            "codeSystemOid": null,
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.54",
+        "id": {
+          "_id": {
+            "$oid": "5c88013fd7c8ac4c3e1066be"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013fd7c8ac4c3e1066b4"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "birthdate",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicBirthdate"
+      },
+      {
+        "_id": {
+          "$oid": "5c88013fd7c8ac4c3e1066b5"
+        },
+        "dataElementCodes": [
+          {
+            "code": "2186-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "Not Hispanic or Latino",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.56",
+        "id": {
+          "_id": {
+            "$oid": "5c88013fd7c8ac4c3e1066bf"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013fd7c8ac4c3e1066b5"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "ethnicity",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicEthnicity"
+      },
+      {
+        "_id": {
+          "$oid": "5c88013fd7c8ac4c3e1066b6"
+        },
+        "dataElementCodes": [
+          {
+            "code": "1002-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "American Indian or Alaska Native",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.59",
+        "id": {
+          "_id": {
+            "$oid": "5c88013fd7c8ac4c3e1066c0"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013fd7c8ac4c3e1066b6"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "race",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicRace"
+      },
+      {
+        "_id": {
+          "$oid": "5c88013fd7c8ac4c3e1066b7"
+        },
+        "dataElementCodes": [
+          {
+            "code": "M",
+            "codeSystem": "AdministrativeGender",
+            "descriptor": "M",
+            "codeSystemOid": "2.16.840.1.113883.5.1",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.55",
+        "id": {
+          "_id": {
+            "$oid": "5c88013fd7c8ac4c3e1066c1"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c88013fd7c8ac4c3e1066b7"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "gender",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicSex"
+      }
+    ],
+    "extendedData": {
+      "type": null,
+      "measure_ids": [
+        "36C5FDB4-EC16-4B75-96B4-CCBC9C7B0473",
+        null
+      ],
+      "source_data_criteria": [
+        {
+          "negation": false,
+          "definition": "patient_characteristic_payer",
+          "title": "MedicareFeeForService",
+          "description": "Patient Characteristic Payer: Medicare Fee For Service",
+          "code_list_id": "2.16.840.1.113883.3.1240.15.2.4008",
+          "type": "characteristic",
+          "id": "MedicareFeeForService_PatientCharacteristicPayer_fd63ab29_79e4_44c1_80df_e02bd05a5667_source",
+          "start_date": 1331712000000,
+          "end_date": 1331712900000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "36C5FDB4-EC16-4B75-96B4-CCBC9C7B0473",
+          "cms_id": "CMSv0",
+          "criteria_id": "162262ac4f6Rz",
+          "codes": {
+            "Source of Payment Typology": [
+              "121"
+            ]
+          },
+          "coded_entry_id": {
+            "$oid": "5aeb7736b848463d625b2155"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "encounter",
+          "status": "performed",
+          "title": "InpatientEncounter",
+          "description": "Encounter, Performed: Inpatient Encounter",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.101.12.1060",
+          "type": "encounters",
+          "id": "InpatientEncounter_EncounterPerformed_a6c66e3c_da7d_4104_836a_c6c427fecb16_source",
+          "start_date": 1331712000000,
+          "end_date": 1331712900000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "36C5FDB4-EC16-4B75-96B4-CCBC9C7B0473",
+          "cms_id": "CMSv0",
+          "criteria_id": "162262ad454gq",
+          "codes": {
+            "SNOMED-CT": [
+              "10378005"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5aeb7736b848463d625b2156"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "id": "MeasurePeriod",
+          "start_date": 0,
+          "end_date": 0,
+          "references": null
+        }
+      ],
+      "is_shared": null,
+      "origin_data": [
+
+      ],
+      "test_id": null,
+      "medical_record_number": "c5ae9f803996dfda65278dfe2a79d91ee397bf3e2e09dccf9c2b3a82b2f0a36f",
+      "medical_record_assigner": "Bonnie",
+      "description": null,
+      "description_category": null,
+      "insurance_providers": "[]"
+    },
+    "qdmVersion": "5.4"
+  }
+}

--- a/test/fixtures/patients/CMS760v0/Correct_Timezone.json
+++ b/test/fixtures/patients/CMS760v0/Correct_Timezone.json
@@ -1,0 +1,171 @@
+{
+  "_id": {
+    "$oid": "5abe84fcb8484660706240db"
+  },
+  "bundleId": "5a57e977942c6d1e61d32f14",
+  "expectedValues": [
+    {
+      "measure_id": "065C9002-603F-46A3-BA0F-E2A9F1732DC3",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "NUMER": 0
+    }
+  ],
+  "familyName": "Timezone",
+  "givenNames": [
+    "Correct"
+  ],
+  "notes": "",
+  "qdmPatient": {
+    "_id": {
+      "$oid": "5c880140d7c8ac4c3e1066e7"
+    },
+    "birthDatetime": "2012-12-31T04:00:00.000+00:00",
+    "dataElements": [
+      {
+        "_id": {
+          "$oid": "5c880140d7c8ac4c3e1066e2"
+        },
+        "birthDatetime": "2012-12-31T04:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "code": "21112-8",
+            "codeSystem": "LOINC",
+            "descriptor": null,
+            "codeSystemOid": null,
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.54",
+        "id": {
+          "_id": {
+            "$oid": "5c880140d7c8ac4c3e1066e8"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880140d7c8ac4c3e1066e2"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "birthdate",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicBirthdate"
+      },
+      {
+        "_id": {
+          "$oid": "5c880140d7c8ac4c3e1066e3"
+        },
+        "dataElementCodes": [
+          {
+            "code": "2186-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "Not Hispanic or Latino",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.56",
+        "id": {
+          "_id": {
+            "$oid": "5c880140d7c8ac4c3e1066e9"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880140d7c8ac4c3e1066e3"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "ethnicity",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicEthnicity"
+      },
+      {
+        "_id": {
+          "$oid": "5c880140d7c8ac4c3e1066e4"
+        },
+        "dataElementCodes": [
+          {
+            "code": "1002-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "American Indian or Alaska Native",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.59",
+        "id": {
+          "_id": {
+            "$oid": "5c880140d7c8ac4c3e1066ea"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880140d7c8ac4c3e1066e4"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "race",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicRace"
+      },
+      {
+        "_id": {
+          "$oid": "5c880140d7c8ac4c3e1066e5"
+        },
+        "dataElementCodes": [
+          {
+            "code": "M",
+            "codeSystem": "AdministrativeGender",
+            "descriptor": "M",
+            "codeSystemOid": "2.16.840.1.113883.5.1",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.55",
+        "id": {
+          "_id": {
+            "$oid": "5c880140d7c8ac4c3e1066eb"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880140d7c8ac4c3e1066e5"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "gender",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicSex"
+      }
+    ],
+    "extendedData": {
+      "type": null,
+      "measure_ids": [
+        "065C9002-603F-46A3-BA0F-E2A9F1732DC3",
+        null
+      ],
+      "source_data_criteria": [
+        {
+          "id": "MeasurePeriod",
+          "start_date": 0,
+          "end_date": 0,
+          "references": null
+        }
+      ],
+      "is_shared": null,
+      "origin_data": [
+
+      ],
+      "test_id": null,
+      "medical_record_number": "04171102a010e3607b1e639d7648062de6fddbf3d7f7291288b13c587b191c6c",
+      "medical_record_assigner": "Bonnie",
+      "description": null,
+      "description_category": null,
+      "insurance_providers": "[]"
+    },
+    "qdmVersion": "5.4"
+  }
+}

--- a/test/fixtures/patients/CMS761v0/No_Participation.json
+++ b/test/fixtures/patients/CMS761v0/No_Participation.json
@@ -1,0 +1,248 @@
+{
+  "_id": {
+    "$oid": "5ad08c06b8484651bb40d494"
+  },
+  "bundleId": "5a57e977942c6d1e61d32f14",
+  "expectedValues": [
+    {
+      "measure_id": "8C942F13-6EAA-4A8E-BB4F-3B3BF7311C1F",
+      "population_index": 0,
+      "IPP": 1,
+      "DENOM": 1,
+      "NUMER": 0
+    }
+  ],
+  "familyName": "Participation",
+  "givenNames": [
+    "No"
+  ],
+  "notes": "",
+  "qdmPatient": {
+    "_id": {
+      "$oid": "5c880141d7c8ac4c3e106705"
+    },
+    "birthDatetime": "1970-01-01T08:00:00.000+00:00",
+    "dataElements": [
+      {
+        "_id": {
+          "$oid": "5c880141d7c8ac4c3e106706"
+        },
+        "admissionSource": null,
+        "authorDatetime": "2012-04-13T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "10378005"
+          }
+        ],
+        "description": "Encounter, Performed: Inpatient Encounter",
+        "diagnoses": [
+
+        ],
+        "dischargeDisposition": null,
+        "facilityLocations": [
+
+        ],
+        "hqmfOid": "2.16.840.1.113883.3.560.1.79",
+        "id": {
+          "_id": {
+            "$oid": "5c880141d7c8ac4c3e106707"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5aec6eb6b848463f1229da32"
+        },
+        "lengthOfStay": {
+          "value": 0,
+          "unit": "days"
+        },
+        "negationRationale": null,
+        "principalDiagnosis": null,
+        "qdmCategory": "encounter",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "relevantPeriod": {
+          "low": "2012-04-13T08:00:00.000+00:00",
+          "high": "2012-04-13T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "_type": "QDM::EncounterPerformed"
+      },
+      {
+        "_id": {
+          "$oid": "5c880141d7c8ac4c3e106700"
+        },
+        "birthDatetime": "1970-01-01T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "code": "21112-8",
+            "codeSystem": "LOINC",
+            "descriptor": null,
+            "codeSystemOid": null,
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.54",
+        "id": {
+          "_id": {
+            "$oid": "5c880141d7c8ac4c3e106708"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880141d7c8ac4c3e106700"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "birthdate",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicBirthdate"
+      },
+      {
+        "_id": {
+          "$oid": "5c880141d7c8ac4c3e106701"
+        },
+        "dataElementCodes": [
+          {
+            "code": "2186-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "Not Hispanic or Latino",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.56",
+        "id": {
+          "_id": {
+            "$oid": "5c880141d7c8ac4c3e106709"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880141d7c8ac4c3e106701"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "ethnicity",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicEthnicity"
+      },
+      {
+        "_id": {
+          "$oid": "5c880141d7c8ac4c3e106702"
+        },
+        "dataElementCodes": [
+          {
+            "code": "1002-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "American Indian or Alaska Native",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.59",
+        "id": {
+          "_id": {
+            "$oid": "5c880141d7c8ac4c3e10670a"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880141d7c8ac4c3e106702"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "race",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicRace"
+      },
+      {
+        "_id": {
+          "$oid": "5c880141d7c8ac4c3e106703"
+        },
+        "dataElementCodes": [
+          {
+            "code": "F",
+            "codeSystem": "AdministrativeGender",
+            "descriptor": "F",
+            "codeSystemOid": "2.16.840.1.113883.5.1",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.55",
+        "id": {
+          "_id": {
+            "$oid": "5c880141d7c8ac4c3e10670b"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880141d7c8ac4c3e106703"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "gender",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicSex"
+      }
+    ],
+    "extendedData": {
+      "type": null,
+      "measure_ids": [
+        "8C942F13-6EAA-4A8E-BB4F-3B3BF7311C1F",
+        null
+      ],
+      "source_data_criteria": [
+        {
+          "negation": false,
+          "definition": "encounter",
+          "status": "performed",
+          "title": "InpatientEncounter",
+          "description": "Encounter, Performed: Inpatient Encounter",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.101.12.1060",
+          "type": "encounters",
+          "id": "InpatientEncounter_EncounterPerformed_a6c66e3c_da7d_4104_836a_c6c427fecb16_source",
+          "start_date": 1334304000000,
+          "end_date": 1334304900000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "8C942F13-6EAA-4A8E-BB4F-3B3BF7311C1F",
+          "cms_id": "CMS761v0",
+          "criteria_id": "162bea28d6fHa",
+          "codes": {
+            "SNOMED-CT": [
+              "10378005"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5aec6eb6b848463f1229da32"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "id": "MeasurePeriod",
+          "start_date": 0,
+          "end_date": 0,
+          "references": null
+        }
+      ],
+      "is_shared": null,
+      "origin_data": [
+
+      ],
+      "test_id": null,
+      "medical_record_number": "c693ab2e8cecaee09a5bd9076bd465210afbb38187fe2abcdb40fcc2d0263d56",
+      "medical_record_assigner": "Bonnie",
+      "description": null,
+      "description_category": null,
+      "insurance_providers": "[{\"codes\":{\"SOP\":[\"349\"]},\"description\":null,\"end_time\":null,\"financial_responsibility_type\":{\"code\":\"SELF\",\"codeSystem\":\"HL7 Relationship Code\"},\"health_record_field\":null,\"member_id\":\"1234567890\",\"mood_code\":\"EVN\",\"name\":\"Other\",\"negationInd\":null,\"negationReason\":null,\"oid\":null,\"payer\":{\"name\":\"Other\"},\"reason\":null,\"relationship\":null,\"specifics\":null,\"start_time\":1199145600,\"status_code\":null,\"time\":null,\"type\":\"OT\"}]"
+    },
+    "qdmVersion": "5.4"
+  }
+}

--- a/test/fixtures/patients/CMS761v0/With_Participation.json
+++ b/test/fixtures/patients/CMS761v0/With_Participation.json
@@ -1,0 +1,307 @@
+{
+  "_id": {
+    "$oid": "5aec6e07b848463f1229da20"
+  },
+  "bundleId": "5a57e977942c6d1e61d32f14",
+  "expectedValues": [
+    {
+      "measure_id": "8C942F13-6EAA-4A8E-BB4F-3B3BF7311C1F",
+      "population_index": 0,
+      "IPP": 1,
+      "DENOM": 1,
+      "NUMER": 1
+    }
+  ],
+  "familyName": "Participation",
+  "givenNames": [
+    "With"
+  ],
+  "notes": "",
+  "qdmPatient": {
+    "_id": {
+      "$oid": "5c880141d7c8ac4c3e106711"
+    },
+    "birthDatetime": "1970-01-01T08:00:00.000+00:00",
+    "dataElements": [
+      {
+        "_id": {
+          "$oid": "5c880141d7c8ac4c3e106712"
+        },
+        "admissionSource": null,
+        "authorDatetime": "2012-04-13T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "SNOMED-CT",
+            "code": "10378005"
+          }
+        ],
+        "description": "Encounter, Performed: Inpatient Encounter",
+        "diagnoses": [
+
+        ],
+        "dischargeDisposition": null,
+        "facilityLocations": [
+
+        ],
+        "hqmfOid": "2.16.840.1.113883.3.560.1.79",
+        "id": {
+          "_id": {
+            "$oid": "5c880141d7c8ac4c3e106713"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5aec6eafb848463f1229da2a"
+        },
+        "lengthOfStay": {
+          "value": 0,
+          "unit": "days"
+        },
+        "negationRationale": null,
+        "principalDiagnosis": null,
+        "qdmCategory": "encounter",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "relevantPeriod": {
+          "low": "2012-04-13T08:00:00.000+00:00",
+          "high": "2012-04-13T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "_type": "QDM::EncounterPerformed"
+      },
+      {
+        "_id": {
+          "$oid": "5c880141d7c8ac4c3e106714"
+        },
+        "dataElementCodes": [
+          {
+            "codeSystem": "Source of Payment Typology",
+            "code": "3"
+          }
+        ],
+        "description": "Participation: Insurance Coverage Type",
+        "hqmfOid": null,
+        "id": {
+          "_id": {
+            "$oid": "5c880141d7c8ac4c3e106715"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5aec6eafb848463f1229da2b"
+        },
+        "participationPeriod": {
+          "low": "2012-05-04T08:00:00.000+00:00",
+          "high": "2012-05-04T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "qdmCategory": "participation",
+        "qdmVersion": "5.4",
+        "_type": "QDM::Participation"
+      },
+      {
+        "_id": {
+          "$oid": "5c880141d7c8ac4c3e10670c"
+        },
+        "birthDatetime": "1970-01-01T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "code": "21112-8",
+            "codeSystem": "LOINC",
+            "descriptor": null,
+            "codeSystemOid": null,
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.54",
+        "id": {
+          "_id": {
+            "$oid": "5c880141d7c8ac4c3e106716"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880141d7c8ac4c3e10670c"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "birthdate",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicBirthdate"
+      },
+      {
+        "_id": {
+          "$oid": "5c880141d7c8ac4c3e10670d"
+        },
+        "dataElementCodes": [
+          {
+            "code": "2186-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "Not Hispanic or Latino",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.56",
+        "id": {
+          "_id": {
+            "$oid": "5c880141d7c8ac4c3e106717"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880141d7c8ac4c3e10670d"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "ethnicity",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicEthnicity"
+      },
+      {
+        "_id": {
+          "$oid": "5c880141d7c8ac4c3e10670e"
+        },
+        "dataElementCodes": [
+          {
+            "code": "1002-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "American Indian or Alaska Native",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.59",
+        "id": {
+          "_id": {
+            "$oid": "5c880141d7c8ac4c3e106718"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880141d7c8ac4c3e10670e"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "race",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicRace"
+      },
+      {
+        "_id": {
+          "$oid": "5c880141d7c8ac4c3e10670f"
+        },
+        "dataElementCodes": [
+          {
+            "code": "F",
+            "codeSystem": "AdministrativeGender",
+            "descriptor": "F",
+            "codeSystemOid": "2.16.840.1.113883.5.1",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.55",
+        "id": {
+          "_id": {
+            "$oid": "5c880141d7c8ac4c3e106719"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880141d7c8ac4c3e10670f"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "gender",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicSex"
+      }
+    ],
+    "extendedData": {
+      "type": null,
+      "measure_ids": [
+        "8C942F13-6EAA-4A8E-BB4F-3B3BF7311C1F",
+        null
+      ],
+      "source_data_criteria": [
+        {
+          "negation": false,
+          "definition": "encounter",
+          "status": "performed",
+          "title": "InpatientEncounter",
+          "description": "Encounter, Performed: Inpatient Encounter",
+          "code_list_id": "2.16.840.1.113883.3.464.1003.101.12.1060",
+          "type": "encounters",
+          "id": "InpatientEncounter_EncounterPerformed_a6c66e3c_da7d_4104_836a_c6c427fecb16_source",
+          "start_date": 1334304000000,
+          "end_date": 1334304900000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "8C942F13-6EAA-4A8E-BB4F-3B3BF7311C1F",
+          "cms_id": "CMS761v0",
+          "criteria_id": "162bea28d6fHa",
+          "codes": {
+            "SNOMED-CT": [
+              "10378005"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5aec6eafb848463f1229da2a"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "participation",
+          "title": "InsuranceCoverageTypeFPAR",
+          "description": "Participation: Insurance Coverage Type",
+          "code_list_id": "2.16.840.1.113762.1.4.1166.29",
+          "type": "participations",
+          "id": "InsuranceCoverageTypeFPAR_Participation_29fbfb89_3cf5_433f_96bd_fb24fb1896f8_source",
+          "start_date": 1336118400000,
+          "end_date": 1336119300000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "8C942F13-6EAA-4A8E-BB4F-3B3BF7311C1F",
+          "cms_id": "CMS761v0",
+          "criteria_id": "1632b8dea99Yg",
+          "codes": {
+            "Source of Payment Typology": [
+              "3"
+            ]
+          },
+          "coded_entry_id": {
+            "$oid": "5aec6eafb848463f1229da2b"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "id": "MeasurePeriod",
+          "start_date": 0,
+          "end_date": 0,
+          "references": null
+        }
+      ],
+      "is_shared": null,
+      "origin_data": [
+
+      ],
+      "test_id": null,
+      "medical_record_number": "22b755900bfa2cd1996b37f5a25fb5e2d08a118c48ededa2b486adffa6fd0a5e",
+      "medical_record_assigner": "Bonnie",
+      "description": null,
+      "description_category": null,
+      "insurance_providers": "[{\"codes\":{\"SOP\":[\"349\"]},\"description\":null,\"end_time\":null,\"financial_responsibility_type\":{\"code\":\"SELF\",\"codeSystem\":\"HL7 Relationship Code\"},\"health_record_field\":null,\"member_id\":\"1234567890\",\"mood_code\":\"EVN\",\"name\":\"Other\",\"negationInd\":null,\"negationReason\":null,\"oid\":null,\"payer\":{\"name\":\"Other\"},\"reason\":null,\"relationship\":null,\"specifics\":null,\"start_time\":1199145600,\"status_code\":null,\"time\":null,\"type\":\"OT\"}]"
+    },
+    "qdmVersion": "5.4"
+  }
+}

--- a/test/fixtures/patients/CMS878v0/Test_NoNumerator.json
+++ b/test/fixtures/patients/CMS878v0/Test_NoNumerator.json
@@ -1,0 +1,240 @@
+{
+  "_id": {
+    "$oid": "5b61b47fb848461e81031467"
+  },
+  "bundleId": "5a57e977942c6d1e61d32f14",
+  "expectedValues": [
+    {
+      "measure_id": "50901F2E-3715-462B-87C1-2AD9B9B1CDE7",
+      "population_index": 0,
+      "IPP": 1,
+      "DENOM": 1,
+      "NUMER": 0
+    }
+  ],
+  "familyName": "NoNumerator",
+  "givenNames": [
+    "Test"
+  ],
+  "notes": "",
+  "qdmPatient": {
+    "_id": {
+      "$oid": "5c880144d7c8ac4c3e10677f"
+    },
+    "birthDatetime": "1976-07-04T05:23:00.000+00:00",
+    "dataElements": [
+      {
+        "_id": {
+          "$oid": "5c880144d7c8ac4c3e106780"
+        },
+        "authorDatetime": "2012-07-30T08:00:00.000+00:00",
+        "components": [
+
+        ],
+        "dataElementCodes": [
+          {
+            "codeSystem": "LOINC",
+            "code": "72166-2"
+          }
+        ],
+        "description": "Assessment, Performed: Tobacco Use Status",
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.117",
+        "id": {
+          "_id": {
+            "$oid": "5c880144d7c8ac4c3e106781"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5b61b47fb848461e81031468"
+        },
+        "method": null,
+        "negationRationale": null,
+        "qdmCategory": "assessment",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "result": "44367-05-28T08:00:00.000+00:00",
+        "_type": "QDM::AssessmentPerformed"
+      },
+      {
+        "_id": {
+          "$oid": "5c880144d7c8ac4c3e10677a"
+        },
+        "birthDatetime": "1976-07-04T05:23:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "code": "21112-8",
+            "codeSystem": "LOINC",
+            "descriptor": null,
+            "codeSystemOid": null,
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.54",
+        "id": {
+          "_id": {
+            "$oid": "5c880144d7c8ac4c3e106782"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880144d7c8ac4c3e10677a"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "birthdate",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicBirthdate"
+      },
+      {
+        "_id": {
+          "$oid": "5c880144d7c8ac4c3e10677b"
+        },
+        "dataElementCodes": [
+          {
+            "code": "2186-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "Not Hispanic or Latino",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.56",
+        "id": {
+          "_id": {
+            "$oid": "5c880144d7c8ac4c3e106783"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880144d7c8ac4c3e10677b"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "ethnicity",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicEthnicity"
+      },
+      {
+        "_id": {
+          "$oid": "5c880144d7c8ac4c3e10677c"
+        },
+        "dataElementCodes": [
+          {
+            "code": "2106-3",
+            "codeSystem": "CDC Race",
+            "descriptor": "White",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.59",
+        "id": {
+          "_id": {
+            "$oid": "5c880144d7c8ac4c3e106784"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880144d7c8ac4c3e10677c"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "race",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicRace"
+      },
+      {
+        "_id": {
+          "$oid": "5c880144d7c8ac4c3e10677d"
+        },
+        "dataElementCodes": [
+          {
+            "code": "F",
+            "codeSystem": "AdministrativeGender",
+            "descriptor": "F",
+            "codeSystemOid": "2.16.840.1.113883.5.1",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.55",
+        "id": {
+          "_id": {
+            "$oid": "5c880144d7c8ac4c3e106785"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880144d7c8ac4c3e10677d"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "gender",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicSex"
+      }
+    ],
+    "extendedData": {
+      "type": null,
+      "measure_ids": [
+        "50901F2E-3715-462B-87C1-2AD9B9B1CDE7",
+        null
+      ],
+      "source_data_criteria": [
+        {
+          "negation": false,
+          "definition": "assessment",
+          "status": "performed",
+          "title": "TobaccoUseStatus",
+          "description": "Assessment, Performed: Tobacco Use Status",
+          "code_list_id": "2.16.840.1.113762.1.4.1110.27",
+          "type": "assessments",
+          "id": "TobaccoUseStatus_AssessmentPerformed_de11e623_3d10_4076_a28d_4430d015a1f1_source",
+          "start_date": 1343635200000,
+          "value": [
+            {
+              "type": "TS",
+              "type_cmp": "CD",
+              "start_date": "05/25/2012",
+              "start_time": "8:00 AM",
+              "value": 1337932800000
+            }
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "50901F2E-3715-462B-87C1-2AD9B9B1CDE7",
+          "cms_id": "CMS878v0",
+          "criteria_id": "164f5a88e6b64",
+          "codes": {
+            "LOINC": [
+              "72166-2"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5b61b47fb848461e81031468"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "id": "MeasurePeriod",
+          "start_date": 0,
+          "end_date": 0,
+          "references": null
+        }
+      ],
+      "is_shared": null,
+      "origin_data": [
+
+      ],
+      "test_id": null,
+      "medical_record_number": "b2860a5756c502304c581b0f48a4f646995c8dc72f49c7b45c3520b016cfaac3",
+      "medical_record_assigner": "Bonnie",
+      "description": null,
+      "description_category": null,
+      "insurance_providers": "[{\"codes\":{\"SOP\":[\"349\"]},\"description\":null,\"end_time\":null,\"financial_responsibility_type\":{\"code\":\"SELF\",\"codeSystem\":\"HL7 Relationship Code\"},\"health_record_field\":null,\"member_id\":\"1234567890\",\"mood_code\":\"EVN\",\"name\":\"Other\",\"negationInd\":null,\"negationReason\":null,\"oid\":null,\"payer\":{\"name\":\"Other\"},\"reason\":null,\"relationship\":null,\"specifics\":null,\"start_time\":1199145600,\"status_code\":null,\"time\":null,\"type\":\"OT\"}]"
+    },
+    "qdmVersion": "5.4"
+  }
+}

--- a/test/fixtures/patients/CMS878v0/Test_Numerator.json
+++ b/test/fixtures/patients/CMS878v0/Test_Numerator.json
@@ -1,0 +1,240 @@
+{
+  "_id": {
+    "$oid": "5b61b4d5b84846662484a5b7"
+  },
+  "bundleId": "5a57e977942c6d1e61d32f14",
+  "expectedValues": [
+    {
+      "measure_id": "50901F2E-3715-462B-87C1-2AD9B9B1CDE7",
+      "population_index": 0,
+      "IPP": 1,
+      "DENOM": 1,
+      "NUMER": 1
+    }
+  ],
+  "familyName": "Numerator",
+  "givenNames": [
+    "Test"
+  ],
+  "notes": "",
+  "qdmPatient": {
+    "_id": {
+      "$oid": "5c880144d7c8ac4c3e10678b"
+    },
+    "birthDatetime": "1987-03-04T12:55:00.000+00:00",
+    "dataElements": [
+      {
+        "_id": {
+          "$oid": "5c880144d7c8ac4c3e10678c"
+        },
+        "authorDatetime": "2012-07-30T08:00:00.000+00:00",
+        "components": [
+
+        ],
+        "dataElementCodes": [
+          {
+            "codeSystem": "LOINC",
+            "code": "72166-2"
+          }
+        ],
+        "description": "Assessment, Performed: Tobacco Use Status",
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.117",
+        "id": {
+          "_id": {
+            "$oid": "5c880144d7c8ac4c3e10678d"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5b61b4d5b84846662484a5b8"
+        },
+        "method": null,
+        "negationRationale": null,
+        "qdmCategory": "assessment",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "result": "44468-09-14T08:00:00.000+00:00",
+        "_type": "QDM::AssessmentPerformed"
+      },
+      {
+        "_id": {
+          "$oid": "5c880144d7c8ac4c3e106786"
+        },
+        "birthDatetime": "1987-03-04T12:55:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "code": "21112-8",
+            "codeSystem": "LOINC",
+            "descriptor": null,
+            "codeSystemOid": null,
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.54",
+        "id": {
+          "_id": {
+            "$oid": "5c880144d7c8ac4c3e10678e"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880144d7c8ac4c3e106786"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "birthdate",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicBirthdate"
+      },
+      {
+        "_id": {
+          "$oid": "5c880144d7c8ac4c3e106787"
+        },
+        "dataElementCodes": [
+          {
+            "code": "2186-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "Not Hispanic or Latino",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.56",
+        "id": {
+          "_id": {
+            "$oid": "5c880144d7c8ac4c3e10678f"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880144d7c8ac4c3e106787"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "ethnicity",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicEthnicity"
+      },
+      {
+        "_id": {
+          "$oid": "5c880144d7c8ac4c3e106788"
+        },
+        "dataElementCodes": [
+          {
+            "code": "2054-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "Black or African American",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.59",
+        "id": {
+          "_id": {
+            "$oid": "5c880144d7c8ac4c3e106790"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880144d7c8ac4c3e106788"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "race",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicRace"
+      },
+      {
+        "_id": {
+          "$oid": "5c880144d7c8ac4c3e106789"
+        },
+        "dataElementCodes": [
+          {
+            "code": "M",
+            "codeSystem": "AdministrativeGender",
+            "descriptor": "M",
+            "codeSystemOid": "2.16.840.1.113883.5.1",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.55",
+        "id": {
+          "_id": {
+            "$oid": "5c880144d7c8ac4c3e106791"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880144d7c8ac4c3e106789"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "gender",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicSex"
+      }
+    ],
+    "extendedData": {
+      "type": null,
+      "measure_ids": [
+        "50901F2E-3715-462B-87C1-2AD9B9B1CDE7",
+        null
+      ],
+      "source_data_criteria": [
+        {
+          "negation": false,
+          "definition": "assessment",
+          "status": "performed",
+          "title": "TobaccoUseStatus",
+          "description": "Assessment, Performed: Tobacco Use Status",
+          "code_list_id": "2.16.840.1.113762.1.4.1110.27",
+          "type": "assessments",
+          "id": "TobaccoUseStatus_AssessmentPerformed_de11e623_3d10_4076_a28d_4430d015a1f1_source",
+          "start_date": 1343635200000,
+          "value": [
+            {
+              "type": "TS",
+              "type_cmp": "CD",
+              "start_date": "07/01/2012",
+              "start_time": "8:00 AM",
+              "value": 1341129600000
+            }
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "50901F2E-3715-462B-87C1-2AD9B9B1CDE7",
+          "cms_id": "CMS878v0",
+          "criteria_id": "164f5a88e6b64",
+          "codes": {
+            "LOINC": [
+              "72166-2"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5b61b4d5b84846662484a5b8"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "id": "MeasurePeriod",
+          "start_date": 0,
+          "end_date": 0,
+          "references": null
+        }
+      ],
+      "is_shared": null,
+      "origin_data": [
+
+      ],
+      "test_id": null,
+      "medical_record_number": "812ef3ac9a6a82749eb010e6750878d88de799903b269b1e87e7c44226c04238",
+      "medical_record_assigner": "Bonnie",
+      "description": null,
+      "description_category": null,
+      "insurance_providers": "[{\"codes\":{\"SOP\":[\"349\"]},\"description\":null,\"end_time\":null,\"financial_responsibility_type\":{\"code\":\"SELF\",\"codeSystem\":\"HL7 Relationship Code\"},\"health_record_field\":null,\"member_id\":\"1234567890\",\"mood_code\":\"EVN\",\"name\":\"Other\",\"negationInd\":null,\"negationReason\":null,\"oid\":null,\"payer\":{\"name\":\"Other\"},\"reason\":null,\"relationship\":null,\"specifics\":null,\"start_time\":1199145600,\"status_code\":null,\"time\":null,\"type\":\"OT\"}]"
+    },
+    "qdmVersion": "5.4"
+  }
+}

--- a/test/fixtures/patients/CMS879v0/Test_NoNumerator.json
+++ b/test/fixtures/patients/CMS879v0/Test_NoNumerator.json
@@ -1,0 +1,420 @@
+{
+  "_id": {
+    "$oid": "5b61b638b84846662484a6c1"
+  },
+  "bundleId": "5a57e977942c6d1e61d32f14",
+  "expectedValues": [
+    {
+      "measure_id": "D5355200-50C1-4A79-8983-8617B93FE6C1",
+      "population_index": 0,
+      "IPP": 1,
+      "DENOM": 1,
+      "NUMER": 0
+    }
+  ],
+  "familyName": "NoNumerator",
+  "givenNames": [
+    "Test"
+  ],
+  "notes": "",
+  "qdmPatient": {
+    "_id": {
+      "$oid": "5c880143d7c8ac4c3e10675f"
+    },
+    "birthDatetime": "1940-01-01T08:00:00.000+00:00",
+    "dataElements": [
+      {
+        "_id": {
+          "$oid": "5c880143d7c8ac4c3e106760"
+        },
+        "authorDatetime": "2012-07-31T08:00:00.000+00:00",
+        "components": [
+
+        ],
+        "dataElementCodes": [
+          {
+            "codeSystem": "LOINC",
+            "code": "24320-4"
+          }
+        ],
+        "description": "Assessment, Performed: Laboratory Tests for Hypertension",
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.117",
+        "id": {
+          "_id": {
+            "$oid": "5c880143d7c8ac4c3e106761"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5b61b638b84846662484a6c2"
+        },
+        "method": null,
+        "negationRationale": null,
+        "qdmCategory": "assessment",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "result": "44307-03-04T08:00:00.000+00:00",
+        "_type": "QDM::AssessmentPerformed"
+      },
+      {
+        "_id": {
+          "$oid": "5c880143d7c8ac4c3e106762"
+        },
+        "authorDatetime": "2012-07-31T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "RxNorm",
+            "code": "200031"
+          }
+        ],
+        "daysSupplied": null,
+        "description": "Medication, Ordered: Beta Blocker Therapy for LVSD",
+        "dosage": null,
+        "frequency": null,
+        "hqmfOid": "2.16.840.1.113883.3.560.1.78",
+        "id": {
+          "_id": {
+            "$oid": "5c880143d7c8ac4c3e106763"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5b61b638b84846662484a6c3"
+        },
+        "negationRationale": {
+          "code": "105480006",
+          "codeSystem": "SNOMED-CT",
+          "descriptor": null,
+          "codeSystemOid": null,
+          "version": null
+        },
+        "prescriberId": null,
+        "qdmCategory": "medication",
+        "qdmStatus": "order",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "refills": null,
+        "relevantPeriod": {
+          "low": "2012-07-31T08:00:00.000+00:00",
+          "high": "9999-12-31T23:59:59.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "route": null,
+        "setting": null,
+        "supply": null,
+        "_type": "QDM::MedicationOrder"
+      },
+      {
+        "_id": {
+          "$oid": "5c880143d7c8ac4c3e106764"
+        },
+        "authorDatetime": "2012-07-31T08:00:00.000+00:00",
+        "components": [
+          {
+            "result": "43510-06-10T08:00:00+00:00",
+            "code": {
+              "code": "200031",
+              "codeSystem": "RxNorm",
+              "version": null,
+              "descriptor": null
+            }
+          }
+        ],
+        "dataElementCodes": [
+          {
+            "codeSystem": "LOINC",
+            "code": "24320-4"
+          }
+        ],
+        "description": "Laboratory Test, Performed: Laboratory Tests for Hypertension",
+        "hqmfOid": "2.16.840.1.113883.3.560.1.5",
+        "id": {
+          "_id": {
+            "$oid": "5c880143d7c8ac4c3e106765"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5b61b638b84846662484a6c4"
+        },
+        "method": null,
+        "negationRationale": null,
+        "qdmCategory": "laboratory_test",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "referenceRange": null,
+        "relevantPeriod": {
+          "low": "2012-07-31T08:00:00.000+00:00",
+          "high": "2012-07-31T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "result": null,
+        "resultDatetime": null,
+        "status": null,
+        "_type": "QDM::LaboratoryTestPerformed"
+      },
+      {
+        "_id": {
+          "$oid": "5c880143d7c8ac4c3e10675a"
+        },
+        "birthDatetime": "1940-01-01T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "code": "21112-8",
+            "codeSystem": "LOINC",
+            "descriptor": null,
+            "codeSystemOid": null,
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.54",
+        "id": {
+          "_id": {
+            "$oid": "5c880143d7c8ac4c3e106766"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880143d7c8ac4c3e10675a"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "birthdate",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicBirthdate"
+      },
+      {
+        "_id": {
+          "$oid": "5c880143d7c8ac4c3e10675b"
+        },
+        "dataElementCodes": [
+          {
+            "code": "2186-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "Not Hispanic or Latino",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.56",
+        "id": {
+          "_id": {
+            "$oid": "5c880143d7c8ac4c3e106767"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880143d7c8ac4c3e10675b"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "ethnicity",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicEthnicity"
+      },
+      {
+        "_id": {
+          "$oid": "5c880143d7c8ac4c3e10675c"
+        },
+        "dataElementCodes": [
+          {
+            "code": "1002-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "American Indian or Alaska Native",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.59",
+        "id": {
+          "_id": {
+            "$oid": "5c880143d7c8ac4c3e106768"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880143d7c8ac4c3e10675c"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "race",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicRace"
+      },
+      {
+        "_id": {
+          "$oid": "5c880143d7c8ac4c3e10675d"
+        },
+        "dataElementCodes": [
+          {
+            "code": "M",
+            "codeSystem": "AdministrativeGender",
+            "descriptor": "M",
+            "codeSystemOid": "2.16.840.1.113883.5.1",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.55",
+        "id": {
+          "_id": {
+            "$oid": "5c880143d7c8ac4c3e106769"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880143d7c8ac4c3e10675d"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "gender",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicSex"
+      }
+    ],
+    "extendedData": {
+      "type": null,
+      "measure_ids": [
+        "D5355200-50C1-4A79-8983-8617B93FE6C1",
+        null
+      ],
+      "source_data_criteria": [
+        {
+          "negation": false,
+          "definition": "assessment",
+          "status": "performed",
+          "title": "LaboratoryTestsforHypertension",
+          "description": "Assessment, Performed: Laboratory Tests for Hypertension",
+          "code_list_id": "2.16.840.1.113883.3.600.1482",
+          "type": "assessments",
+          "id": "LaboratoryTestsforHypertension_AssessmentPerformed_7dd701f4_bcdb_4198_8958_6f1a1f79a7bc_source",
+          "start_date": 1343721600000,
+          "value": [
+            {
+              "type": "TS",
+              "type_cmp": "CD",
+              "start_date": "05/03/2012",
+              "start_time": "8:00 AM",
+              "value": 1336032000000
+            }
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "D5355200-50C1-4A79-8983-8617B93FE6C1",
+          "cms_id": "CMS879v0",
+          "criteria_id": "164f5ac39e4yh",
+          "codes": {
+            "LOINC": [
+              "24320-4"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5b61b638b84846662484a6c2"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": true,
+          "definition": "medication",
+          "status": "ordered",
+          "title": "BetaBlockerTherapyforLVSD",
+          "description": "Medication, Ordered: Beta Blocker Therapy for LVSD",
+          "code_list_id": "2.16.840.1.113883.3.526.3.1184",
+          "type": "medications",
+          "id": "Derived from BetaBlockerTherapyforLVSD_MedicationNotOrdered_802b51cf_5bf7_469e_a6ab_61619fae8a1a_source",
+          "start_date": 1343721600000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "D5355200-50C1-4A79-8983-8617B93FE6C1",
+          "cms_id": "CMS879v0",
+          "criteria_id": "164f5ad29adOC",
+          "codes": {
+            "RxNorm": [
+              "200031"
+            ]
+          },
+          "negation_code_list_id": "2.16.840.1.113883.3.600.791",
+          "coded_entry_id": {
+            "$oid": "5b61b638b84846662484a6c3"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "laboratory_test",
+          "status": "performed",
+          "title": "LaboratoryTestsforHypertension",
+          "description": "Laboratory Test, Performed: Laboratory Tests for Hypertension",
+          "code_list_id": "2.16.840.1.113883.3.600.1482",
+          "type": "laboratory_tests",
+          "id": "LaboratoryTestsforHypertension_LaboratoryTestPerformed_7dd701f4_bcdb_4198_8958_6f1a1f79a7bc_source",
+          "start_date": 1343721600000,
+          "end_date": 1343722500000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+            "COMPONENT": {
+              "type": "COL",
+              "values": [
+                {
+                  "type": "CMP",
+                  "type_cmp": "TS",
+                  "key": "COMPONENT",
+                  "code_list_id": "2.16.840.1.113883.3.526.3.1184",
+                  "field_title": "Component",
+                  "code_list_id_cmp": "",
+                  "referenceRangeLow_value": "",
+                  "referenceRangeLow_unit": "",
+                  "referenceRangeHigh_value": "",
+                  "referenceRangeHigh_unit": "",
+                  "title": "Beta Blocker Therapy for LVSD",
+                  "start_date": "07/17/2011",
+                  "start_time": "8:00 AM",
+                  "value": 1310889600000
+                }
+              ]
+            }
+          },
+          "hqmf_set_id": "D5355200-50C1-4A79-8983-8617B93FE6C1",
+          "cms_id": "CMS879v0",
+          "criteria_id": "164f5adab85Ec",
+          "codes": {
+            "LOINC": [
+              "24320-4"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5b61b638b84846662484a6c4"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "id": "MeasurePeriod",
+          "start_date": 0,
+          "end_date": 0,
+          "references": null
+        }
+      ],
+      "is_shared": null,
+      "origin_data": [
+
+      ],
+      "test_id": null,
+      "medical_record_number": "6f7fa9bdd5fc70b547408d8374fe5b66d446e9160acb57bc101f8ce353712056",
+      "medical_record_assigner": "Bonnie",
+      "description": null,
+      "description_category": null,
+      "insurance_providers": "[{\"codes\":{\"SOP\":[\"349\"]},\"description\":null,\"end_time\":null,\"financial_responsibility_type\":{\"code\":\"SELF\",\"codeSystem\":\"HL7 Relationship Code\"},\"health_record_field\":null,\"member_id\":\"1234567890\",\"mood_code\":\"EVN\",\"name\":\"Other\",\"negationInd\":null,\"negationReason\":null,\"oid\":null,\"payer\":{\"name\":\"Other\"},\"reason\":null,\"relationship\":null,\"specifics\":null,\"start_time\":1199145600,\"status_code\":null,\"time\":null,\"type\":\"OT\"}]"
+    },
+    "qdmVersion": "5.4"
+  }
+}

--- a/test/fixtures/patients/CMS879v0/Test_Numerator.json
+++ b/test/fixtures/patients/CMS879v0/Test_Numerator.json
@@ -1,0 +1,420 @@
+{
+  "_id": {
+    "$oid": "5b61b693b84846662484a6e4"
+  },
+  "bundleId": "5a57e977942c6d1e61d32f14",
+  "expectedValues": [
+    {
+      "measure_id": "D5355200-50C1-4A79-8983-8617B93FE6C1",
+      "population_index": 0,
+      "IPP": 1,
+      "DENOM": 1,
+      "NUMER": 1
+    }
+  ],
+  "familyName": "Numerator",
+  "givenNames": [
+    "Test"
+  ],
+  "notes": "",
+  "qdmPatient": {
+    "_id": {
+      "$oid": "5c880143d7c8ac4c3e10676f"
+    },
+    "birthDatetime": "1940-01-01T08:00:00.000+00:00",
+    "dataElements": [
+      {
+        "_id": {
+          "$oid": "5c880143d7c8ac4c3e106770"
+        },
+        "authorDatetime": "2012-07-31T08:00:00.000+00:00",
+        "components": [
+
+        ],
+        "dataElementCodes": [
+          {
+            "codeSystem": "LOINC",
+            "code": "24320-4"
+          }
+        ],
+        "description": "Assessment, Performed: Laboratory Tests for Hypertension",
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.117",
+        "id": {
+          "_id": {
+            "$oid": "5c880143d7c8ac4c3e106771"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5b61b693b84846662484a6e5"
+        },
+        "method": null,
+        "negationRationale": null,
+        "qdmCategory": "assessment",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "result": "44307-03-04T08:00:00.000+00:00",
+        "_type": "QDM::AssessmentPerformed"
+      },
+      {
+        "_id": {
+          "$oid": "5c880143d7c8ac4c3e106772"
+        },
+        "authorDatetime": "2012-07-31T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "codeSystem": "RxNorm",
+            "code": "200031"
+          }
+        ],
+        "daysSupplied": null,
+        "description": "Medication, Ordered: Beta Blocker Therapy for LVSD",
+        "dosage": null,
+        "frequency": null,
+        "hqmfOid": "2.16.840.1.113883.3.560.1.78",
+        "id": {
+          "_id": {
+            "$oid": "5c880143d7c8ac4c3e106773"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5b61b693b84846662484a6e6"
+        },
+        "negationRationale": {
+          "code": "105480006",
+          "codeSystem": "SNOMED-CT",
+          "descriptor": null,
+          "codeSystemOid": null,
+          "version": null
+        },
+        "prescriberId": null,
+        "qdmCategory": "medication",
+        "qdmStatus": "order",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "refills": null,
+        "relevantPeriod": {
+          "low": "2012-07-31T08:00:00.000+00:00",
+          "high": "9999-12-31T23:59:59.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "route": null,
+        "setting": null,
+        "supply": null,
+        "_type": "QDM::MedicationOrder"
+      },
+      {
+        "_id": {
+          "$oid": "5c880143d7c8ac4c3e106774"
+        },
+        "authorDatetime": "2012-07-31T08:00:00.000+00:00",
+        "components": [
+          {
+            "result": "44512-07-06T08:00:00+00:00",
+            "code": {
+              "code": "200031",
+              "codeSystem": "RxNorm",
+              "version": null,
+              "descriptor": null
+            }
+          }
+        ],
+        "dataElementCodes": [
+          {
+            "codeSystem": "LOINC",
+            "code": "24320-4"
+          }
+        ],
+        "description": "Laboratory Test, Performed: Laboratory Tests for Hypertension",
+        "hqmfOid": "2.16.840.1.113883.3.560.1.5",
+        "id": {
+          "_id": {
+            "$oid": "5c880143d7c8ac4c3e106775"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5b61b693b84846662484a6e7"
+        },
+        "method": null,
+        "negationRationale": null,
+        "qdmCategory": "laboratory_test",
+        "qdmStatus": "performed",
+        "qdmVersion": "5.4",
+        "reason": null,
+        "referenceRange": null,
+        "relevantPeriod": {
+          "low": "2012-07-31T08:00:00.000+00:00",
+          "high": "2012-07-31T08:15:00.000+00:00",
+          "lowClosed": true,
+          "highClosed": true
+        },
+        "result": null,
+        "resultDatetime": null,
+        "status": null,
+        "_type": "QDM::LaboratoryTestPerformed"
+      },
+      {
+        "_id": {
+          "$oid": "5c880143d7c8ac4c3e10676a"
+        },
+        "birthDatetime": "1940-01-01T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "code": "21112-8",
+            "codeSystem": "LOINC",
+            "descriptor": null,
+            "codeSystemOid": null,
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.54",
+        "id": {
+          "_id": {
+            "$oid": "5c880143d7c8ac4c3e106776"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880143d7c8ac4c3e10676a"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "birthdate",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicBirthdate"
+      },
+      {
+        "_id": {
+          "$oid": "5c880143d7c8ac4c3e10676b"
+        },
+        "dataElementCodes": [
+          {
+            "code": "2186-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "Not Hispanic or Latino",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.56",
+        "id": {
+          "_id": {
+            "$oid": "5c880143d7c8ac4c3e106777"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880143d7c8ac4c3e10676b"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "ethnicity",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicEthnicity"
+      },
+      {
+        "_id": {
+          "$oid": "5c880143d7c8ac4c3e10676c"
+        },
+        "dataElementCodes": [
+          {
+            "code": "1002-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "American Indian or Alaska Native",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.59",
+        "id": {
+          "_id": {
+            "$oid": "5c880143d7c8ac4c3e106778"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880143d7c8ac4c3e10676c"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "race",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicRace"
+      },
+      {
+        "_id": {
+          "$oid": "5c880143d7c8ac4c3e10676d"
+        },
+        "dataElementCodes": [
+          {
+            "code": "M",
+            "codeSystem": "AdministrativeGender",
+            "descriptor": "M",
+            "codeSystemOid": "2.16.840.1.113883.5.1",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.55",
+        "id": {
+          "_id": {
+            "$oid": "5c880143d7c8ac4c3e106779"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880143d7c8ac4c3e10676d"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "gender",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicSex"
+      }
+    ],
+    "extendedData": {
+      "type": null,
+      "measure_ids": [
+        "D5355200-50C1-4A79-8983-8617B93FE6C1",
+        null
+      ],
+      "source_data_criteria": [
+        {
+          "negation": false,
+          "definition": "assessment",
+          "status": "performed",
+          "title": "LaboratoryTestsforHypertension",
+          "description": "Assessment, Performed: Laboratory Tests for Hypertension",
+          "code_list_id": "2.16.840.1.113883.3.600.1482",
+          "type": "assessments",
+          "id": "LaboratoryTestsforHypertension_AssessmentPerformed_7dd701f4_bcdb_4198_8958_6f1a1f79a7bc_source",
+          "start_date": 1343721600000,
+          "value": [
+            {
+              "type": "TS",
+              "type_cmp": "CD",
+              "start_date": "05/03/2012",
+              "start_time": "8:00 AM",
+              "value": 1336032000000
+            }
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "D5355200-50C1-4A79-8983-8617B93FE6C1",
+          "cms_id": "CMS879v0",
+          "criteria_id": "164f5ac39e4yh",
+          "codes": {
+            "LOINC": [
+              "24320-4"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5b61b693b84846662484a6e5"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": true,
+          "definition": "medication",
+          "status": "ordered",
+          "title": "BetaBlockerTherapyforLVSD",
+          "description": "Medication, Ordered: Beta Blocker Therapy for LVSD",
+          "code_list_id": "2.16.840.1.113883.3.526.3.1184",
+          "type": "medications",
+          "id": "Derived from BetaBlockerTherapyforLVSD_MedicationNotOrdered_802b51cf_5bf7_469e_a6ab_61619fae8a1a_source",
+          "start_date": 1343721600000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+          },
+          "hqmf_set_id": "D5355200-50C1-4A79-8983-8617B93FE6C1",
+          "cms_id": "CMS879v0",
+          "criteria_id": "164f5ad29adOC",
+          "codes": {
+            "RxNorm": [
+              "200031"
+            ]
+          },
+          "negation_code_list_id": "2.16.840.1.113883.3.600.791",
+          "coded_entry_id": {
+            "$oid": "5b61b693b84846662484a6e6"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "negation": false,
+          "definition": "laboratory_test",
+          "status": "performed",
+          "title": "LaboratoryTestsforHypertension",
+          "description": "Laboratory Test, Performed: Laboratory Tests for Hypertension",
+          "code_list_id": "2.16.840.1.113883.3.600.1482",
+          "type": "laboratory_tests",
+          "id": "LaboratoryTestsforHypertension_LaboratoryTestPerformed_7dd701f4_bcdb_4198_8958_6f1a1f79a7bc_source",
+          "start_date": 1343721600000,
+          "end_date": 1343722500000,
+          "value": [
+
+          ],
+          "references": null,
+          "field_values": {
+            "COMPONENT": {
+              "type": "COL",
+              "values": [
+                {
+                  "type": "CMP",
+                  "type_cmp": "TS",
+                  "key": "COMPONENT",
+                  "code_list_id": "2.16.840.1.113883.3.526.3.1184",
+                  "field_title": "Component",
+                  "code_list_id_cmp": "",
+                  "referenceRangeLow_value": "",
+                  "referenceRangeLow_unit": "",
+                  "referenceRangeHigh_value": "",
+                  "referenceRangeHigh_unit": "",
+                  "title": "Beta Blocker Therapy for LVSD",
+                  "start_date": "07/17/2012",
+                  "start_time": "8:00 AM",
+                  "value": 1342512000000
+                }
+              ]
+            }
+          },
+          "hqmf_set_id": "D5355200-50C1-4A79-8983-8617B93FE6C1",
+          "cms_id": "CMS879v0",
+          "criteria_id": "164f5adab85Ec",
+          "codes": {
+            "LOINC": [
+              "24320-4"
+            ]
+          },
+          "negation_code_list_id": "",
+          "coded_entry_id": {
+            "$oid": "5b61b693b84846662484a6e7"
+          },
+          "code_source": "DEFAULT"
+        },
+        {
+          "id": "MeasurePeriod",
+          "start_date": 0,
+          "end_date": 0,
+          "references": null
+        }
+      ],
+      "is_shared": null,
+      "origin_data": [
+
+      ],
+      "test_id": null,
+      "medical_record_number": "a5b1de56a574b5ad0b76cdfac071de678289832fc7518f1fa5540ebc5e235e15",
+      "medical_record_assigner": "Bonnie",
+      "description": null,
+      "description_category": null,
+      "insurance_providers": "[{\"codes\":{\"SOP\":[\"349\"]},\"description\":null,\"end_time\":null,\"financial_responsibility_type\":{\"code\":\"SELF\",\"codeSystem\":\"HL7 Relationship Code\"},\"health_record_field\":null,\"member_id\":\"1234567890\",\"mood_code\":\"EVN\",\"name\":\"Other\",\"negationInd\":null,\"negationReason\":null,\"oid\":null,\"payer\":{\"name\":\"Other\"},\"reason\":null,\"relationship\":null,\"specifics\":null,\"start_time\":1199145600,\"status_code\":null,\"time\":null,\"type\":\"OT\"}]"
+    },
+    "qdmVersion": "5.4"
+  }
+}

--- a/test/fixtures/patients/CMSv9999/Patient_Blank.json
+++ b/test/fixtures/patients/CMSv9999/Patient_Blank.json
@@ -1,0 +1,261 @@
+{
+  "_id": {
+    "$oid": "5af5b02db848462db95f11f3"
+  },
+  "bundleId": "5a57e977942c6d1e61d32f14",
+  "expectedValues": [
+    {
+      "measure_id": "21C422D4-1658-478D-AEC2-B87B73638C41",
+      "population_index": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "21C422D4-1658-478D-AEC2-B87B73638C41",
+      "population_index": 1,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "21C422D4-1658-478D-AEC2-B87B73638C41",
+      "population_index": 2,
+      "STRAT": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "21C422D4-1658-478D-AEC2-B87B73638C41",
+      "population_index": 3,
+      "STRAT": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "21C422D4-1658-478D-AEC2-B87B73638C41",
+      "population_index": 4,
+      "STRAT": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "21C422D4-1658-478D-AEC2-B87B73638C41",
+      "population_index": 5,
+      "STRAT": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "21C422D4-1658-478D-AEC2-B87B73638C41",
+      "population_index": 6,
+      "STRAT": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "21C422D4-1658-478D-AEC2-B87B73638C41",
+      "population_index": 7,
+      "STRAT": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "21C422D4-1658-478D-AEC2-B87B73638C41",
+      "population_index": 8,
+      "STRAT": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "21C422D4-1658-478D-AEC2-B87B73638C41",
+      "population_index": 9,
+      "STRAT": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    },
+    {
+      "measure_id": "21C422D4-1658-478D-AEC2-B87B73638C41",
+      "population_index": 10,
+      "STRAT": 0,
+      "IPP": 0,
+      "DENOM": 0,
+      "DENEX": 0,
+      "NUMER": 0
+    }
+  ],
+  "familyName": "Blank",
+  "givenNames": [
+    "Patient"
+  ],
+  "notes": "",
+  "qdmPatient": {
+    "_id": {
+      "$oid": "5c880141d7c8ac4c3e10671f"
+    },
+    "birthDatetime": "1970-01-01T08:00:00.000+00:00",
+    "dataElements": [
+      {
+        "_id": {
+          "$oid": "5c880141d7c8ac4c3e10671a"
+        },
+        "birthDatetime": "1970-01-01T08:00:00.000+00:00",
+        "dataElementCodes": [
+          {
+            "code": "21112-8",
+            "codeSystem": "LOINC",
+            "descriptor": null,
+            "codeSystemOid": null,
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.54",
+        "id": {
+          "_id": {
+            "$oid": "5c880141d7c8ac4c3e106720"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880141d7c8ac4c3e10671a"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "birthdate",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicBirthdate"
+      },
+      {
+        "_id": {
+          "$oid": "5c880141d7c8ac4c3e10671b"
+        },
+        "dataElementCodes": [
+          {
+            "code": "2186-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "Not Hispanic or Latino",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.56",
+        "id": {
+          "_id": {
+            "$oid": "5c880141d7c8ac4c3e106721"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880141d7c8ac4c3e10671b"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "ethnicity",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicEthnicity"
+      },
+      {
+        "_id": {
+          "$oid": "5c880141d7c8ac4c3e10671c"
+        },
+        "dataElementCodes": [
+          {
+            "code": "1002-5",
+            "codeSystem": "CDC Race",
+            "descriptor": "American Indian or Alaska Native",
+            "codeSystemOid": "2.16.840.1.113883.6.238",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.59",
+        "id": {
+          "_id": {
+            "$oid": "5c880141d7c8ac4c3e106722"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880141d7c8ac4c3e10671c"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "race",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicRace"
+      },
+      {
+        "_id": {
+          "$oid": "5c880141d7c8ac4c3e10671d"
+        },
+        "dataElementCodes": [
+          {
+            "code": "M",
+            "codeSystem": "AdministrativeGender",
+            "descriptor": "M",
+            "codeSystemOid": "2.16.840.1.113883.5.1",
+            "version": null,
+            "_type": "QDM::Code"
+          }
+        ],
+        "description": null,
+        "hqmfOid": "2.16.840.1.113883.10.20.28.3.55",
+        "id": {
+          "_id": {
+            "$oid": "5c880141d7c8ac4c3e106723"
+          },
+          "namingSystem": null,
+          "qdmVersion": "5.4",
+          "value": "5c880141d7c8ac4c3e10671d"
+        },
+        "qdmCategory": "patient_characteristic",
+        "qdmStatus": "gender",
+        "qdmVersion": "5.4",
+        "_type": "QDM::PatientCharacteristicSex"
+      }
+    ],
+    "extendedData": {
+      "type": null,
+      "measure_ids": [
+        "21C422D4-1658-478D-AEC2-B87B73638C41",
+        null
+      ],
+      "source_data_criteria": [
+        {
+          "id": "MeasurePeriod",
+          "start_date": 0,
+          "end_date": 0,
+          "references": null
+        }
+      ],
+      "is_shared": null,
+      "origin_data": [
+
+      ],
+      "test_id": null,
+      "medical_record_number": "e89dca90064c46158e292fbc8721b5a82c516421b206f91179e708dee8c8036a",
+      "medical_record_assigner": "Bonnie",
+      "description": null,
+      "description_category": null,
+      "insurance_providers": "[{\"codes\":{\"SOP\":[\"349\"]},\"description\":null,\"end_time\":null,\"financial_responsibility_type\":{\"code\":\"SELF\",\"codeSystem\":\"HL7 Relationship Code\"},\"health_record_field\":null,\"member_id\":\"1234567890\",\"mood_code\":\"EVN\",\"name\":\"Other\",\"negationInd\":null,\"negationReason\":null,\"oid\":null,\"payer\":{\"name\":\"Other\"},\"reason\":null,\"relationship\":null,\"specifics\":null,\"start_time\":1199145600,\"status_code\":null,\"time\":null,\"type\":\"OT\"}]"
+    },
+    "qdmVersion": "5.4"
+  }
+}

--- a/test/rake/export_fixtures_test.rb
+++ b/test/rake/export_fixtures_test.rb
@@ -37,3 +37,4 @@ class ExportFixturesTest < ActiveSupport::TestCase
     end
   end
 end
+

--- a/test/rake/export_fixtures_test.rb
+++ b/test/rake/export_fixtures_test.rb
@@ -37,4 +37,3 @@ class ExportFixturesTest < ActiveSupport::TestCase
     end
   end
 end
-

--- a/test/rake/export_fixtures_test.rb
+++ b/test/rake/export_fixtures_test.rb
@@ -1,0 +1,55 @@
+require 'test_helper'
+
+class ExportFixturesTest < ActiveSupport::TestCase
+  setup do
+    dump_database
+    measure_set = File.join('cql_measures', 'core_measures', 'CMS32v7')
+    simple_measure_set = File.join('cql_measures', 'core_measures', 'CMS134v6')
+    users_set = File.join('users', 'base_set')
+    records_set = File.join('records','core_measures', 'CMS32v7')
+    simple_records_set = File.join('records','core_measures', 'CMS134v6')
+    collection_fixtures(users_set, measure_set, simple_measure_set, records_set, simple_records_set)
+    @user = User.by_email('bonnie@example.com').first
+    associate_user_with_patients(@user, Record.all)
+  end
+
+  test "generate_cqm_patient_fixtures description" do
+    rake_task_descriptions = capture(:stdout) do
+      system('rake -T')
+    end
+    assert rake_task_descriptions.include? 'rake bonnie:fixtures:generate_cqm_patient_fixtures_from_cql_patients[email]'
+    assert rake_task_descriptions.include? '# Export patient fixtures for a given account'
+  end
+
+  test "export single patient from account" do
+    begin
+      system('mv test/fixtures/patients test/fixtures/patients.back')
+      system('mv spec/javascripts/fixtures/json/patients spec/javascripts/fixtures/json/patients.back')
+
+      assert_output(
+        "exported a patient record to test/fixtures/patients/CMS32v7/Visit_1 ED.json
+exported a patient record to spec/javascripts/fixtures/json/patients/CMS32v7/Visit_1 ED.json
+exported a patient record to test/fixtures/patients/CMS32v7/Visits_2 ED.json
+exported a patient record to spec/javascripts/fixtures/json/patients/CMS32v7/Visits_2 ED.json
+exported a patient record to test/fixtures/patients/CMS32v7/Visits 2 Excl_2 ED.json
+exported a patient record to spec/javascripts/fixtures/json/patients/CMS32v7/Visits 2 Excl_2 ED.json
+exported a patient record to test/fixtures/patients/CMS32v7/Visits 1 Excl_2 ED.json
+exported a patient record to spec/javascripts/fixtures/json/patients/CMS32v7/Visits 1 Excl_2 ED.json
+exported a patient record to test/fixtures/patients/CMS134v6/Elements_Test.json
+exported a patient record to spec/javascripts/fixtures/json/patients/CMS134v6/Elements_Test.json
+exported a patient record to test/fixtures/patients/CMS134v6/Fail_Hospice_Not_Performed_Denex.json
+exported a patient record to spec/javascripts/fixtures/json/patients/CMS134v6/Fail_Hospice_Not_Performed_Denex.json
+Failed to export the following patients:
+measure.hqmf_set_id: 7B2A9277-43DA-4D99-9BEE-6AC271A07747
+\trecord._id: 5a58f001942c6d500fc8cb92
+\terror: Error: 'cc' is not a valid UCUM unit.
+"
+      ) { Rake::Task['bonnie:fixtures:generate_cqm_patient_fixtures_from_cql_patients'].invoke('bonnie@example.com') }
+      assert_equal 11, `ls -l test/fixtures/patients/CMS* | wc -l`.to_i
+      assert_equal 11, `ls -l spec/javascripts/fixtures/json/patients/CMS* | wc -l`.to_i
+    ensure
+      system('mv test/fixtures/patients.back test/fixtures/patients')
+      system('mv spec/javascripts/fixtures/json/patients.back spec/javascripts/fixtures/json/patients')
+    end
+  end
+end

--- a/test/rake/export_fixtures_test.rb
+++ b/test/rake/export_fixtures_test.rb
@@ -27,23 +27,7 @@ class ExportFixturesTest < ActiveSupport::TestCase
       system('mv spec/javascripts/fixtures/json/patients spec/javascripts/fixtures/json/patients.back')
 
       assert_output(
-        "exported a patient record to test/fixtures/patients/CMS32v7/Visit_1 ED.json
-exported a patient record to spec/javascripts/fixtures/json/patients/CMS32v7/Visit_1 ED.json
-exported a patient record to test/fixtures/patients/CMS32v7/Visits_2 ED.json
-exported a patient record to spec/javascripts/fixtures/json/patients/CMS32v7/Visits_2 ED.json
-exported a patient record to test/fixtures/patients/CMS32v7/Visits 2 Excl_2 ED.json
-exported a patient record to spec/javascripts/fixtures/json/patients/CMS32v7/Visits 2 Excl_2 ED.json
-exported a patient record to test/fixtures/patients/CMS32v7/Visits 1 Excl_2 ED.json
-exported a patient record to spec/javascripts/fixtures/json/patients/CMS32v7/Visits 1 Excl_2 ED.json
-exported a patient record to test/fixtures/patients/CMS134v6/Elements_Test.json
-exported a patient record to spec/javascripts/fixtures/json/patients/CMS134v6/Elements_Test.json
-exported a patient record to test/fixtures/patients/CMS134v6/Fail_Hospice_Not_Performed_Denex.json
-exported a patient record to spec/javascripts/fixtures/json/patients/CMS134v6/Fail_Hospice_Not_Performed_Denex.json
-Failed to export the following patients:
-measure.hqmf_set_id: 7B2A9277-43DA-4D99-9BEE-6AC271A07747
-\trecord._id: 5a58f001942c6d500fc8cb92
-\terror: Error: 'cc' is not a valid UCUM unit.
-"
+        /CMS32/
       ) { Rake::Task['bonnie:fixtures:generate_cqm_patient_fixtures_from_cql_patients'].invoke('bonnie@example.com') }
       assert_equal 11, `ls -l test/fixtures/patients/CMS* | wc -l`.to_i
       assert_equal 11, `ls -l spec/javascripts/fixtures/json/patients/CMS* | wc -l`.to_i


### PR DESCRIPTION
Add a rake task to export cqm patient fixtures from a database that has qdm records (convert before creating the fixtures).

Export fixtures form bonnie-fixtures@mitre.org using said rake task.  

There are some expected failures in exporting:

```
Failed to export the following patients:
measure.hqmf_set_id: 7B2A9277-43DA-4D99-9BEE-6AC271A07747
        record._id: 5a58f001942c6d500fc8cb92
        error: Error: 'cc' is not a valid UCUM unit.
measure.hqmf_set_id: 8439F671-2932-4D4C-88CA-EA5FAEACC89A
        record._id: 5b6b26c9b848461165a3e809
        error: Error: 'bpm' is not a valid UCUM unit.
```
Pull requests into Bonnie require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] JIRA ticket for this PR: https://jira.mitre.org/browse/BONNIE-1932
- [x] JIRA ticket links to this PR
- [x] Code diff has been done and been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] If UI changes have been made, google WAVE plug-in has been executed to ensure no 508 issues were introduced.
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Test fixtures updated and documented as necessary ( see [internal wiki](https://gitlab.mitre.org/bonnie/internal-documentation/wikis/testing#test-fixtures) )
- [x] Code coverage has not gone down and all code touched or added is covered. 
     * In rare situations, this may not be possible or applicable to a PR. In those situations:
         1. Note why this could not be done or is not applicable here: 
         2. Add TODOs in the code noting that it requires a test
         3. Add a JIRA task to add the test and link it here: 
- [x] Automated regression test(s) pass N/A


**Reviewer 1:**

Name: @zlister 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code


**Reviewer 2:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
