### PR TITLE
Bump cqm-execution and cqm-models versions for UAT release

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 
 GIT
   remote: https://github.com/projecttacoma/cqm-models
-  revision: f3cca6fc5b137d080b78123eb54229dcf810e654
+  revision: cf36e145241a941324806236e1e5acb09a729ebf
   branch: 2019-standards-update
   specs:
     cqm-models (2.0.0)

--- a/yarn.lock
+++ b/yarn.lock
@@ -328,14 +328,14 @@ core-util-is@~1.0.0:
 
 "cql-execution@https://github.com/cqframework/cql-execution#master":
   version "1.3.4"
-  resolved "https://github.com/cqframework/cql-execution#cf599c9720b5f0d1338d838d3059b11f52b9b91e"
+  resolved "https://github.com/cqframework/cql-execution#4f9535a7fbcff5923b11ddf7dafe55442c81d1fa"
   dependencies:
     moment "^2.20.1"
     ucum "0.0.7"
 
 "cqm-execution@https://github.com/projecttacoma/cqm-execution#2019-standards-update":
   version "2.0.0"
-  resolved "https://github.com/projecttacoma/cqm-execution#0f21099256dacee1452b7c87cf2c46afccb22960"
+  resolved "https://github.com/projecttacoma/cqm-execution#97581beeedf81cab20c60568df5a36c38f2269ca"
   dependencies:
     cqm-models "https://github.com/projecttacoma/cqm-models#2019-standards-update"
     lodash "^4.17.5"
@@ -343,7 +343,7 @@ core-util-is@~1.0.0:
 
 "cqm-models@https://github.com/projecttacoma/cqm-models#2019-standards-update":
   version "2.0.0"
-  resolved "https://github.com/projecttacoma/cqm-models#f3cca6fc5b137d080b78123eb54229dcf810e654"
+  resolved "https://github.com/projecttacoma/cqm-models#cf36e145241a941324806236e1e5acb09a729ebf"
   dependencies:
     cql-execution "https://github.com/cqframework/cql-execution#master"
     mongoose "^5.4.14"
@@ -765,9 +765,9 @@ mongoose-legacy-pluralize@1.0.2:
   integrity sha512-Yo/7qQU4/EyIS8YDFSeenIvXxZN+ld7YdV9LqFVQJzTLye8unujAWPZ4NWKfFA+RNjh+wvTWKY9Z3E5XM6ZZiQ==
 
 mongoose@^5.4.14:
-  version "5.6.5"
-  resolved "https://registry.yarnpkg.com/mongoose/-/mongoose-5.6.5.tgz#fdddf9a3c588a670b81b23bec203440f5ddf2876"
-  integrity sha512-c8bIo8mxbf1ybwo9jgPKcJRICQBlIMKwDWt2A+M7h0AutroQ5EqzRAYOK1vrHwwwq00EcJyVwjVBW2wv8E9Wfw==
+  version "5.6.6"
+  resolved "https://registry.yarnpkg.com/mongoose/-/mongoose-5.6.6.tgz#78953b9ea91b1bf685ce59d7737100352af627f6"
+  integrity sha512-5uecJSyl2TwbGM9vJteP4C54zsQL6qllq1qe/JPGO3oqIWcK/PnzCL91E0gfPH5VVpvWGX+6PafNYmU3NK8S7w==
   dependencies:
     async "2.6.2"
     bson "~1.1.1"


### PR DESCRIPTION
Version update for UAT release:
cqm-models in Gemfile
cqm-execution in package.json