### PR TITLE
MAT-1008: Fixing the parent.highlightEntry() bug

### DIFF
--- a/app/assets/javascripts/views/logic/cql_clause_view.js.coffee
+++ b/app/assets/javascripts/views/logic/cql_clause_view.js.coffee
@@ -107,7 +107,7 @@ class Thorax.Views.CqlClauseView extends Thorax.Views.BonnieView
 
       # if we dont have a ref_id then we may just be a text clause. so we pass this to our parent clause
       else
-        @parent.highlightEntry()
+        @parent?.highlightEntry?()
 
   ###*
   # Event handler for the mouseout event. This will report to the CqlPopulationLogic view that highlighting should be cleared.


### PR DESCRIPTION
After the Bonnie hand-off, we discovered an abundance of errors being reported. The vast majority were complaining about

    TypeError: this.parent.highlightEntry is not a function

Although clearly a bug in the JavaScript code, evidently, it has no impact on the user's experience. However, the logs are flooded with this message, obscuring any actual, important errors.

As it had no impact, this was deemed a low priority. But the fix is trivial, and would allow for better monitoring of actual errors.