### PR TITLE
Display populated timing attribute on collapsed data criteria

### DIFF
--- a/app/assets/javascripts/models/data_criteria.js.coffee
+++ b/app/assets/javascripts/models/data_criteria.js.coffee
@@ -100,10 +100,11 @@ class Thorax.Models.SourceDataCriteria extends Thorax.Model
 
   # Use the mongoose schema to look at the fields for this element
   getPrimaryTimingAttribute: ->
-    for attr in @getPrimaryTimingAttributes()
+    timingAttributes = @getPrimaryTimingAttributes()
+    for attr in timingAttributes
       return attr.name if @get('qdmDataElement')[attr.name]?.low? || @get('qdmDataElement')[attr.name]?.high? || @get('qdmDataElement')[attr.name]?.isDateTime?
     # Fall back to returning the first primary timing attribute if none of the timing attributes have values
-    return @getPrimaryTimingAttributes()[0].name
+    return timingAttributes[0].name
 
   # Gets a list of the names, titles and types of the primary timing attributes for this SDC.
   getPrimaryTimingAttributes: ->

--- a/app/assets/javascripts/models/data_criteria.js.coffee
+++ b/app/assets/javascripts/models/data_criteria.js.coffee
@@ -92,7 +92,7 @@ class Thorax.Models.SourceDataCriteria extends Thorax.Model
       criteriaType = "#{criteriaType}_#{@get('qdmDataElement').qdmStatus}"
     criteriaType
 
-  @PRIMARY_TIMING_ATTRIBUTES = ['relevantPeriod', 'relevantDatetime', 'prevalencePeriod', 'participationPeriod', 'authorDatetime']
+  @PRIMARY_TIMING_ATTRIBUTES = ['relevantPeriod', 'relevantDatetime', 'prevalencePeriod', 'participationPeriod', 'authorDatetime', 'resultDatetime']
 
   # the attributes to skip in user attribute view and editing fields
   @SKIP_ATTRIBUTES = ['dataElementCodes', 'codeListId', 'description', 'id', '_id', 'qrdaOid', 'qdmTitle', 'hqmfOid', 'qdmCategory', 'qdmVersion', 'qdmStatus', 'negationRationale', '_type']
@@ -102,9 +102,6 @@ class Thorax.Models.SourceDataCriteria extends Thorax.Model
   getPrimaryTimingAttribute: ->
     for attr in @getPrimaryTimingAttributes()
       return attr.name if @get('qdmDataElement')[attr.name]?.low? || @get('qdmDataElement')[attr.name]?.high? || @get('qdmDataElement')[attr.name]?.isDateTime?
-    # ResultDatetime is not a primary timing attribute, but will be displayed if no other dates are available
-    if @get('qdmDataElement')['resultDatetime']?.isDateTime?
-      return 'resultDatetime'
     return @getPrimaryTimingAttributes()[0].name
 
   # Gets a list of the names, titles and types of the primary timing attributes for this SDC.

--- a/app/assets/javascripts/models/data_criteria.js.coffee
+++ b/app/assets/javascripts/models/data_criteria.js.coffee
@@ -102,6 +102,7 @@ class Thorax.Models.SourceDataCriteria extends Thorax.Model
   getPrimaryTimingAttribute: ->
     for attr in @getPrimaryTimingAttributes()
       return attr.name if @get('qdmDataElement')[attr.name]?.low? || @get('qdmDataElement')[attr.name]?.high? || @get('qdmDataElement')[attr.name]?.isDateTime?
+    # Fall back to returning the first primary timing attribute if none of the timing attributes have values
     return @getPrimaryTimingAttributes()[0].name
 
   # Gets a list of the names, titles and types of the primary timing attributes for this SDC.

--- a/app/assets/javascripts/models/data_criteria.js.coffee
+++ b/app/assets/javascripts/models/data_criteria.js.coffee
@@ -74,7 +74,7 @@ class Thorax.Models.SourceDataCriteria extends Thorax.Model
   # determines if a data criteria has a time period associated with it: it potentially has both
   # a start and end date.
   isPeriodType: ->
-    @getPrimaryTimingAttribute() != 'authorDatetime'
+    @getPrimaryTimingAttribute() not in ['authorDatetime', 'resultDatetime']
 
   # determines if a data criteria describes an issue or problem with a person
   # allergy/intolerance, diagnosis, and symptom fall into this
@@ -100,6 +100,11 @@ class Thorax.Models.SourceDataCriteria extends Thorax.Model
 
   # Use the mongoose schema to look at the fields for this element
   getPrimaryTimingAttribute: ->
+    for attr in @getPrimaryTimingAttributes()
+      return attr.name if @get('qdmDataElement')[attr.name]?.low? || @get('qdmDataElement')[attr.name]?.high? || @get('qdmDataElement')[attr.name]?.isDateTime?
+    # ResultDatetime is not a primary timing attribute, but will be displayed if no other dates are available
+    if @get('qdmDataElement')['resultDatetime']?.isDateTime?
+      return 'resultDatetime'
     return @getPrimaryTimingAttributes()[0].name
 
   # Gets a list of the names, titles and types of the primary timing attributes for this SDC.

--- a/spec/javascripts/models/data_criteria_spec.js.coffee
+++ b/spec/javascripts/models/data_criteria_spec.js.coffee
@@ -45,3 +45,25 @@ describe "SourceDataCriteria", ->
     dataCriteria = new Thorax.Models.SourceDataCriteria({qdmDataElement: dataElement, description: 'With Spaces'})
     expect(dataCriteria.clone().get('qdmDataElement').description).toBe 'With Spaces'
 
+  it "specifies 'LaboratoryTest, Performed' to have resultDatetime if no other timing attributes have values", ->
+    dataElement = new cqm.models.LaboratoryTestPerformed()
+    dataElement.resultDatetime = new cqm.models.CQL.DateTime(2012, 2, 3)
+    dataCriteria = new Thorax.Models.SourceDataCriteria({qdmDataElement: dataElement})
+    expect(dataCriteria.getCriteriaType()).toBe 'laboratory_test_performed'
+    expect(dataCriteria.isPeriodType()).toBe false
+    expect(dataCriteria.getPrimaryTimingAttribute()).toBe 'resultDatetime'
+
+  it "specifies 'LaboratoryTest, Performed' to have authorDateTime if relevantPeriod is null", ->
+    dataElement = new cqm.models.LaboratoryTestPerformed()
+    dataElement.authorDatetime = new cqm.models.CQL.DateTime(2012, 2, 3)
+    dataCriteria = new Thorax.Models.SourceDataCriteria({qdmDataElement: dataElement})
+    expect(dataCriteria.getCriteriaType()).toBe 'laboratory_test_performed'
+    expect(dataCriteria.isPeriodType()).toBe false
+    expect(dataCriteria.getPrimaryTimingAttribute()).toBe 'authorDatetime'
+
+  it "specifies 'LaboratoryTest, Performed' to have relevantPeriod if all timing attributes are null", ->
+    dataElement = new cqm.models.LaboratoryTestPerformed()
+    dataCriteria = new Thorax.Models.SourceDataCriteria({qdmDataElement: dataElement})
+    expect(dataCriteria.getCriteriaType()).toBe 'laboratory_test_performed'
+    expect(dataCriteria.isPeriodType()).toBe true
+    expect(dataCriteria.getPrimaryTimingAttribute()).toBe 'relevantPeriod'


### PR DESCRIPTION
Display populated timing attribute on collapsed data criteria, consider a resultdatetime as a primary timing attribute

eg: If datacriteria has value for authordatetime but not relevantperiod, display authordatetime on collapsed datacriteria.

Pull requests into Bonnie require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] JIRA ticket for this PR: https://jira.mitre.org/browse/BONNIE-2129
- [x] JIRA ticket links to this PR
- [x] Code diff has been done and been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] If UI changes have been made, google WAVE plug-in has been executed to ensure no 508 issues were introduced.
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Test fixtures updated and documented as necessary ( see [internal wiki](https://gitlab.mitre.org/bonnie/internal-documentation/wikis/testing#test-fixtures) )
- [x] Code coverage has not gone down and all code touched or added is covered. 
     * In rare situations, this may not be possible or applicable to a PR. In those situations:
         1. Note why this could not be done or is not applicable here: 
         2. Add TODOs in the code noting that it requires a test
         3. Add a JIRA task to add the test and link it here: 
- [x] Automated regression test(s) pass NA

**Reviewer 1:**

Name: @losborne 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

If JIRA tests were used to supplement or replace automated tests:
- [x] JIRA tests have been run and pass
- [x] You agree with the justification for use of JIRA tests or have provided input on why you disagree


**Reviewer 2:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

If JIRA tests were used to supplement or replace automated tests:
- [x] JIRA tests have been run and pass
- [x] You agree with the justification for use of JIRA tests or have provided input on why you disagree
