### PR TITLE
API measure loading fix (in cqm-parsers)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem "non-stupid-digest-assets"
 
 # gem 'cqm-parsers', '~> 0.2.1'
 
-gem 'cqm-parsers', :git => 'https://github.com/projecttacoma/cqm-parsers', :branch => '2019-standards-update-zip-load-fix'
+gem 'cqm-parsers', :git => 'https://github.com/projecttacoma/cqm-parsers', :branch => '2019-standards-update'
 gem 'cqm-models', :git => 'https://github.com/projecttacoma/cqm-models', :branch => '2019-standards-update'
 
 # gem 'cqm-parsers', :path => '../cqm-parsers'

--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem "non-stupid-digest-assets"
 
 # gem 'cqm-parsers', '~> 0.2.1'
 
-gem 'cqm-parsers', :git => 'https://github.com/projecttacoma/cqm-parsers', :branch => '2019-standards-update'
+gem 'cqm-parsers', :git => 'https://github.com/projecttacoma/cqm-parsers', :branch => '2019-standards-update-zip-load-fix'
 gem 'cqm-models', :git => 'https://github.com/projecttacoma/cqm-models', :branch => '2019-standards-update'
 
 # gem 'cqm-parsers', :path => '../cqm-parsers'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,8 +15,8 @@ GIT
 
 GIT
   remote: https://github.com/projecttacoma/cqm-parsers
-  revision: 1b45d1561e58bc24bacfca798f55380ef580a386
-  branch: 2019-standards-update
+  revision: 5294c3816817e10fd18d3df9ed685ffc10eb9e6f
+  branch: 2019-standards-update-zip-load-fix
   specs:
     cqm-parsers (0.2.1)
       activesupport (~> 4.2.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,8 +15,8 @@ GIT
 
 GIT
   remote: https://github.com/projecttacoma/cqm-parsers
-  revision: 5294c3816817e10fd18d3df9ed685ffc10eb9e6f
-  branch: 2019-standards-update-zip-load-fix
+  revision: 42224a2247fad4a7c6391353b3fe1c751fc63a0d
+  branch: 2019-standards-update
   specs:
     cqm-parsers (0.2.1)
       activesupport (~> 4.2.0)


### PR DESCRIPTION
Pull requests into Bonnie require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**BEFORE MERGE**
- [x] ❗️After https://github.com/projecttacoma/cqm-parsers/pull/55 is merged. update gemfile

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] JIRA ticket for this PR: https://jira.mitre.org/browse/BONNIE-2089 https://jira.mitre.org/browse/BONNIE-2095
- [x] JIRA ticket links to this PR
- [x] Code diff has been done and been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)

**Reviewer 1:**

Name: @mayerm94
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

**Reviewer 2:**

Name: @losborne 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
