### PR TITLE
Verification function for the convert measures rake task

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,7 +36,7 @@ GIT
 
 GIT
   remote: https://github.com/projecttacoma/cqm-converter
-  revision: 143cc16fadce48166b6bc074bb01b1d4ecf469e9
+  revision: c1ac4080fe027335ef0ae82a5f8749cadb8b0ef8
   branch: master
   specs:
     cqm-converter (1.0.3)

--- a/lib/tasks/cql.rake
+++ b/lib/tasks/cql.rake
@@ -142,23 +142,26 @@ namespace :bonnie do
           if diff.empty?
             print ".".green
           else
-            fail_count += 1
-            puts "Conversion Difference".yellow
+            puts "\nConversion Difference".yellow
             measure_user = User.find_by(_id: measure[:user_id])
             puts "Measure #{measure.cms_id}: #{measure.title} with id #{measure._id} in account #{measure_user.email}".light_blue
             diff.each_entry do |element|
               puts "--- #{element} --- Is different from CQL measure".light_blue
             end
+            fail_count += 1
           end
+        rescue StandardError => e
+          fail_count += 1
+          puts "\nMeasure  #{measure.title} #{measure.cms_id} with id #{measure._id} failed with message: #{e.message}".red
         rescue ExecJS::ProgramError => e
+          fail_count += 1
           # if there was a conversion failure we should record the resulting failure message with the measure
-          puts "Measure  #{measure.title} #{measure.cms_id} failed with message: #{e.message}".red
+          puts "\nMeasure  #{measure.title} #{measure.cms_id} with id #{measure._id} failed with message: #{e.message}".red
         end
       end
-      puts '**** Done converting ****'
+      puts "\n**** Done converting ****"
       puts "Successful Conversions: #{bonnie_cql_measures.count - fail_count}"
-      puts "Unsuccessful Conversion*: #{fail_count}"
-      puts "* - the converted measure exists, but the data is off in some way from the original CQL measure"
+      puts "Unsuccessful/Failed Conversions: #{fail_count}"
     end
 
     def self.measure_conversion_diff(cql_measure, cqm_measure)

--- a/lib/tasks/cql.rake
+++ b/lib/tasks/cql.rake
@@ -186,7 +186,9 @@ namespace :bonnie do
       calc_method = cql_measure[:episode_of_care] ? 'EPISODE_OF_CARE' : 'PATIENT'
       differences.push('calculation_method') if calc_method != cqm_measure['calculation_method']
 
-      differences.push('source_data_criteria') if cql_measure.source_data_criteria.count != cqm_measure.source_data_criteria.count
+      # Duplicate source data criteria are removed from the measure when converted, so this verification ensures that was done properly
+      unique_sdc = cql_measure.source_data_criteria.values.index_by { |sdc| [sdc['code_list_id'], sdc['description']] }
+      differences.push('source_data_criteria') if unique_sdc.length != cqm_measure.source_data_criteria.count
 
       if cql_measure[:composite]
         differences.push('composite') if !cqm_measure['composite']

--- a/lib/tasks/cql.rake
+++ b/lib/tasks/cql.rake
@@ -5,7 +5,6 @@ namespace :bonnie do
   namespace :cql do
 
     require 'colorize'
-    require 'byebug'
 
     desc %{Recreates the JSON elm stored on CQL measures using an instance of
       a locally running CQLTranslationService JAR.


### PR DESCRIPTION
A validation function was created to verify the measure converter rake task properly converted the measures into CQM format. All attributes were verified in detail except for "cql_libraries" which was only validated based on the number of elements, and "population_sets" which wasn't verified at all.

After running the rake task with the validator on the database collection of CQL measures, there were two validation notes that came up due to value sets. Here are the messages:

Conversion Difference
Measure CMS645v2: Bone density evaluation for patients with prostate cancer and receiving androgen deprivation therapy with _id 5a97f802b848467fb6a92e3c in account edeyoung@mitre.org
--- value_sets --- Is different from CQL measure
Conversion Difference
Measure CMSv0: mesg12 with _id 5bfe3673b84846165cd1d1fe in account rreddy@hcareis.com
--- value_sets --- Is different from CQL measure


Pull requests into Bonnie require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] JIRA ticket for this PR: https://jira.mitre.org/browse/BONNIE-1837
- [x] JIRA ticket links to this PR
- [x] Code diff has been done and been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] If UI changes have been made, google WAVE plug-in has been executed to ensure no 508 issues were introduced. - N/A
- [x] Tests are included and test edge cases - N/A
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Test fixtures updated and documented as necessary ( see [internal wiki](https://gitlab.mitre.org/bonnie/internal-documentation/wikis/testing#test-fixtures) ) - N/A
- [x] Code coverage has not gone down and all code touched or added is covered. 
     * In rare situations, this may not be possible or applicable to a PR. In those situations:
         1. Note why this could not be done or is not applicable here: 
         2. Add TODOs in the code noting that it requires a test
         3. Add a JIRA task to add the test and link it here: 
- [x] Automated regression test(s) pass - N/A


**Reviewer 1:**

Name: @losborne 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

**Reviewer 2:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

If JIRA tests were used to supplement or replace automated tests:
- [x] JIRA tests have been run and pass
- [x] You agree with the justification for use of JIRA tests or have provided input on why you disagree
