### PR TITLE
Improve measure loading error message and fix display in html

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,7 @@ gem 'bonnie_bundler', :git => 'https://github.com/projecttacoma/bonnie_bundler.g
 # gem 'quality-measure-engine', :git => 'https://github.com/projectcypress/quality-measure-engine.git', :branch => 'master'
 # gem 'hquery-patient-api', :git => 'https://github.com/projecttacoma/patientapi.git', :branch => 'master'
 gem 'cqm-converter', :git => 'https://github.com/projecttacoma/cqm-converter', :branch => 'master'
-gem 'cqm-parsers', :git => 'https://github.com/projecttacoma/cqm-parsers', :branch => 'bonnie_version'
+gem 'cqm-parsers', :git => 'https://github.com/projecttacoma/cqm-parsers', :branch => 'improve-error-message'
 gem 'cqm-models', :git => 'https://github.com/projecttacoma/cqm-models', :branch => 'master'
 
 # gem 'health-data-standards', :path => '../health-data-standards'

--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,7 @@ gem 'bonnie_bundler', :git => 'https://github.com/projecttacoma/bonnie_bundler.g
 # gem 'quality-measure-engine', :git => 'https://github.com/projectcypress/quality-measure-engine.git', :branch => 'master'
 # gem 'hquery-patient-api', :git => 'https://github.com/projecttacoma/patientapi.git', :branch => 'master'
 gem 'cqm-converter', :git => 'https://github.com/projecttacoma/cqm-converter', :branch => 'master'
-gem 'cqm-parsers', :git => 'https://github.com/projecttacoma/cqm-parsers', :branch => 'improve-error-message'
+gem 'cqm-parsers', :git => 'https://github.com/projecttacoma/cqm-parsers', :branch => 'bonnie_version'
 gem 'cqm-models', :git => 'https://github.com/projecttacoma/cqm-models', :branch => 'master'
 
 # gem 'health-data-standards', :path => '../health-data-standards'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,8 +56,8 @@ GIT
 
 GIT
   remote: https://github.com/projecttacoma/cqm-parsers
-  revision: 0049a1fbc3c08bb01bce5637608bc7ecab466333
-  branch: bonnie_version
+  revision: ba0f15bf689d72010f5dc5134216fdf7cb78a499
+  branch: improve-error-message
   specs:
     cqm-parsers (0.2.1)
       activesupport (~> 4.2.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,8 +56,8 @@ GIT
 
 GIT
   remote: https://github.com/projecttacoma/cqm-parsers
-  revision: ba0f15bf689d72010f5dc5134216fdf7cb78a499
-  branch: improve-error-message
+  revision: 717f2e1fc930e23dc97bf62fbd38ea7df0963c47
+  branch: bonnie_version
   specs:
     cqm-parsers (0.2.1)
       activesupport (~> 4.2.0)

--- a/app/helpers/measure_helper.rb
+++ b/app/helpers/measure_helper.rb
@@ -82,7 +82,8 @@ module MeasureHelper
       }
       if details.present?
         back_end_version[:json][:details] = details
-        front_end_version[:body] += " Details: #{details}"
+        # Strip off the <#RuntimeError: ... > from the details because it causes issues in html
+        front_end_version[:body] += " Details: #{details.sub(/^#<.*Error: /, '').sub(/>$/, '')}"
       end
       super(front_end_version: front_end_version, back_end_version: back_end_version)
     end


### PR DESCRIPTION
Fix measure loading error message so it doesn't just say `Details:#`
Can see error with `bonnie/test/fixtures/cql_measure_exports/DocofMeds_v5_1_Artifacts.zip`

Pull requests into Bonnie require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

- [x] Update Gemfile after https://github.com/projecttacoma/cqm-parsers/pull/52 is merged

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] JIRA ticket for this PR: N/A
- [x] JIRA ticket links to this PR N/A
- [x] Code diff has been done and been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] If UI changes have been made, google WAVE plug-in has been executed to ensure no 508 issues were introduced.
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Test fixtures updated and documented as necessary ( see [internal wiki](https://gitlab.mitre.org/bonnie/internal-documentation/wikis/testing#test-fixtures) )
- [x] Code coverage has not gone down and all code touched or added is covered. 
- [x] Automated regression test(s) pass N/A

**Reviewer 1:**

Name: @hackrm 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
