### PR TITLE
Truncate results in Excel Export cells

### DIFF
--- a/lib/patient_export.rb
+++ b/lib/patient_export.rb
@@ -232,8 +232,7 @@ class PatientExport
   # excel has a maximum character restriction on cells of 32,767 characters
   def self.truncate_result(result)
     if result.length >= 32700
-      result = result[0...32700]
-      result += " <Entry Truncated To Fit Cell>"
+      result[0...32700] + " <Entry Truncated To Fit Cell>"
     else
       result
     end

--- a/lib/patient_export.rb
+++ b/lib/patient_export.rb
@@ -48,7 +48,7 @@ class PatientExport
           white_right_border = styles.add_style(:border => { :style => :thin,:color => "FFFFFF", :edges => [:left, :right] })
 
           sheet.add_row(["\nKEY\n","",""], style: key_title_style, height: 55)
-          sheet.add_row(["NOTE: FALSE(...) indicates a false value. The type of falseness is specified in the parentheses.\nFor example, FALSE([]) indicates falseness due to an empty list.","",""], 
+          sheet.add_row(["NOTE: FALSE(...) indicates a false value. The type of falseness is specified in the parentheses.\nFor example, FALSE([]) indicates falseness due to an empty list.\nCells that are too long will be truncated due to limitations in Excel.","",""], 
                         style: false_info_style, height: 70)
           sheet.merge_cells("A1:C1") 
           sheet.merge_cells("A2:C2")

--- a/lib/patient_export.rb
+++ b/lib/patient_export.rb
@@ -143,7 +143,7 @@ class PatientExport
                   # Fortunately we want to ignore those results, so we can just skip results that
                   # dont have corresponding details from the measure.
                   next if statement_details.dig(lib_key,statement).nil?
-                  header_row.push(statement_details[lib_key][statement])
+                  header_row.push(truncate_result(statement_details[lib_key][statement]))
                   statement_to_column[statement] = cur_column
                   cur_column = cur_column + 1
                 end
@@ -202,7 +202,7 @@ class PatientExport
                     if result.eql? "UNHIT"
                       statement_results[statement_to_column[statement]] = "Not Calculated"
                     else
-                      statement_results[statement_to_column[statement]] = result
+                      statement_results[statement_to_column[statement]] = truncate_result(result)
                     end
                   end
                 end
@@ -226,6 +226,16 @@ class PatientExport
           pop_index = pop_index + 1
         end
       end
+    end
+  end
+
+  # excel has a maximum character restriction on cells of 32,767 characters
+  def self.truncate_result(result)
+    if result.length >= 32700
+      result = result[0...32700]
+      result += " <Entry Truncated To Fit Cell>"
+    else
+      result
     end
   end
 

--- a/test/unit/helpers/excel_export_helper_test.rb
+++ b/test/unit/helpers/excel_export_helper_test.rb
@@ -1,6 +1,8 @@
 require 'test_helper'
 require './app/helpers/excel_export_helper'
 require './app/helpers/patient_helper'
+require './lib/patient_export'
+
 class ExcelExportHelperTest < ActionController::TestCase
   include Devise::Test::ControllerHelpers
 
@@ -191,6 +193,19 @@ class ExcelExportHelperTest < ActionController::TestCase
     frontend_excel_spreadsheet = Roo::Spreadsheet.open(frontend_excel_file.path)
 
     compare_excel_spreadsheets(backend_excel_spreadsheet, frontend_excel_spreadsheet, patient_details.keys.length)
+  end
+
+  test 'result truncation truncates long strings' do
+    long_string = 'a' * 400000
+    truncated_string = PatientExport.truncate_result(long_string)
+    assert true, truncated_string.length < 32700
+    assert true, (truncated_string.include? 'Entry Truncated To Fit Cell')
+  end
+
+  test 'result truncation doesnt truncate short strings' do
+    short_string = 'short_string'
+    truncated_string = PatientExport.truncate_result(short_string)
+    assert_equal short_string, truncated_string
   end
 
   def get_results_with_failed_patients(patients, results)

--- a/test/unit/helpers/excel_export_helper_test.rb
+++ b/test/unit/helpers/excel_export_helper_test.rb
@@ -198,7 +198,8 @@ class ExcelExportHelperTest < ActionController::TestCase
   test 'result truncation truncates long strings' do
     long_string = 'a' * 400000
     truncated_string = PatientExport.truncate_result(long_string)
-    assert_equal true, truncated_string.length < 32700
+    # excel has a maximum character restriction on cells of 32,767 characters
+    assert_equal true, truncated_string.length < 32767
     assert_equal true, (truncated_string.include? 'Entry Truncated To Fit Cell')
   end
 

--- a/test/unit/helpers/excel_export_helper_test.rb
+++ b/test/unit/helpers/excel_export_helper_test.rb
@@ -198,8 +198,8 @@ class ExcelExportHelperTest < ActionController::TestCase
   test 'result truncation truncates long strings' do
     long_string = 'a' * 400000
     truncated_string = PatientExport.truncate_result(long_string)
-    assert true, truncated_string.length < 32700
-    assert true, (truncated_string.include? 'Entry Truncated To Fit Cell')
+    assert_equal true, truncated_string.length < 32700
+    assert_equal true, (truncated_string.include? 'Entry Truncated To Fit Cell')
   end
 
   test 'result truncation doesnt truncate short strings' do


### PR DESCRIPTION
Truncate column names and results that are too long to fit in excel cells.

Pull requests into Bonnie require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] JIRA ticket for this PR: https://jira.mitre.org/browse/BONNIE-1985
- [x] JIRA ticket links to this PR
- [x] Code diff has been done and been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] If UI changes have been made, google WAVE plug-in has been executed to ensure no 508 issues were introduced. NA
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Test fixtures updated and documented as necessary ( see [internal wiki](https://gitlab.mitre.org/bonnie/internal-documentation/wikis/testing#test-fixtures) )
- [x] Code coverage has not gone down and all code touched or added is covered. 
     * In rare situations, this may not be possible or applicable to a PR. In those situations:
         1. Note why this could not be done or is not applicable here: 
         2. Add TODOs in the code noting that it requires a test
         3. Add a JIRA task to add the test and link it here: 
- [x] Automated regression test(s) pass (2 misaligned columns, one good regression)
![image](https://user-images.githubusercontent.com/3967953/57474768-df486000-7260-11e9-8168-37530de71f88.png)

If JIRA tests were used to supplement or replace automated tests:
- [x] JIRA test links:
- [x] Justification for using JIRA tests:
- [x] JIRA tests have been added to sprint


**Reviewer 1:**

Name: @losborne 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

If JIRA tests were used to supplement or replace automated tests:
- [x] JIRA tests have been run and pass
- [x] You agree with the justification for use of JIRA tests or have provided input on why you disagree


**Reviewer 2:**

Name: @hackrm 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

If JIRA tests were used to supplement or replace automated tests:
- [x] JIRA tests have been run and pass
- [x] You agree with the justification for use of JIRA tests or have provided input on why you disagree
