### PR TITLE
Data criteria description spacing

### DIFF
--- a/app/assets/javascripts/models/data_criteria.js.coffee
+++ b/app/assets/javascripts/models/data_criteria.js.coffee
@@ -19,6 +19,7 @@ class Thorax.Models.SourceDataCriteria extends Thorax.Model
     dataElementAsObject = clonedDataElement.toObject()
     dataElementAsObject.description = @get('description')
     dataElementAsObject.qdmDataElement = clonedDataElement
+    dataElementAsObject.qdmDataElement.description = dataElementAsObject.description
 
     # make and return the new SDC
     return new Thorax.Models.SourceDataCriteria(dataElementAsObject)

--- a/spec/javascripts/models/data_criteria_spec.js.coffee
+++ b/spec/javascripts/models/data_criteria_spec.js.coffee
@@ -38,3 +38,10 @@ describe "SourceDataCriteria", ->
     expect(dataCriteria.getCriteriaType()).toBe 'assessment_recommended'
     expect(dataCriteria.isPeriodType()).toBe false
     expect(dataCriteria.getPrimaryTimingAttribute()).toBe 'authorDatetime'
+
+  it "copies description onto qdmDataElement when cloned", ->
+    dataElement = new cqm.models.AssessmentRecommended()
+    dataElement.description = 'WithoutSpaces'
+    dataCriteria = new Thorax.Models.SourceDataCriteria({qdmDataElement: dataElement, description: 'With Spaces'})
+    expect(dataCriteria.clone().get('qdmDataElement').description).toBe 'With Spaces'
+


### PR DESCRIPTION
Bug behavior: Description spaces are removed after saving and re-loading patient.  Need to drag on a new element rather than using a converted element to reproduce. Measure also needs to have the no-spaces version of the description (not all exhibit the bug behavior).  The new qdm element measure (CMSv5555) will work.

![image](https://user-images.githubusercontent.com/14879344/62948116-c8f6f680-bdb1-11e9-850c-e261343ae2f9.png)

Fixed behavior: Spaces are preserved after saving and re-loading.
![image](https://user-images.githubusercontent.com/14879344/62948131-d01e0480-bdb1-11e9-9811-fb71100ac1dc.png)

Pull requests into Bonnie require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] JIRA ticket for this PR: https://jira.mitre.org/browse/BONNIE-2128
- [x] JIRA ticket links to this PR
- [x] Code diff has been done and been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] If UI changes have been made, google WAVE plug-in has been executed to ensure no 508 issues were introduced.
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Test fixtures updated and documented as necessary ( see [internal wiki](https://gitlab.mitre.org/bonnie/internal-documentation/wikis/testing#test-fixtures) )
- [x] Code coverage has not gone down and all code touched or added is covered. 
     * In rare situations, this may not be possible or applicable to a PR. In those situations:
         1. Note why this could not be done or is not applicable here: 
         2. Add TODOs in the code noting that it requires a test
         3. Add a JIRA task to add the test and link it here: 
- [x] Automated regression test(s) pass

If JIRA tests were used to supplement or replace automated tests:
- [x] JIRA test links:
- [x] Justification for using JIRA tests:
- [x] JIRA tests have been added to sprint


**Reviewer 1:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

If JIRA tests were used to supplement or replace automated tests:
- [x] JIRA tests have been run and pass
- [x] You agree with the justification for use of JIRA tests or have provided input on why you disagree


**Reviewer 2:**

Name: @zlister 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

If JIRA tests were used to supplement or replace automated tests:
- [x] JIRA tests have been run and pass
- [x] You agree with the justification for use of JIRA tests or have provided input on why you disagree
