### PR TITLE
Resolved error thrown when hover highlighting fails to find a data element to highlight

### DIFF
--- a/app/assets/javascripts/views/logic/cql_logic_view.js.coffee
+++ b/app/assets/javascripts/views/logic/cql_logic_view.js.coffee
@@ -231,8 +231,8 @@ class Thorax.Views.CqlPopulationLogic extends Thorax.Views.BonnieView
   highlightPatientData: (dataCriteriaIDs) ->
     if @highlightPatientDataEnabled == true && @latestResult
       for dataCriteriaID in dataCriteriaIDs
-        dataCriteria = _.find(@latestResult.patient.get('source_data_criteria').models, (sdc) -> sdc.get('_id').toString() == dataCriteriaID)
-        dataCriteria.trigger('highlight', Thorax.Views.EditCriteriaView.highlight.valid)
+        dataCriteria = _.find(@latestResult.patient.get('source_data_criteria').models, (sdc) -> sdc.get('qdmDataElement')._id.toString() == dataCriteriaID)
+        dataCriteria?.trigger('highlight', Thorax.Views.EditCriteriaView.highlight.valid)
 
   ###*
   # Clears all highlighted patient data. Called by the CqlStatement if its statement is mouseout'd.


### PR DESCRIPTION
- added null check and updated reference to _id for data element highlighting

Pull requests into Bonnie require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] Code diff has been done and been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)

**Reviewer 1:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
