### PR TITLE
Updated patientapi

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ gem 'hquery-patient-api', '~> 1.1'
 # gem 'cqm-parsers', '~> 0.2.1'
 
 # gem 'health-data-standards', :git => 'https://github.com/projectcypress/health-data-standards.git', :branch => 'master_bonnie'
-gem 'cql_qdm_patientapi', :git => 'https://github.com/projecttacoma/cql_qdm_patientapi.git', :branch => 'master'
+gem 'cql_qdm_patientapi', :git => 'https://github.com/projecttacoma/cql_qdm_patientapi.git', :branch => 'cqm_patient_conversion'
 # gem 'simplexml_parser', :git => 'https://github.com/projecttacoma/simplexml_parser.git', :branch => 'master'
 # gem 'hqmf2js', :git => 'https://github.com/projecttacoma/hqmf2js.git', :branch => 'master'
 gem 'bonnie_bundler', :git => 'https://github.com/projecttacoma/bonnie_bundler.git', :branch => 'cqm-integration'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -26,17 +26,17 @@ GIT
 
 GIT
   remote: https://github.com/projecttacoma/cql_qdm_patientapi.git
-  revision: bbb76658ee3605e0f54b340b7097d62c5bca8d8b
-  branch: master
+  revision: 89de54c5d08439bcf54144e8643f139b2a926993
+  branch: cqm_patient_conversion
   specs:
-    cql_qdm_patientapi (1.3.1)
+    cql_qdm_patientapi (1.3.2)
       coffee-rails (~> 4.1)
       rails (>= 4.2, < 6.0)
       sprockets-rails (~> 2.3)
 
 GIT
   remote: https://github.com/projecttacoma/cqm-converter
-  revision: 6572c2cd0f162d676c13426d0e3e2a82542871ad
+  revision: 0c9c7344a64aee2e27a767d879c664be1f01a0d6
   branch: master
   specs:
     cqm-converter (1.0.3)
@@ -205,7 +205,7 @@ GEM
       warden (~> 1.2.3)
     diffy (3.0.7)
     docile (1.3.1)
-    domain_name (0.5.20180417)
+    domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
     doorkeeper (4.4.3)
       railties (>= 4.2)

--- a/test/rake/export_fixtures_test.rb
+++ b/test/rake/export_fixtures_test.rb
@@ -74,7 +74,7 @@ class ExportFixturesTest < ActiveSupport::TestCase
         /CMS32/
       ) { Rake::Task['bonnie:fixtures:generate_cqm_patient_fixtures_from_cql_patients'].invoke('bonnie@example.com') }
       assert_equal 12, `ls -l test/fixtures/cqm_patients/CMS* | wc -l`.to_i
-      assert_equal 11, `ls -l spec/javascripts/fixtures/json/patients/CMS* | wc -l`.to_i
+      assert_equal 12, `ls -l spec/javascripts/fixtures/json/patients/CMS* | wc -l`.to_i
     ensure
       FileUtils.rm_r 'test/fixtures/cqm_patients'
       FileUtils.mv 'test/fixtures/cqm_patients.back', 'test/fixtures/cqm_patients'

--- a/test/rake/export_fixtures_test.rb
+++ b/test/rake/export_fixtures_test.rb
@@ -73,7 +73,7 @@ class ExportFixturesTest < ActiveSupport::TestCase
       assert_output(
         /CMS32/
       ) { Rake::Task['bonnie:fixtures:generate_cqm_patient_fixtures_from_cql_patients'].invoke('bonnie@example.com') }
-      assert_equal 11, `ls -l test/fixtures/cqm_patients/CMS* | wc -l`.to_i
+      assert_equal 12, `ls -l test/fixtures/cqm_patients/CMS* | wc -l`.to_i
       assert_equal 11, `ls -l spec/javascripts/fixtures/json/patients/CMS* | wc -l`.to_i
     ensure
       FileUtils.rm_r 'test/fixtures/cqm_patients'


### PR DESCRIPTION
Pull requests into Bonnie require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

Points to the correct CQL_QDM_PatientAPI and Converter for our converter rake tasks.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] Code diff has been done and been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] If UI changes have been made, google WAVE plug-in has been executed to ensure no 508 issues were introduced.
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Test fixtures updated and documented as necessary ( see [internal wiki](https://gitlab.mitre.org/bonnie/internal-documentation/wikis/testing#test-fixtures) )
- [x] Code coverage has not gone down and all code touched or added is covered. 
     * In rare situations, this may not be possible or applicable to a PR. In those situations:
         1. Note why this could not be done or is not applicable here: 
         2. Add TODOs in the code noting that it requires a test
         3. Add a JIRA task to add the test and link it here: 
- [x] ~Automated regression test(s) pass~

**Reviewer 1:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

If JIRA tests were used to supplement or replace automated tests:
- [ ] JIRA tests have been run and pass
- [ ] You agree with the justification for use of JIRA tests or have provided input on why you disagree
