### PR TITLE
Ratio/Quantity Constructor updates

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,7 +49,7 @@ GIT
 
 GIT
   remote: https://github.com/projecttacoma/cqm-models
-  revision: b2b5856295755ac4324d8326588cf9d18ae6fe98
+  revision: 26e00e673714b41e3f88ae8304fff4ca8378864a
   branch: master
   specs:
     cqm-models (2.0.0)

--- a/app/assets/javascripts/views/patient_builder/data_criteria_attribute_display.js.coffee
+++ b/app/assets/javascripts/views/patient_builder/data_criteria_attribute_display.js.coffee
@@ -37,7 +37,8 @@ class Thorax.Views.DataCriteriaAttributeDisplayView extends Thorax.Views.BonnieV
     # DateTime or Time
     else if value.isDateTime
       if value.isTime() # if it is a "Time"
-        return moment.utc(value.toJSDate()).format('LT')
+        # The year, month, day get discarded so don't matter
+        return moment(new Date(2012, 1, 1, value.hour, value.minute, value.second)).format('LT')
       else
         return moment.utc(value.toJSDate()).format('L LT')
 

--- a/app/assets/javascripts/views/patient_builder/inputs/quantity.js.coffee
+++ b/app/assets/javascripts/views/patient_builder/inputs/quantity.js.coffee
@@ -33,7 +33,7 @@ class Thorax.Views.InputQuantityView extends Thorax.Views.BonnieView
   handleInputChange: (e) ->
     inputData = @serialize()
     try
-      @value = new cqm.models.CQL.Quantity(value: inputData.value_value, unit: inputData.value_unit)
+      @value = new cqm.models.CQL.Quantity(parseFloat(inputData.value_value), inputData.value_unit)
       @$('.quantity-control-unit').removeClass('has-error')
     catch error
       @value = null

--- a/app/assets/javascripts/views/patient_builder/inputs/ratio.js.coffee
+++ b/app/assets/javascripts/views/patient_builder/inputs/ratio.js.coffee
@@ -23,7 +23,7 @@ class Thorax.Views.InputRatioView extends Thorax.Views.BonnieView
 
   updateValueFromSubviews: ->
     if @numeratorView.hasValidValue() && @denominatorView.hasValidValue()
-      @value = new cqm.models.CQL.Ratio(numerator: @numeratorView.value, denominator: @denominatorView.value)
+      @value = new cqm.models.CQL.Ratio(@numeratorView.value, @denominatorView.value)
     else
       @value = null
     @trigger 'valueChanged', @

--- a/app/assets/javascripts/views/patient_builder/inputs/time.js.coffee
+++ b/app/assets/javascripts/views/patient_builder/inputs/time.js.coffee
@@ -36,7 +36,10 @@ class Thorax.Views.InputTimeView extends Thorax.Views.BonnieView
     else
       end = ' PM'
 
-    timeString = time.hour + ':' + time.minute + end
+    # Pad hour/minute if only 1 digit
+    paddedHour = String("0" + time.hour).slice(-2)
+    paddedMin = String("0" + time.minute).slice(-2)
+    timeString = paddedHour + ':' + paddedMin + end
     timeString
 
   context: ->

--- a/app/assets/javascripts/views/patient_builder/inputs/time.js.coffee
+++ b/app/assets/javascripts/views/patient_builder/inputs/time.js.coffee
@@ -21,16 +21,28 @@ class Thorax.Views.InputTimeView extends Thorax.Views.BonnieView
       @$('.time-picker').timepicker(template: false, defaultTime: false).on 'changeTime.timepicker', _.bind(@handleChange, this)
 
   createDefault: ->
-    todayInMP = new Date()
-    todayInMP.setYear(@defaultYear)
+    time = new cqm.models.CQL.DateTime(2000, 1, 1, 8, 0, 0, 0, 0).getTime()
+    @getTimeString(time)
 
-    # create CQL Times
-    return new cqm.models.CQL.DateTime(2000, 1, 1, 8, 0, 0, 0, 0).getTime()
+  getTimeString:  (time) ->
+    # Build time string with format HH:MM PP
+    isAm = true
+    if time.hour >= 12
+      isAm = false
+      time.hour = time.hour - 12
+
+    if isAm
+      end = ' AM'
+    else
+      end = ' PM'
+
+    timeString = time.hour + ':' + time.minute + end
+    timeString
 
   context: ->
     _(super).extend
       time_is_defined: @value?
-      time: moment.utc(@value.toJSDate()).format('LT') if @value?
+      time: @getTimeString(@value) if @value?
 
   # checks if the value in this view is valid. returns true or false. this is used by the attribute entry view to determine
   # if the add button should be active or not
@@ -43,9 +55,9 @@ class Thorax.Views.InputTimeView extends Thorax.Views.BonnieView
     # check the status of the checkbox and disable/enable fields
     if @$("input[name='time_is_defined']").prop("checked")
       @$("input[name='time']").prop('disabled', false)
-      defaultDate = @createDefault()
-      @$("input[name='time']").val(moment.utc(defaultDate.toJSDate()).format('LT'))
-      @$("input[name='time']").timepicker('setTime', moment.utc(defaultDate.toJSDate()).format('LT'))
+      defaultTime = @createDefault()
+      @$("input[name='time']").val(defaultTime)
+      @$("input[name='time']").timepicker('setTime', defaultTime)
     else
       @$("input[name='time']").prop('disabled', true).val("")
 

--- a/spec/javascripts/patient_builder_tests/input_views/interval_quantity_input_view_spec.js.coffee
+++ b/spec/javascripts/patient_builder_tests/input_views/interval_quantity_input_view_spec.js.coffee
@@ -24,27 +24,33 @@ describe 'InputView', ->
       expect(view.trigger).toHaveBeenCalledWith('valueChanged', view)
       expect(view.hasValidValue()).toBe true
       expect(view.value).toEqual new cqm.models.CQL.Interval(
-        new cqm.models.CQL.Quantity(value: 200, unit: 'mg'),
-        new cqm.models.CQL.Quantity(value: 400, unit: ''))
+        new cqm.models.CQL.Quantity(200, 'mg'),
+        new cqm.models.CQL.Quantity(400, ''))
 
       view.$('.quantity-interval-end input[name="value_unit"]').val('mg').change()
       expect(view.trigger).toHaveBeenCalledWith('valueChanged', view)
       expect(view.hasValidValue()).toBe true
-      expect(view.value).toEqual new cqm.models.CQL.Interval(
-        new cqm.models.CQL.Quantity(value: 200, unit: 'mg'),
-        new cqm.models.CQL.Quantity(value: 400, unit: 'mg'))
+      expected = new cqm.models.CQL.Interval(new cqm.models.CQL.Quantity(200, 'mg'), new cqm.models.CQL.Quantity(400, 'mg'))
+      expect(view.value.high.value).toEqual(expected.high.value)
+      expect(view.value.high.unit).toEqual(expected.high.unit)
+      expect(view.value.low.value).toEqual(expected.low.value)
+      expect(view.value.low.unit).toEqual(expected.low.unit)
 
     it 'starts with initial quantity and becomes invalid after bad unit entry, valid again after fix', ->
       view = new Thorax.Views.InputIntervalQuantityView(initialValue: new cqm.models.CQL.Interval(
-        new cqm.models.CQL.Quantity(value: 200, unit: 'mg')
-        new cqm.models.CQL.Quantity(value: 400, unit: 'mg')))
+        new cqm.models.CQL.Quantity(200, 'mg')
+        new cqm.models.CQL.Quantity(400, 'mg')))
       view.render()
       spyOn(view, 'trigger')
 
       expect(view.hasValidValue()).toBe true
-      expect(view.value).toEqual new cqm.models.CQL.Interval(
-        new cqm.models.CQL.Quantity(value: 200, unit: 'mg')
-        new cqm.models.CQL.Quantity(value: 400, unit: 'mg'))
+      expected = new cqm.models.CQL.Interval(
+        new cqm.models.CQL.Quantity(200, 'mg')
+        new cqm.models.CQL.Quantity(400, 'mg'))
+      expect(view.value.high.value).toEqual(expected.high.value)
+      expect(view.value.high.unit).toEqual(expected.high.unit)
+      expect(view.value.low.value).toEqual(expected.low.value)
+      expect(view.value.low.unit).toEqual(expected.low.unit)
       expect(view.$('.quantity-interval-start input[name="value_value"]').val()).toEqual '200'
       expect(view.$('.quantity-interval-start input[name="value_unit"]').val()).toEqual 'mg'
       expect(view.$('.quantity-interval-end input[name="value_value"]').val()).toEqual '400'
@@ -61,19 +67,26 @@ describe 'InputView', ->
       view.$('.quantity-interval-end input[name="value_unit"]').val('kg').change()
       expect(view.trigger).toHaveBeenCalledWith('valueChanged', view)
       expect(view.hasValidValue()).toBe true
-      expect(view.value).toEqual new cqm.models.CQL.Interval(
-        new cqm.models.CQL.Quantity(value: 200, unit: 'mg')
-        new cqm.models.CQL.Quantity(value: 400, unit: 'kg'))
+      expected = new cqm.models.CQL.Interval(
+        new cqm.models.CQL.Quantity(200, 'mg')
+        new cqm.models.CQL.Quantity(400, 'kg'))
+      expect(view.value.high.value).toEqual(expected.high.value)
+      expect(view.value.high.unit).toEqual(expected.high.unit)
+      expect(view.value.low.value).toEqual(expected.low.value)
+      expect(view.value.low.unit).toEqual(expected.low.unit)
 
     it 'starts with initial quantity with no low value', ->
       view = new Thorax.Views.InputIntervalQuantityView(initialValue: new cqm.models.CQL.Interval(
-        null, new cqm.models.CQL.Quantity(value: 400, unit: 'mg')))
+        null, new cqm.models.CQL.Quantity(400, 'mg')))
       view.render()
       spyOn(view, 'trigger')
 
       expect(view.hasValidValue()).toBe true
-      expect(view.value).toEqual new cqm.models.CQL.Interval(
-        null, new cqm.models.CQL.Quantity(value: 400, unit: 'mg'))
+      expected = new cqm.models.CQL.Interval(
+        null, new cqm.models.CQL.Quantity(400, 'mg'))
+      expect(view.value.low).toBeNull()
+      expect(view.value.high.value).toEqual(expected.high.value)
+      expect(view.value.high.unit).toEqual(expected.high.unit)
       expect(view.$('input[name="low_quantity_is_defined"]').prop('checked')).toBe false
       expect(view.$('.quantity-interval-start input[name="value_value"]').val()).toEqual ''
       expect(view.$('.quantity-interval-start input[name="value_value"]').prop('disabled')).toBe true
@@ -87,13 +100,16 @@ describe 'InputView', ->
 
     it 'starts with initial quantity with no high value', ->
       view = new Thorax.Views.InputIntervalQuantityView(initialValue: new cqm.models.CQL.Interval(
-        new cqm.models.CQL.Quantity(value: 400, unit: 'mg'), null))
+        new cqm.models.CQL.Quantity(400, 'mg'), null))
       view.render()
       spyOn(view, 'trigger')
 
       expect(view.hasValidValue()).toBe true
-      expect(view.value).toEqual new cqm.models.CQL.Interval(
-        new cqm.models.CQL.Quantity(value: 400, unit: 'mg'), null)
+      expected = new cqm.models.CQL.Interval(
+        new cqm.models.CQL.Quantity(400, 'mg'), null)
+      expect(view.value.low.value).toEqual(expected.low.value)
+      expect(view.value.low.unit).toEqual(expected.low.unit)
+      expect(view.value.high).toBeNull()
       expect(view.$('input[name="low_quantity_is_defined"]').prop('checked')).toBe true
       expect(view.$('.quantity-interval-start input[name="value_value"]').val()).toEqual '400'
       expect(view.$('.quantity-interval-start input[name="value_value"]').prop('disabled')).toBe false
@@ -107,8 +123,8 @@ describe 'InputView', ->
 
     it 'starts with initial quantity with defined ends, and becomes [null, null] after check boxes', ->
       view = new Thorax.Views.InputIntervalQuantityView(initialValue: new cqm.models.CQL.Interval(
-        new cqm.models.CQL.Quantity(value: 200, unit: 'mg')
-        new cqm.models.CQL.Quantity(value: 400, unit: 'mg')))
+        new cqm.models.CQL.Quantity(200, 'mg')
+        new cqm.models.CQL.Quantity(400, 'mg')))
       view.render()
       spyOn(view, 'trigger')
 
@@ -117,8 +133,11 @@ describe 'InputView', ->
       expect(view.trigger).toHaveBeenCalledWith('valueChanged', view)
       expect(view.$('.quantity-interval-start input[name="value_value"]').prop('disabled')).toBe true
       expect(view.$('.quantity-interval-start input[name="value_unit"]').prop('disabled')).toBe true
-      expect(view.value).toEqual new cqm.models.CQL.Interval(
-        null, new cqm.models.CQL.Quantity(value: 400, unit: 'mg'))
+      expected = new cqm.models.CQL.Interval(
+        null, new cqm.models.CQL.Quantity(400, 'mg'))
+      expect(view.value.high.value).toEqual(expected.high.value)
+      expect(view.value.high.unit).toEqual(expected.high.unit)
+      expect(view.value.low).toBeNull()
 
       # uncheck high quantity
       view.$('input[name="high_quantity_is_defined"]').prop('checked', false).change()

--- a/spec/javascripts/patient_builder_tests/input_views/quantity_input_view_spec.js.coffee
+++ b/spec/javascripts/patient_builder_tests/input_views/quantity_input_view_spec.js.coffee
@@ -13,20 +13,20 @@ describe 'InputView', ->
       view.$('input[name="value_value"]').val('200').change()
       expect(view.trigger).toHaveBeenCalledWith('valueChanged', view)
       expect(view.hasValidValue()).toBe true
-      expect(view.value).toEqual new cqm.models.CQL.Quantity(value: 200, unit: '')
+      expect(view.value).toEqual new cqm.models.CQL.Quantity(200, '')
 
       view.$('input[name="value_unit"]').val('mg').change()
       expect(view.trigger).toHaveBeenCalledWith('valueChanged', view)
       expect(view.hasValidValue()).toBe true
-      expect(view.value).toEqual new cqm.models.CQL.Quantity(value: 200, unit: 'mg')
-    
+      expect(view.value).toEqual new cqm.models.CQL.Quantity(200, 'mg')
+
     it 'starts with initial quantity and becomes invalid after bad unit entry, valid again after fix', ->
-      view = new Thorax.Views.InputQuantityView(initialValue: new cqm.models.CQL.Quantity(value: 200, unit: 'm'))
+      view = new Thorax.Views.InputQuantityView(initialValue: new cqm.models.CQL.Quantity(200, 'm'))
       view.render()
       spyOn(view, 'trigger')
 
       expect(view.hasValidValue()).toBe true
-      expect(view.value).toEqual new cqm.models.CQL.Quantity(value: 200, unit: 'm')
+      expect(view.value).toEqual new cqm.models.CQL.Quantity(200, 'm')
       expect(view.$('input[name="value_value"]').val()).toEqual '200'
       expect(view.$('input[name="value_unit"]').val()).toEqual 'm'
 
@@ -42,7 +42,7 @@ describe 'InputView', ->
       expect(view.trigger).toHaveBeenCalledWith('valueChanged', view)
       expect(view.$('.quantity-control-unit').hasClass('has-error')).toBe false
       expect(view.hasValidValue()).toBe true
-      expect(view.value).toEqual new cqm.models.CQL.Quantity(value: 200, unit: 'cm')
+      expect(view.value).toEqual new cqm.models.CQL.Quantity(200, 'cm')
     
     it 'can disable and enable all entry fields', ->
       view = new Thorax.Views.InputQuantityView()

--- a/spec/javascripts/patient_builder_tests/input_views/ratio_input_view_spec.js.coffee
+++ b/spec/javascripts/patient_builder_tests/input_views/ratio_input_view_spec.js.coffee
@@ -23,29 +23,32 @@ describe 'InputView', ->
       view.$('.ratio-denominator input[name="value_value"]').val('1').change()
       expect(view.trigger).toHaveBeenCalledWith('valueChanged', view)
       expect(view.hasValidValue()).toBe true
-      expect(view.value).toEqual new cqm.models.CQL.Ratio(
-        numerator: new cqm.models.CQL.Quantity(value: 200, unit: 'mg')
-        denominator: new cqm.models.CQL.Quantity(value: 1, unit: ''))
+      expected = new cqm.models.CQL.Ratio(new cqm.models.CQL.Quantity(200, 'mg'), new cqm.models.CQL.Quantity(1, ''))
+      expect(view.value.numerator.value).toEqual(expected.numerator.value)
+      expect(view.value.numerator.unit).toEqual(expected.numerator.unit)
+      expect(view.value.denominator.value).toEqual(expected.denominator.value)
+      expect(view.value.denominator.unit).toEqual(expected.denominator.unit)
 
       view.$('.ratio-denominator input[name="value_unit"]').val('L').change()
       expect(view.trigger).toHaveBeenCalledWith('valueChanged', view)
       expect(view.hasValidValue()).toBe true
-      expect(view.value).toEqual new cqm.models.CQL.Ratio(
-        numerator: new cqm.models.CQL.Quantity(value: 200, unit: 'mg')
-        denominator: new cqm.models.CQL.Quantity(value: 1, unit: 'L'))
-    
-    
+      expected = new cqm.models.CQL.Ratio(new cqm.models.CQL.Quantity(200, 'mg'), new cqm.models.CQL.Quantity(1, 'L'))
+      expect(view.value.numerator.value).toEqual(expected.numerator.value)
+      expect(view.value.numerator.unit).toEqual(expected.numerator.unit)
+      expect(view.value.denominator.value).toEqual(expected.denominator.value)
+      expect(view.value.denominator.unit).toEqual(expected.denominator.unit)
+
     it 'starts with initial quantity and becomes invalid after bad unit entry, valid again after fix', ->
-      view = new Thorax.Views.InputRatioView(initialValue: new cqm.models.CQL.Ratio(
-        numerator: new cqm.models.CQL.Quantity(value: 200, unit: 'mg')
-        denominator: new cqm.models.CQL.Quantity(value: 1, unit: 'L')))
+      view = new Thorax.Views.InputRatioView(initialValue: new cqm.models.CQL.Ratio(new cqm.models.CQL.Quantity(200, 'mg'), new cqm.models.CQL.Quantity(1, 'L')))
       view.render()
       spyOn(view, 'trigger')
 
       expect(view.hasValidValue()).toBe true
-      expect(view.value).toEqual new cqm.models.CQL.Ratio(
-        numerator: new cqm.models.CQL.Quantity(value: 200, unit: 'mg')
-        denominator: new cqm.models.CQL.Quantity(value: 1, unit: 'L'))
+      expected = new cqm.models.CQL.Ratio(new cqm.models.CQL.Quantity(200, 'mg'), new cqm.models.CQL.Quantity(1, 'L'))
+      expect(view.value.numerator.value).toEqual(expected.numerator.value)
+      expect(view.value.numerator.unit).toEqual(expected.numerator.unit)
+      expect(view.value.denominator.value).toEqual(expected.denominator.value)
+      expect(view.value.denominator.unit).toEqual(expected.denominator.unit)
       expect(view.$('.ratio-numerator input[name="value_value"]').val()).toEqual '200'
       expect(view.$('.ratio-numerator input[name="value_unit"]').val()).toEqual 'mg'
       expect(view.$('.ratio-denominator input[name="value_value"]').val()).toEqual '1'
@@ -62,6 +65,8 @@ describe 'InputView', ->
       view.$('.ratio-numerator input[name="value_unit"]').val('kg').change()
       expect(view.trigger).toHaveBeenCalledWith('valueChanged', view)
       expect(view.hasValidValue()).toBe true
-      expect(view.value).toEqual new cqm.models.CQL.Ratio(
-        numerator: new cqm.models.CQL.Quantity(value: 200, unit: 'kg')
-        denominator: new cqm.models.CQL.Quantity(value: 1, unit: 'L'))
+      expected = new cqm.models.CQL.Ratio(new cqm.models.CQL.Quantity(200, 'kg'), new cqm.models.CQL.Quantity(1, 'L'))
+      expect(view.value.numerator.value).toEqual(expected.numerator.value)
+      expect(view.value.numerator.unit).toEqual(expected.numerator.unit)
+      expect(view.value.denominator.value).toEqual(expected.denominator.value)
+      expect(view.value.denominator.unit).toEqual(expected.denominator.unit)

--- a/spec/javascripts/patient_builder_tests/input_views/time_input_view_spec.js.coffee
+++ b/spec/javascripts/patient_builder_tests/input_views/time_input_view_spec.js.coffee
@@ -9,7 +9,7 @@ describe 'InputView', ->
       expect(view.value).toBe null
       expect(view.$el.find("input[name='time_is_defined']").prop('checked')).toBe false
       expect(view.$el.find("input[name='time']").val()).toEqual ""
-    
+
     it 'can start with no value, not allowing null', ->
       view = new Thorax.Views.InputTimeView(allowNull: false)
       view.render()
@@ -24,7 +24,7 @@ describe 'InputView', ->
       view = new Thorax.Views.InputTimeView(initialValue: time)
       view.render()
       expect(view.hasValidValue()).toBe true
-      expect(view.value).toEqual new cqm.models.CQL.DateTime(0, 1, 1, 8, 15, 0, 0, 0)
+      expect(view.value).toEqual new cqm.models.CQL.DateTime(0, 1, 1, 8, 15, 0, 0, null)
       expect(view.$el.find("input[name='time_is_defined']").prop('checked')).toBe true
       expect(view.$el.find("input[name='time']").val()).toEqual "8:15 AM"
 
@@ -40,7 +40,7 @@ describe 'InputView', ->
       expect(view.trigger).toHaveBeenCalledWith('valueChanged', view)
       expect(view.hasValidValue()).toBe true
       expect(view.$el.find("input[name='time']").val()).toEqual "8:00 AM"
-      expect(view.value).toEqual new cqm.models.CQL.DateTime(0, 1, 1, 8, 0, 0, 0, 0)
+      expect(view.value).toEqual new cqm.models.CQL.DateTime(0, 1, 1, 8, 0, 0, 0, null)
 
     it 'can start with a value, not allowing null, then unchecked to be null', ->
       date = new cqm.models.CQL.DateTime(2012, 2, 23, 8, 15, 0, 0, 0)
@@ -67,4 +67,4 @@ describe 'InputView', ->
       view.$el.find("input[name='time']").val('9:45 AM').timepicker('setTime', '9:45 AM')
       expect(view.trigger).toHaveBeenCalledWith('valueChanged', view)
       expect(view.hasValidValue()).toBe true
-      expect(view.value).toEqual new cqm.models.CQL.DateTime(0, 1, 1, 9, 45, 0, 0, 0)
+      expect(view.value).toEqual new cqm.models.CQL.DateTime(0, 1, 1, 9, 45, 0, 0, null)

--- a/yarn.lock
+++ b/yarn.lock
@@ -326,17 +326,16 @@ core-util-is@~1.0.0:
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
   integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
 
-cql-execution@^1.3.3:
+"cql-execution@https://github.com/cqframework/cql-execution":
   version "1.3.4"
-  resolved "https://registry.yarnpkg.com/cql-execution/-/cql-execution-1.3.4.tgz#8b9be14756062318be708533436674675b1c5cfc"
-  integrity sha512-o0NxnrrWke5mQLco+8CBl/9T8PtQtDsuvJcwi4D9j//IhTlU2xjbuZxfrTo9D7nS85RuhAHJwpXqoAXcSaE6cg==
+  resolved "https://github.com/cqframework/cql-execution#cf599c9720b5f0d1338d838d3059b11f52b9b91e"
   dependencies:
     moment "^2.20.1"
     ucum "0.0.7"
 
 "cqm-execution@https://github.com/projecttacoma/cqm-execution":
   version "2.0.0"
-  resolved "https://github.com/projecttacoma/cqm-execution#8c3d12486a766b6878aa6315cd2863075822f249"
+  resolved "https://github.com/projecttacoma/cqm-execution#4fde9dfe4aac01a265d11c92d65165a0ef2c5937"
   dependencies:
     cqm-models "https://github.com/projecttacoma/cqm-models"
     lodash "^4.17.5"
@@ -344,9 +343,9 @@ cql-execution@^1.3.3:
 
 "cqm-models@https://github.com/projecttacoma/cqm-models":
   version "2.0.0"
-  resolved "https://github.com/projecttacoma/cqm-models#b2b5856295755ac4324d8326588cf9d18ae6fe98"
+  resolved "https://github.com/projecttacoma/cqm-models#26e00e673714b41e3f88ae8304fff4ca8378864a"
   dependencies:
-    cql-execution "^1.3.3"
+    cql-execution "https://github.com/cqframework/cql-execution"
     mongoose "^5.4.14"
 
 create-ecdh@^4.0.0:


### PR DESCRIPTION
Updates to Ratio/Quantity constructors from cql-execution changes

Also Update InputTimeView with changes to cql Time (timezoneoffset removal)

Pull requests into Bonnie require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:

- [x] Update cqm-models reference
- [x] Update cqm-execution reference

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] JIRA ticket for this PR:
- [x] JIRA ticket links to this PR
- [x] Code diff has been done and been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] If UI changes have been made, google WAVE plug-in has been executed to ensure no 508 issues were introduced.
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Test fixtures updated and documented as necessary ( see [internal wiki](https://gitlab.mitre.org/bonnie/internal-documentation/wikis/testing#test-fixtures) )
- [x] Code coverage has not gone down and all code touched or added is covered. 
- [x] Automated regression test(s) pass N/A


**Reviewer 1:**

Name: @jbradl11 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

**Reviewer 2:**

Name: @hossenlopp 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code