### PR TITLE
Show calculation errors and set measures to pending if they occur

### DIFF
--- a/app/assets/javascripts/cqm_calculator.js.coffee
+++ b/app/assets/javascripts/cqm_calculator.js.coffee
@@ -59,6 +59,8 @@
       )
     catch error
       console.log(error)
+      @clearResult(population, patient, options)
+      result = new Thorax.Models.Result({}, population: population, patient: patient)
       bonnie.showError({
         title: 'Measure Calculation Error',
         summary: "There was an error calculating measure #{measure.get('cqmMeasure').cms_id}.",

--- a/app/assets/javascripts/cqm_calculator.js.coffee
+++ b/app/assets/javascripts/cqm_calculator.js.coffee
@@ -39,7 +39,7 @@
         populationSetId = measure_population.get('population_set_id')
         populationSetResults = patientResults[populationSetId]
 
-        if populationSetResults.observation_values 
+        if populationSetResults.observation_values
           populationSetResults.observation_values.sort()
         else
           populationSetResults.observation_values = []
@@ -58,8 +58,11 @@
         console.log "finished calculation of #{cqmMeasure.cms_id} - #{patient.getFirstName()} #{patient.getLastName()}"
       )
     catch error
-      console.log error
-      result.state = 'cancelled'
+      bonnie.showError({
+        title: 'Measure Calculation Error',
+        summary: "There was an error calculating measure #{measure.get('cqmMeasure').cms_id}.",
+        body: "One of the data elements associated with the measure is causing an issue. Please review the elements associated with the measure to verify that they are all constructed properly.<br>Error message: <b>#{error.message}</b>"
+      })
     return result
 
   calculateAll: (measure, patients, options = {}) ->
@@ -126,7 +129,7 @@
         populationSetId = population.get('population_set_id')
         populationSetResults = patientResults[populationSetId]
 
-        if populationSetResults.observation_values 
+        if populationSetResults.observation_values
           populationSetResults.observation_values.sort()
         else
           populationSetResults.observation_values = []
@@ -138,7 +141,10 @@
       )
       console.log "finished BATCH calculation of #{cqmMeasure.cms_id}"
     catch error
-      console.log error
-      results.forEach((result) -> result.state = 'cancelled')
+      bonnie.showError({
+        title: 'Measure Calculation Error',
+        summary: "There was an error calculating measure #{measure.get('cqmMeasure').cms_id}.",
+        body: "One of the data elements associated with the measure is causing an issue. Please review the elements associated with the measure to verify that they are all constructed properly.<br>Error message: <b>#{error.message}</b>"
+      })
 
     return results

--- a/app/assets/javascripts/cqm_calculator.js.coffee
+++ b/app/assets/javascripts/cqm_calculator.js.coffee
@@ -58,6 +58,7 @@
         console.log "finished calculation of #{cqmMeasure.cms_id} - #{patient.getFirstName()} #{patient.getLastName()}"
       )
     catch error
+      console.log(error)
       bonnie.showError({
         title: 'Measure Calculation Error',
         summary: "There was an error calculating measure #{measure.get('cqmMeasure').cms_id}.",
@@ -141,6 +142,7 @@
       )
       console.log "finished BATCH calculation of #{cqmMeasure.cms_id}"
     catch error
+      console.log(error)
       bonnie.showError({
         title: 'Measure Calculation Error',
         summary: "There was an error calculating measure #{measure.get('cqmMeasure').cms_id}.",

--- a/app/assets/javascripts/error_handler.js.coffee
+++ b/app/assets/javascripts/error_handler.js.coffee
@@ -2,7 +2,7 @@
 Costanza.init (info, rawError) ->
   # Still print out the raw error for developers.
   console.error rawError
-  
+ 
   # Ignore mirrored Costanza error messages (we have already handled these).
   # This check stops doubled error message popups from appearing.
   unless /Costanza/i.test rawError.toString()

--- a/app/assets/javascripts/views/logic/cql_logic_patient_builder_view.js.coffee
+++ b/app/assets/javascripts/views/logic/cql_logic_patient_builder_view.js.coffee
@@ -15,5 +15,8 @@ class Thorax.Views.CqlPatientBuilderLogic extends Thorax.Views.BonnieView
   showRationale: (result) ->
     for pop in @population_names
       @results[pop] = result.get(pop)
-    @cqlLogicView.showRationale result
+    if !result.isPopulated()
+      @cqlLogicView.clearRationale()
+    else
+      @cqlLogicView.showRationale result
     @render()

--- a/spec/javascripts/patient_builder_tests/measure_view_spec.js.coffee
+++ b/spec/javascripts/patient_builder_tests/measure_view_spec.js.coffee
@@ -88,8 +88,12 @@
       jasmine.getJSONFixtures().clearCache()
       bonnie.measures = new Thorax.Collections.Measures()
       @cqlMeasure = loadMeasureWithValueSets 'cqm_measure_data/CMS134v6/CMS134v6.json', 'cqm_measure_data/CMS134v6/value_sets.json'
+      @measureWithError = loadMeasureWithValueSets 'cqm_measure_data/CMS136v7/CMS136v7.json', 'cqm_measure_data/CMS136v7/value_sets.json'
       bonnie.measures.add @cqlMeasure
+      bonnie.measures.add @measureWithError
+
       @cqlPatients = new Thorax.Collections.Patients [getJSONFixture('patients/CMS134v6/Elements_Test.json')], parse: true
+      @patientsWithError = new Thorax.Collections.Patients [getJSONFixture('patients/CMS136v7/Pass_IPP1.json')], parse: true
 
       @cqlMeasureValueSetsView = new Thorax.Views.MeasureValueSets(model: @cqlMeasure, measure: @cqlMeasure, patients: @cqlPatients)
       @cqlMeasureValueSetsView.appendTo 'body'
@@ -137,6 +141,16 @@
       @measureView.appendTo 'body'
       expect(@measureView.$("button[data-call-method=sharePatients]")).not.toExist()
       @measureView.remove()
+
+    it 'shows error dialog if cql calculation error occurs', ->
+      spyOn(bonnie, 'showError')
+      @measureWithError.get('populations').at(0).calculate(@patientsWithError.at(0))
+      expect(bonnie.showError).toHaveBeenCalled()
+
+    it 'shows error dialog if error occurs in batch cql calculation', ->
+      spyOn(bonnie, 'showError')
+      bonnie.cqm_calculator.calculateAll @measureWithError, @patientsWithError
+      expect(bonnie.showError).toHaveBeenCalled()
 
     describe 'value sets view', ->
       it 'exists', ->


### PR DESCRIPTION
Since we now do calculation on the front end, the error popup needs to be triggered there as well.

Pull requests into Bonnie require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] JIRA ticket for this PR: https://jira.mitre.org/browse/BONNIE-2131
- [x] JIRA ticket links to this PR
- [x] Code diff has been done and been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] If UI changes have been made, google WAVE plug-in has been executed to ensure no 508 issues were introduced.
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Test fixtures updated and documented as necessary ( see [internal wiki](https://gitlab.mitre.org/bonnie/internal-documentation/wikis/testing#test-fixtures) )
- [x] Code coverage has not gone down and all code touched or added is covered. 
- [x] Automated regression test(s) pass


**Reviewer 1:**

Name: @hossenlopp
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

**Reviewer 2:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
