### PR TITLE
[MAT-1781] Correctly display the Duplicate Error message

### DIFF
--- a/app/helpers/measure_helper.rb
+++ b/app/helpers/measure_helper.rb
@@ -329,9 +329,5 @@ module MeasureHelper
       f.write("Original Filename was #{uploaded_file.original_filename}\n")
       f.write(error.to_s + "\n" + (error.backtrace||[]).join("\n"))
     end
-    # email the error
-    if error.respond_to?(:operator_error) && error.operator_error && defined? ExceptionNotifier::Notifier # rubocop:disable Style/GuardClause, Style/IfUnlessModifier
-      ExceptionNotifier::Notifier.exception_notification(Rails.env, error).deliver_now
-    end
   end
 end

--- a/app/helpers/measure_helper.rb
+++ b/app/helpers/measure_helper.rb
@@ -1,11 +1,11 @@
 module MeasureHelper
   class SharedError < StandardError
     attr_reader :front_end_version, :back_end_version, :operator_error
-    def initialize(msg: "Error", front_end_version:, back_end_version:, operator_error: false)
+    def initialize(msg: nil, front_end_version:, back_end_version:, operator_error: false)
+      msg ||= front_end_version[:summary] || "Error"
       @front_end_version = front_end_version
       @back_end_version = back_end_version
       @operator_error = operator_error
-      msg = front_end_version[:summary] unless front_end_version[:summary].nil?
       super(msg)
     end
   end

--- a/app/helpers/measure_helper.rb
+++ b/app/helpers/measure_helper.rb
@@ -330,7 +330,7 @@ module MeasureHelper
     end
     # email the error
     if error.respond_to?(:operator_error) && error.operator_error && defined? ExceptionNotifier::Notifier # rubocop:disable Style/GuardClause, Style/IfUnlessModifier
-      ExceptionNotifier::Notifier.exception_notification(env, error).deliver_now
+      ExceptionNotifier::Notifier.exception_notification(Rails.env, error).deliver_now
     end
   end
 end

--- a/app/helpers/measure_helper.rb
+++ b/app/helpers/measure_helper.rb
@@ -5,6 +5,7 @@ module MeasureHelper
       @front_end_version = front_end_version
       @back_end_version = back_end_version
       @operator_error = operator_error
+      msg = front_end_version[:summary] unless front_end_version[:summary].nil?
       super(msg)
     end
   end


### PR DESCRIPTION
An unexpected error was bubbling up from the `ExceptionNotifier` attempting to email the error to the end-user when uploading a duplicate measure. The Error from `ExceptionNotifier` was blocking the duplicate measure error from triggering the UI error message.

Per discussion with BA and dev team, emailing the error to the end-user has been removed in favor of UI-only error display.

Adding the error summary to the error log file.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] JIRA ticket for this PR: [MAT-1781](https://jira.cms.gov/browse/MAT-1781)
- [ ] JIRA ticket links to this PR
- [ ] Code diff has been done and been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [ ] If UI changes have been made, google WAVE plug-in has been executed to ensure no 508 issues were introduced.
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [ ] Test fixtures updated and documented as necessary ( see [internal wiki](https://gitlab.mitre.org/bonnie/internal-documentation/wikis/testing#test-fixtures) )
- [ ] Code coverage has not gone down and all code touched or added is covered. 
     * In rare situations, this may not be possible or applicable to a PR. In those situations:
         1. Note why this could not be done or is not applicable here: 
         2. Add TODOs in the code noting that it requires a test
         3. Add a JIRA task to add the test and link it here: 
- [ ] Automated regression test(s) pass

If JIRA tests were used to supplement or replace automated tests:
- [ ] JIRA test links:
- [ ] Justification for using JIRA tests:
- [ ] JIRA tests have been added to sprint


**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

If JIRA tests were used to supplement or replace automated tests:
- [ ] JIRA tests have been run and pass
- [ ] You agree with the justification for use of JIRA tests or have provided input on why you disagree


**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

If JIRA tests were used to supplement or replace automated tests:
- [ ] JIRA tests have been run and pass
- [ ] You agree with the justification for use of JIRA tests or have provided input on why you disagree
