### PR TITLE
add .codecov.yml with coverage thresholds

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,31 @@
+codecov:
+  notify:
+    require_ci_to_pass: yes
+
+coverage:
+  precision: 2
+  round: nearest
+  range: "60...90"
+
+  status:
+    project:
+			default:
+				threshold: 0.2%
+				target: 52.03%
+    patch:
+      default:
+        target: 52.03%
+
+parsers:
+  gcov:
+    branch_detection:
+      conditional: yes
+      loop: yes
+      method: no
+      macro: no
+
+comment:
+  layout: "header, diff"
+  behavior: default
+  require_changes: no
+

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -7,14 +7,14 @@ coverage:
   round: nearest
   range: "60...90"
 
-  status:
-    project:
-			default:
-				threshold: 0.2%
-				target: 52.03%
-    patch:
-      default:
-        target: 52.03%
+status:
+  project:
+    default:
+      threshold: 0.2%
+      target: 52.03%
+  patch:
+    default:
+      target: 52.03%
 
 parsers:
   gcov:


### PR DESCRIPTION
Add codecov.yml to set coverage thresholds

Pull requests into Bonnie require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

- [x] https://github.com/projecttacoma/bonnie/pull/1254 fails due to codecov threshold not met

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] JIRA ticket for this PR: https://jira.mitre.org/browse/BONNIE-2061
- [x] JIRA ticket links to this PR
- [x] Code diff has been done and been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] If UI changes have been made, google WAVE plug-in has been executed to ensure no 508 issues were introduced.
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Test fixtures updated and documented as necessary ( see [internal wiki](https://gitlab.mitre.org/bonnie/internal-documentation/wikis/testing#test-fixtures) )
- [x] Code coverage has not gone down and all code touched or added is covered. 
     * In rare situations, this may not be possible or applicable to a PR. In those situations:
         1. Note why this could not be done or is not applicable here: 
         2. Add TODOs in the code noting that it requires a test
         3. Add a JIRA task to add the test and link it here: 
- [x] Automated regression test(s) pass

**Reviewer 1:**

Name: @jbradl11 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
