### PR TITLE
Optional attributes in composite input view

### DIFF
--- a/app/assets/javascripts/views/patient_builder/inputs/code.js.coffee
+++ b/app/assets/javascripts/views/patient_builder/inputs/code.js.coffee
@@ -6,12 +6,15 @@ class Thorax.Views.InputCodeView extends Thorax.Views.BonnieView
   #   initialValue - CQL Code - Optional. Initial value of code.
   #   cqmValueSets - List of CQM Value sets. Optional.
   #   codeSystemMap - Code system map of system oid to system names.
+  #   allowNull - boolean - Optional. If a null or empty integer is allowed. Defaults to false.
   initialize: ->
     if @initialValue?
       @value = @initialValue
-      #
     else
       @value = null
+
+    if !@hasOwnProperty('allowNull')
+      @allowNull = false
 
   events:
     'change input': 'handleCustomInputChange'
@@ -71,7 +74,7 @@ class Thorax.Views.InputCodeView extends Thorax.Views.BonnieView
   # checks if the value in this view is valid. returns true or false. this is used by the attribute entry view to determine
   # if the add button should be active or not
   hasValidValue: ->
-    @value?
+    @allowNull || @value?
 
   # Event listener for the custom code input fields
   handleCustomInputChange: (e) ->

--- a/spec/javascripts/patient_builder_tests/input_views/code_input_view_spec.js.coffee
+++ b/spec/javascripts/patient_builder_tests/input_views/code_input_view_spec.js.coffee
@@ -14,6 +14,13 @@ describe 'InputView', ->
       expect(view.value).toBe null
       expect(view.$('select[name="valueset"]').val()).toBe '--'
 
+    it 'starts with no valid value but allows for null', ->
+      view = new Thorax.Views.InputCodeView(cqmValueSets: @measure.get('cqmValueSets'), codeSystemMap: @measure.codeSystemMap(), allowNull: true)
+      view.render()
+      expect(view.hasValidValue()).toBe true
+      expect(view.value).toBe null
+      expect(view.$('select[name="valueset"]').val()).toBe '--'
+
     it 'starts with value in measure value sets', ->
       # in "Bipolar Disorder" oid "2.16.840.1.113883.3.67.1.101.1.128"
       initialCode = new cqm.models.CQL.Code('191618007', '2.16.840.1.113883.6.96', undefined, "Bipolar affective disorder, current episode manic (disorder)")

--- a/spec/javascripts/patient_builder_tests/input_views/composite_input_view_spec.js.coffee
+++ b/spec/javascripts/patient_builder_tests/input_views/composite_input_view_spec.js.coffee
@@ -52,6 +52,33 @@ describe 'InputView', ->
       expect(resultComponentView.componentViews.map((view) -> view.name)).toContain('code')
       expect(resultComponentView.componentViews.map((view) -> view.name)).toContain('result')
 
+    it 'populates DiagnosisComponent views and allows for null rank and presentOnAdmissionIndicator', ->
+      diagnosisComponentView = new Thorax.Views.InputCompositeView
+        schema: cqm.models.DiagnosisComponentSchema,
+        typeName: 'DiagnosisComponent',
+        codeSystemMap: @measure.codeSystemMap(),
+        cqmValueSets: @measure.get('cqmValueSets')
+      diagnosisComponentView.render()
+      expect(diagnosisComponentView.componentViews.length).toEqual 3
+      expect(diagnosisComponentView.componentViews.map((view) -> view.name)).toContain('code')
+      expect(diagnosisComponentView.componentViews.map((view) -> view.name)).toContain('presentOnAdmissionIndicator')
+      expect(diagnosisComponentView.componentViews.map((view) -> view.name)).toContain('rank')
+
+      # should be false and have no value because no code
+      expect(diagnosisComponentView.hasValidValue()).toBe false
+      expect(diagnosisComponentView.value).toBe null
+
+      # choose the diabetes valueset to set a code
+      codeView = diagnosisComponentView.componentViews[0]
+      expect(codeView.name).toEqual('code')
+      codeView.view.$('select[name="valueset"] > option[value="2.16.840.1.113883.3.464.1003.103.12.1001"]').prop('selected', true).change()
+
+      # check the value
+      expect(diagnosisComponentView.hasValidValue()).toBe true
+      expect(diagnosisComponentView.value.code).toEqual new cqm.models.CQL.Code("105401000119101", "2.16.840.1.113883.6.96", undefined, "Diabetes mellitus due to pancreatic injury (disorder)")
+      expect(diagnosisComponentView.value.presentOnAdmissionIndicator).toBe null
+      expect(diagnosisComponentView.value.rank).toBe null
+
     it 'populates Identifier views', ->
       identifierView = new Thorax.Views.InputCompositeView
         schema: cqm.models.IdentifierSchema,


### PR DESCRIPTION
Adds a map of type to list of optional attributes. Uses this map to `allowNull = true` on the input views that should be optional. Starts with DiagnosisComponent types to have optional rank and presentOnAdmissionIndicator.

Pull requests into Bonnie require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] JIRA ticket for this PR: https://jira.mitre.org/browse/BONNIE-2085
- [x] JIRA ticket links to this PR
- [x] Code diff has been done and been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] If UI changes have been made, google WAVE plug-in has been executed to ensure no 508 issues were introduced.
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Test fixtures updated and documented as necessary ( see [internal wiki](https://gitlab.mitre.org/bonnie/internal-documentation/wikis/testing#test-fixtures) )
- [x] Code coverage has not gone down and all code touched or added is covered. 
     * In rare situations, this may not be possible or applicable to a PR. In those situations:
         1. Note why this could not be done or is not applicable here: 
         2. Add TODOs in the code noting that it requires a test
         3. Add a JIRA task to add the test and link it here: 
- [x] Automated regression test(s) pass

**Reviewer 1:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

**Reviewer 2:**

Name: @mayerm94
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code