### PR TITLE
fixed population criteria data sent back for excel generation

### DIFF
--- a/app/assets/javascripts/views/measure_view.js.coffee
+++ b/app/assets/javascripts/views/measure_view.js.coffee
@@ -142,10 +142,9 @@ class Thorax.Views.Measure extends Thorax.Views.BonnieView
         # Populates the population details
         if (population_details[pop.cid] == undefined)
           population_details[pop.cid] = {title: pop.get("title"), statement_relevance: result.get("statement_relevance")}
-          criteria = []
-          for popAttrs of pop.attributes
-            if (popAttrs != "title" && popAttrs != "sub_id" && popAttrs != "title")
-              criteria.push(popAttrs)
+          criteria = pop.populationCriteria()
+          if pop.get('observations')?.length > 0
+            criteria.push('OBSERV')
           population_details[pop.cid]["criteria"] = criteria
 
     $.fileDownload "patients/excel_export",


### PR DESCRIPTION
Pull requests into Bonnie require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] JIRA ticket for this PR: https://jira.mitre.org/browse/BONNIE-2109
- [ ] JIRA ticket links to this PR
- [ ] Tests have been run locally and pass (remember to update Gemfile when applicable)

**Reviewer 1:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
