### PR TITLE
Entities optional

### DIFF
--- a/app/assets/javascripts/views/patient_builder/data_criteria_attribute_display.js.coffee
+++ b/app/assets/javascripts/views/patient_builder/data_criteria_attribute_display.js.coffee
@@ -63,10 +63,10 @@ class Thorax.Views.DataCriteriaAttributeDisplayView extends Thorax.Views.BonnieV
     else if value.schema?
       attrStrings = []
       value.schema.eachPath (path, info) =>
-        return if _.without(Thorax.Models.SourceDataCriteria.SKIP_ATTRIBUTES, 'id').includes(path) || !value[path]?
+        return if _.without(Thorax.Models.SourceDataCriteria.SKIP_ATTRIBUTES, 'id').includes(path)
         attrStrings.push @model.getAttributeTitle(path) + ": " + @_stringifyValue(value[path])
       attrString = attrStrings.join(', ')
-      if value._type?
+      if value._type? && value._type != 'QDM::Identifier'
         attrString = "[#{value._type.replace('QDM::','')}] #{attrString}"
       if !topLevel
         attrString = "{ #{attrString} }"

--- a/app/assets/javascripts/views/patient_builder/inputs/composite.js.coffee
+++ b/app/assets/javascripts/views/patient_builder/inputs/composite.js.coffee
@@ -9,6 +9,7 @@ class Thorax.Views.InputCompositeView extends Thorax.Views.BonnieView
     'CarePartner': ['identifier', 'relationship'], # 'id' same as above
     'Practitioner': ['identifier', 'role', 'specialty', 'qualification'], # 'id' same as above
     'Organization': ['identifier', 'type'], # 'id' same as above
+    'Identifier': ['namingSystem', 'value'],
   }
 
   # Expected options to be passed in using the constructor options hash:
@@ -17,6 +18,7 @@ class Thorax.Views.InputCompositeView extends Thorax.Views.BonnieView
   #   codeSystemMap - The mapping of code systems oids to code system names.
   #   typeName = The name of the type we should be constructing
   #   defaultYear = The default year if there is a DateTime input view
+  #   allowNull = Whether or not this input should allow no entry
   initialize: ->
     @value = null
 

--- a/spec/javascripts/patient_builder_tests/input_views/composite_input_view_spec.js.coffee
+++ b/spec/javascripts/patient_builder_tests/input_views/composite_input_view_spec.js.coffee
@@ -108,6 +108,42 @@ describe 'InputView', ->
       expect(practitionerEntityView.componentViews[0].name).toEqual('identifier')
       expect(practitionerEntityView.componentViews[0].view.showLabels).toBe(false)
 
+    it 'allows for optional PatientEntity fields', ->
+      patientEntityView = new Thorax.Views.InputCompositeView
+        schema: cqm.models.PatientEntitySchema,
+        typeName: 'PatientEntity',
+        codeSystemMap: @measure.codeSystemMap(),
+        cqmValueSets: @measure.get('cqmValueSets')
+      patientEntityView.render()
+      validateEntityOptionalInputs(patientEntityView)
+
+    it 'allows for optional CarePartner fields', ->
+      carePartnerEntityView = new Thorax.Views.InputCompositeView
+        schema: cqm.models.CarePartnerSchema,
+        typeName: 'CarePartner',
+        codeSystemMap: @measure.codeSystemMap(),
+        cqmValueSets: @measure.get('cqmValueSets')
+      carePartnerEntityView.render()
+      validateEntityOptionalInputs(carePartnerEntityView)
+
+    it 'allows for optional Practitioner fields', ->
+      practitionerEntityView = new Thorax.Views.InputCompositeView
+        schema: cqm.models.PractitionerSchema,
+        typeName: 'Practitioner',
+        codeSystemMap: @measure.codeSystemMap(),
+        cqmValueSets: @measure.get('cqmValueSets')
+      practitionerEntityView.render()
+      validateEntityOptionalInputs(practitionerEntityView)
+
+    it 'allows for optional Organization fields', ->
+      organizationEntityView = new Thorax.Views.InputCompositeView
+        schema: cqm.models.OrganizationSchema,
+        typeName: 'Organization',
+        codeSystemMap: @measure.codeSystemMap(),
+        cqmValueSets: @measure.get('cqmValueSets')
+      organizationEntityView.render()
+      validateEntityOptionalInputs(organizationEntityView)
+
     it 'allows for a Component to be added', ->
       expect(@view.value).toBeNull()
       # Both the valueset/code and the result must be valid to add a Component
@@ -138,3 +174,25 @@ describe 'InputView', ->
       # Enable end and populate with default datetime
       @facilityLocationView.$('input[name="end_date_is_defined"]').click()
       expect(@facilityLocationView.value._type).toEqual('QDM::FacilityLocation')
+
+    it 'allows for a FacilityLocation to be added', ->
+      expect(@facilityLocationView.value).toBeNull()
+      # Both valueset/code and locationPeriod must be input
+      @facilityLocationView.$('select[name="valueset"]').val("2.16.840.1.113883.3.464.1003.101.12.1001").change()
+      # No need to set code, one is selected by default
+      expect(@facilityLocationView.value._type).toEqual('QDM::FacilityLocation') # null locationPeriod by default is allowed
+
+      # Enable start and populate with default datetime
+      @facilityLocationView.$('input[name="start_date_is_defined"]').click()
+      expect(@facilityLocationView.value._type).toEqual('QDM::FacilityLocation')
+
+      # Enable end and populate with default datetime
+      @facilityLocationView.$('input[name="end_date_is_defined"]').click()
+      expect(@facilityLocationView.value._type).toEqual('QDM::FacilityLocation')
+
+validateEntityOptionalInputs = (entityView) ->
+  expect(entityView.hasValidValue()).toBe false
+
+  # Though ids should be optional, mongoose requires an id field so we make it required
+  entityView.$('input[placeholder="id"]').val('foo').change()
+  expect(entityView.hasValidValue()).toBe true

--- a/spec/javascripts/patient_builder_tests/input_views/composite_input_view_spec.js.coffee
+++ b/spec/javascripts/patient_builder_tests/input_views/composite_input_view_spec.js.coffee
@@ -175,20 +175,6 @@ describe 'InputView', ->
       @facilityLocationView.$('input[name="end_date_is_defined"]').click()
       expect(@facilityLocationView.value._type).toEqual('QDM::FacilityLocation')
 
-    it 'allows for a FacilityLocation to be added', ->
-      expect(@facilityLocationView.value).toBeNull()
-      # Both valueset/code and locationPeriod must be input
-      @facilityLocationView.$('select[name="valueset"]').val("2.16.840.1.113883.3.464.1003.101.12.1001").change()
-      # No need to set code, one is selected by default
-      expect(@facilityLocationView.value._type).toEqual('QDM::FacilityLocation') # null locationPeriod by default is allowed
-
-      # Enable start and populate with default datetime
-      @facilityLocationView.$('input[name="start_date_is_defined"]').click()
-      expect(@facilityLocationView.value._type).toEqual('QDM::FacilityLocation')
-
-      # Enable end and populate with default datetime
-      @facilityLocationView.$('input[name="end_date_is_defined"]').click()
-      expect(@facilityLocationView.value._type).toEqual('QDM::FacilityLocation')
 
 validateEntityOptionalInputs = (entityView) ->
   expect(entityView.hasValidValue()).toBe false

--- a/yarn.lock
+++ b/yarn.lock
@@ -765,9 +765,9 @@ mongoose-legacy-pluralize@1.0.2:
   integrity sha512-Yo/7qQU4/EyIS8YDFSeenIvXxZN+ld7YdV9LqFVQJzTLye8unujAWPZ4NWKfFA+RNjh+wvTWKY9Z3E5XM6ZZiQ==
 
 mongoose@^5.4.14:
-  version "5.6.7"
-  resolved "https://registry.yarnpkg.com/mongoose/-/mongoose-5.6.7.tgz#f98116e2740816c5be3cdf07040834abcd090f2a"
-  integrity sha512-42rbdZ9HLBbGjLvRSB4voqemgFkJTIyqSLLcJARKs1zdQzEJ3O77dWRllIy2bSo35GcY17ihEdoJX27pDqu3Mg==
+  version "5.6.8"
+  resolved "https://registry.yarnpkg.com/mongoose/-/mongoose-5.6.8.tgz#9b6d2575c21402def45f50072a3900c54b697cc8"
+  integrity sha512-BhgGU/KvnVX8WbamcWgtG/45rp+xZnaF9MhNbzESIIYxK7g5QurXYcaGGCm/JFiIdIxkVUgBycWG7UzRUEzvDg==
   dependencies:
     async "2.6.2"
     bson "~1.1.1"


### PR DESCRIPTION
Entity input fields are actually all optional.

Though in the QDM spec `id` is optional, Mongoose will automatically create one if it is `null`. So rather than having the mongoose `id` added to the Entity, we make `id` not optional in Bonnie (for now, at least), so that the `id` is guaranteed to be one that makes sense to the user.

Pull requests into Bonnie require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

- [x] Update package.json and Gemfile after https://github.com/projecttacoma/cqm-models/pull/140 bubbles up

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] JIRA ticket for this PR: https://jira.mitre.org/browse/BONNIE-2106
- [x] JIRA ticket links to this PR
- [x] Code diff has been done and been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] If UI changes have been made, google WAVE plug-in has been executed to ensure no 508 issues were introduced. N/A
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Test fixtures updated and documented as necessary ( see [internal wiki](https://gitlab.mitre.org/bonnie/internal-documentation/wikis/testing#test-fixtures) )
- [x] Code coverage has not gone down and all code touched or added is covered. 
     * In rare situations, this may not be possible or applicable to a PR. In those situations:
         1. Note why this could not be done or is not applicable here: 
         2. Add TODOs in the code noting that it requires a test
         3. Add a JIRA task to add the test and link it here: 
- [x] Automated regression test(s) pass N/A only the input view is changed

**Reviewer 1:**

Name: @hossenlopp 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code


**Reviewer 2:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
