### PR TITLE
Nil check for the low and high fields of timingAttribute

### DIFF
--- a/app/assets/javascripts/views/patient_builder/data_criteria.js.coffee
+++ b/app/assets/javascripts/views/patient_builder/data_criteria.js.coffee
@@ -153,7 +153,7 @@ class Thorax.Views.EditCriteriaView extends Thorax.Views.BuilderChildView
       return false
 
     if timingAttribute.isInterval
-      timingAttribute.low.year is timingAttribute.high.year is @model.measure().getMeasurePeriodYear()
+      timingAttribute.low?.year is timingAttribute.high?.year is @model.measure().getMeasurePeriodYear()
     else
       timingAttribute.year is @model.measure().getMeasurePeriodYear()
 


### PR DESCRIPTION
This nil check is needed for situations when the interval timingAttribute of a dataElement is null so that a error is not thrown on the web console. 

*Since it's such a small PR, only 1 reviewer required

Pull requests into Bonnie require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] This PR is into the correct branch.
~~- [ ] JIRA ticket for this PR:~~
~~- [ ] JIRA ticket links to this PR~~
- [x] Code diff has been done and been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
~~- [ ] If UI changes have been made, google WAVE plug-in has been executed to ensure no 508 issues were introduced.~~
~~- [ ] Tests are included and test edge cases~~
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
~~- [ ] Test fixtures updated and documented as necessary ( see [internal wiki](https://gitlab.mitre.org/bonnie/internal-documentation/wikis/testing#test-fixtures) )~~
- [x] Code coverage has not gone down and all code touched or added is covered. 
~~- [ ] Automated regression test(s) pass~~


**Reviewer 1:**

Name: @losborne 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
