### PR TITLE
Fix reference to observation_values in excel_export_helper

### DIFF
--- a/app/helpers/excel_export_helper.rb
+++ b/app/helpers/excel_export_helper.rb
@@ -36,9 +36,8 @@ module ExcelExportHelper
           }
           result[pop_set_or_strat[:id]]['population_relevance'].each_key do |population_criteria|
             if population_criteria == 'observation_values'
-              # Values are stored for each episode separately, so we need to gather the values from the episode_results object.
-              result[pop_set_or_strat[:id]]['episode_results']&.each_value do |episode|
-                result_criteria['observation_values'].concat episode['observation_values']
+              result[pop_set_or_strat[:id]]['observation_values']&.each do |observation_value|
+                result_criteria['observation_values'].push observation_value
               end
               result_criteria['observation_values'].sort!
             else


### PR DESCRIPTION
This change fixes a stale reference to `episode_results`, which no longer exists.

Pull requests into Bonnie require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] JIRA ticket for this PR: https://jira.mitre.org/browse/BONNIE-2124
- [x] JIRA ticket links to this PR
- [x] Code diff has been done and been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] If UI changes have been made, google WAVE plug-in has been executed to ensure no 508 issues were introduced. N/A
- [x] Tests are included and test edge cases N/A - this is 'covered' by the excel regression
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable) (excel regression is green after this PR)
- [x] Test fixtures updated and documented as necessary ( see [internal wiki](https://gitlab.mitre.org/bonnie/internal-documentation/wikis/testing#test-fixtures) ) N/A
- [x] Code coverage has not gone down and all code touched or added is covered. 
- [x] Automated regression test(s) pass N/A only affects excel

**Reviewer 1:**

Name: @mayerm94 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

**Reviewer 2:**

Name: @hackrm 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
