### PR TITLE
Use Default Measurement Period for Date/DateTime Inputs

### DIFF
--- a/app/assets/javascripts/views/patient_builder/data_criteria.js.coffee
+++ b/app/assets/javascripts/views/patient_builder/data_criteria.js.coffee
@@ -148,7 +148,14 @@ class Thorax.Views.EditCriteriaView extends Thorax.Views.BuilderChildView
     @triggerMaterialize()
 
   isDuringMeasurePeriod: ->
-    moment.utc(@model.get('start_date')).year() is moment.utc(@model.get('end_date')).year() is moment.utc(@model.measure().get('cqmMeasure').measure_period.low.value).year()
+    timingAttribute = @model.get('qdmDataElement')[@model.getPrimaryTimingAttribute()]
+    if !timingAttribute?
+      return false
+
+    if timingAttribute.isInterval
+      timingAttribute.low.year is timingAttribute.high.year is @model.measure().getMeasurePeriodYear()
+    else
+      timingAttribute.year is @model.measure().getMeasurePeriodYear()
 
   # Copy timing attributes (relevantPeriod, prevelancePeriod etc..) onto the criteria being dragged from the criteria it is being dragged ontop of
   copyTimingAttributes: (droppedCriteria, targetCriteria) ->

--- a/app/assets/javascripts/views/patient_builder/data_criteria_attribute_editor.js.coffee
+++ b/app/assets/javascripts/views/patient_builder/data_criteria_attribute_editor.js.coffee
@@ -98,11 +98,11 @@ class Thorax.Views.DataCriteriaAttributeEditorView extends Thorax.Views.BonnieVi
   _createInputViewForType: (type) ->
     @inputView = switch type
       when 'Code' then new Thorax.Views.InputCodeView({ cqmValueSets: @parent.measure.get('cqmValueSets'), codeSystemMap: @parent.measure.codeSystemMap()})
-      when 'Date' then new Thorax.Views.InputDateView({ allowNull: false })
-      when 'DateTime' then new Thorax.Views.InputDateTimeView({ allowNull: false })
+      when 'Date' then new Thorax.Views.InputDateView({ allowNull: false, defaultYear: @parent.measure.getMeasurePeriodYear() })
+      when 'DateTime' then new Thorax.Views.InputDateTimeView({ allowNull: false, defaultYear: @parent.measure.getMeasurePeriodYear() })
       when 'Decimal' then new Thorax.Views.InputDecimalView({ allowNull: false })
       when 'Integer', 'Number' then new Thorax.Views.InputIntegerView({ allowNull: false })
-      when 'Interval<DateTime>' then new Thorax.Views.InputIntervalDateTimeView()
+      when 'Interval<DateTime>' then new Thorax.Views.InputIntervalDateTimeView({ defaultYear: @parent.measure.getMeasurePeriodYear()})
       when 'Interval<Quantity>' then new Thorax.Views.InputIntervalQuantityView()
       when 'Quantity' then new Thorax.Views.InputQuantityView()
       when 'Ratio' then new Thorax.Views.InputRatioView()
@@ -115,7 +115,7 @@ class Thorax.Views.DataCriteriaAttributeEditorView extends Thorax.Views.BonnieVi
 
   _createCompositeInputViewForSchema: (schema, typeName) ->
     @showInputViewPlaceholder = false
-    @inputView = new Thorax.Views.InputCompositeView(schema: schema, typeName: typeName, cqmValueSets: @parent.measure.get('cqmValueSets'), codeSystemMap: @parent.measure.codeSystemMap())
+    @inputView = new Thorax.Views.InputCompositeView(schema: schema, typeName: typeName, cqmValueSets: @parent.measure.get('cqmValueSets'), codeSystemMap: @parent.measure.codeSystemMap(), defaultYear: @parent.measure.getMeasurePeriodYear())
     @listenTo(@inputView, 'valueChanged', @updateAddButtonStatus) if @inputView?
 
   # sets up the view for the attribute input view.

--- a/app/assets/javascripts/views/patient_builder/inputs/any.js.coffee
+++ b/app/assets/javascripts/views/patient_builder/inputs/any.js.coffee
@@ -6,6 +6,7 @@ class Thorax.Views.InputAnyView extends Thorax.Views.BonnieView
   #   attributeName - The name of the attribute. Required
   #   cqmValueSets - List of CQM Value sets. Required.
   #   codeSystemMap - Map of code system oids to code system names. Required.
+  #   defaultYear - Default year to use for Date/DateTime input views.
   initialize: ->
     @value = null
 
@@ -54,8 +55,8 @@ class Thorax.Views.InputAnyView extends Thorax.Views.BonnieView
   _createInputViewForType: (type, placeholderText) ->
     return switch type
       when 'Code' then new Thorax.Views.InputCodeView({ cqmValueSets: @cqmValueSets, codeSystemMap: @codeSystemMap })
-      when 'Date' then new Thorax.Views.InputDateView({ allowNull: false, defaultYear: @parent.measure.getMeasurePeriodYear()})
-      when 'DateTime' then new Thorax.Views.InputDateTimeView({ allowNull: false, defaultYear: @parent.measure.getMeasurePeriodYear() })
+      when 'Date' then new Thorax.Views.InputDateView({ allowNull: false, defaultYear: @defaultYear })
+      when 'DateTime' then new Thorax.Views.InputDateTimeView({ allowNull: false, defaultYear: @defaultYear })
       when 'Decimal' then new Thorax.Views.InputDecimalView({ allowNull: false, placeholder: placeholderText })
       when 'Integer', 'Number' then new Thorax.Views.InputIntegerView({ allowNull: false, placeholder: placeholderText })
       when 'Quantity' then new Thorax.Views.InputQuantityView()

--- a/app/assets/javascripts/views/patient_builder/inputs/any.js.coffee
+++ b/app/assets/javascripts/views/patient_builder/inputs/any.js.coffee
@@ -54,8 +54,8 @@ class Thorax.Views.InputAnyView extends Thorax.Views.BonnieView
   _createInputViewForType: (type, placeholderText) ->
     return switch type
       when 'Code' then new Thorax.Views.InputCodeView({ cqmValueSets: @cqmValueSets, codeSystemMap: @codeSystemMap })
-      when 'Date' then new Thorax.Views.InputDateView({ allowNull: false })
-      when 'DateTime' then new Thorax.Views.InputDateTimeView({ allowNull: false })
+      when 'Date' then new Thorax.Views.InputDateView({ allowNull: false, defaultYear: @parent.measure.getMeasurePeriodYear()})
+      when 'DateTime' then new Thorax.Views.InputDateTimeView({ allowNull: false, defaultYear: @parent.measure.getMeasurePeriodYear() })
       when 'Decimal' then new Thorax.Views.InputDecimalView({ allowNull: false, placeholder: placeholderText })
       when 'Integer', 'Number' then new Thorax.Views.InputIntegerView({ allowNull: false, placeholder: placeholderText })
       when 'Quantity' then new Thorax.Views.InputQuantityView()

--- a/app/assets/javascripts/views/patient_builder/inputs/composite.js.coffee
+++ b/app/assets/javascripts/views/patient_builder/inputs/composite.js.coffee
@@ -12,6 +12,7 @@ class Thorax.Views.InputCompositeView extends Thorax.Views.BonnieView
   #   cqmValueSets - Array<CQM.ValueSet> - All valuesets on the measure.
   #   codeSystemMap - The mapping of code systems oids to code system names.
   #   typeName = The name of the type we should be constructing
+  #   defaultYear = The default year if there is a DateTime input view
   initialize: ->
     @value = null
 
@@ -53,9 +54,9 @@ class Thorax.Views.InputCompositeView extends Thorax.Views.BonnieView
 
   _createInputViewForType: (type, attributeName, info) ->
     inputView = switch type
-      when 'Interval<DateTime>' then new Thorax.Views.InputIntervalDateTimeView({ allowNull: @_attrShouldAllowNull(attributeName) })
+      when 'Interval<DateTime>' then new Thorax.Views.InputIntervalDateTimeView({ allowNull: @_attrShouldAllowNull(attributeName), defaultYear: @defaultYear })
       when 'Interval<Quantity>' then new Thorax.Views.InputIntervalQuantityView({ allowNull: @_attrShouldAllowNull(attributeName) })
-      when 'DateTime' then new Thorax.Views.InputDateTimeView({ allowNull: @_attrShouldAllowNull(attributeName) })
+      when 'DateTime' then new Thorax.Views.InputDateTimeView({ allowNull: @_attrShouldAllowNull(attributeName), defaultYear: @defaultYear })
       when 'Time' then new Thorax.Views.InputTimeView({ allowNull: @_attrShouldAllowNull(attributeName) })
       when 'Quantity' then new Thorax.Views.InputQuantityView({ allowNull: @_attrShouldAllowNull(attributeName) })
       when 'Code' then new Thorax.Views.InputCodeView({ cqmValueSets: @cqmValueSets, codeSystemMap: @codeSystemMap, allowNull: @_attrShouldAllowNull(attributeName) })

--- a/app/assets/javascripts/views/patient_builder/inputs/composite.js.coffee
+++ b/app/assets/javascripts/views/patient_builder/inputs/composite.js.coffee
@@ -64,7 +64,7 @@ class Thorax.Views.InputCompositeView extends Thorax.Views.BonnieView
       when 'Integer', 'Number' then new Thorax.Views.InputIntegerView({ placeholder: attributeName, allowNull: @_attrShouldAllowNull(attributeName) })
       when 'Decimal' then new Thorax.Views.InputDecimalView({ placeholder: attributeName, allowNull: @_attrShouldAllowNull(attributeName) })
       when 'Ratio' then new Thorax.Views.InputRatioView({ allowNull: @_attrShouldAllowNull(attributeName) })
-      when 'Any' then new Thorax.Views.InputAnyView({ attributeName: attributeName, cqmValueSets: @cqmValueSets, codeSystemMap: @codeSystemMap, allowNull: @_attrShouldAllowNull(attributeName) })
+      when 'Any' then new Thorax.Views.InputAnyView({ attributeName: attributeName, cqmValueSets: @cqmValueSets, codeSystemMap: @codeSystemMap, allowNull: @_attrShouldAllowNull(attributeName), defaultYear: @defaultYear })
       when 'Identifier' then new Thorax.Views.InputCompositeView({ schema: info.schema, typeName: type })
       else null
 


### PR DESCRIPTION
Fixing a couple of small issues:
1. Non-primary DateTime/Date input views weren't updating if the measurement period changed
2. The blue bar next to data elements wasn't showing up if they are in the measurement period because the function for detecting that was out-of-date.

Pull requests into Bonnie require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] JIRA ticket for this PR: https://jira.mitre.org/browse/BONNIE-2096
- [x] JIRA ticket links to this PR
- [x] Code diff has been done and been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] If UI changes have been made, google WAVE plug-in has been executed to ensure no 508 issues were introduced.
- [x] Tests are included and test edge cases N/A small fixes
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Test fixtures updated and documented as necessary ( see [internal wiki](https://gitlab.mitre.org/bonnie/internal-documentation/wikis/testing#test-fixtures) )
- [x] Code coverage has not gone down and all code touched or added is covered. 
     * In rare situations, this may not be possible or applicable to a PR. In those situations:
         1. Note why this could not be done or is not applicable here: 
         2. Add TODOs in the code noting that it requires a test
         3. Add a JIRA task to add the test and link it here: 
- [x] Automated regression test(s) pass

If JIRA tests were used to supplement or replace automated tests:
- [x] JIRA test links:
- [x] Justification for using JIRA tests:
- [x] JIRA tests have been added to sprint


**Reviewer 1:**

Name: @hackrm 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

If JIRA tests were used to supplement or replace automated tests:
- [x] JIRA tests have been run and pass: N/A
- [x] You agree with the justification for use of JIRA tests or have provided input on why you disagree: N/A


**Reviewer 2:**

Name: @hossenlopp 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

If JIRA tests were used to supplement or replace automated tests:
- [x] JIRA tests have been run and pass
- [x] You agree with the justification for use of JIRA tests or have provided input on why you disagree
