### PR TITLE
Save the Code System's FHIR URI when setting the Resource's Primary Code

### DIFF
--- a/app/assets/javascripts/helpers/fhir_value_sets.js.coffee
+++ b/app/assets/javascripts/helpers/fhir_value_sets.js.coffee
@@ -28,6 +28,15 @@
     @_codeSystemMap['http://hl7.org/fhir/diagnostic-report-status'] = 'DiagnosticReportStatus'
     @_codeSystemMap['http://terminology.hl7.org/CodeSystem/observation-category'] = 'ObservationCategoryCodes'
     @_codeSystemMap['http://loinc.org'] = 'LOINCCodes'
+    # Source: https://www.hl7.org/fhir/terminologies-systems.html#tabs-ext & https://cts.nlm.nih.gov/fhir/index.html
+    @_codeSystemMap['http://loinc.org'] = 'LOINC'
+    @_codeSystemMap['http://snomed.info/sct'] = 'SNOMEDCT'
+    @_codeSystemMap['http://www.ama-assn.org/go/cpt'] = 'CPT'
+    # Source: https://cts.nlm.nih.gov/fhir/index.html
+    @_codeSystemMap['http://www.nlm.nih.gov/research/umls/sop'] = 'SOP'
+    @_codeSystemMap['http://hl7.org/fhir/sid/icd-9-cm'] = 'ICD9CM' #Source: https://cts.nlm.nih.gov/fhir/index.html
+    @_codeSystemMap['http://www.icd10data.com/icd10pcs'] = 'ICD10PCS' #Source: https://cts.nlm.nih.gov/fhir/index.html
+    @_codeSystemMap['http://hl7.org/fhir/sid/icd-10-cm'] = 'ICD10CM' #Source: https://cts.nlm.nih.gov/fhir/index.html
 
     return @_codeSystemMap
 

--- a/spec/javascripts/patient_builder_tests/input_views/code_input_view_spec.js.coffee
+++ b/spec/javascripts/patient_builder_tests/input_views/code_input_view_spec.js.coffee
@@ -44,7 +44,7 @@ describe 'InputView', ->
 
       # pick system
       view.$('select[name="vs_codesystem"] > option[value="encounter-status"]').prop('selected', true).change()
-      expect(view.$('select[name="vs_codesystem"]').val()).toBe 'encounter-status'
+      expect(view.$('select[name="vs_codesystem"]').val()).toBe 'http://hl7.org/fhir/encounter-status'
       expect(view.hasValidValue()).toBe true
 
       # pick code


### PR DESCRIPTION
Saving the code system URI, when available, otherwise use system name. The HL7 FHIR framework uses custom code system uniform resource identifiers (URIs) to reference code systems.

- Adding more systems and their FHIR URI's to the codeSystemMap.
- Extracted the codeSystem URI look up code into its own function and refactored addCode and addDefaultCodeToDataElement to save the system URI instead of just the name retrieved from VSAC.

**Updated Primary Code JSON from Encounter Resource**
```
"type": [
  {
    "coding": [
      {
        "system": "http://www.ama-assn.org/go/cpt",
        "version": "2020",
        "code": "99385",
        "display": "Initial comprehensive preventive medicine evaluation and management of an individual including an age and gender appropriate history, examination, counseling/anticipatory guidance/risk factor reduction interventions, and the ordering of laboratory/diagnostic procedures, new patient; 18-39 years",
        "userSelected": true
      }
    ]
  }
]
```

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] This PR is into the correct branch.
- [ ] JIRA ticket for this PR:
- [ ] JIRA ticket links to this PR
- [ ] Code diff has been done and been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [ ] If UI changes have been made, google WAVE plug-in has been executed to ensure no 508 issues were introduced.
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [ ] Test fixtures updated and documented as necessary ( see [internal wiki](https://gitlab.mitre.org/bonnie/internal-documentation/wikis/testing#test-fixtures) )
- [ ] Code coverage has not gone down and all code touched or added is covered. 
     * In rare situations, this may not be possible or applicable to a PR. In those situations:
         1. Note why this could not be done or is not applicable here: 
         2. Add TODOs in the code noting that it requires a test
         3. Add a JIRA task to add the test and link it here: 
- [ ] Automated regression test(s) pass

If JIRA tests were used to supplement or replace automated tests:
- [ ] JIRA test links:
- [ ] Justification for using JIRA tests:
- [ ] JIRA tests have been added to sprint


**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

If JIRA tests were used to supplement or replace automated tests:
- [ ] JIRA tests have been run and pass
- [ ] You agree with the justification for use of JIRA tests or have provided input on why you disagree


**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

If JIRA tests were used to supplement or replace automated tests:
- [ ] JIRA tests have been run and pass
- [ ] You agree with the justification for use of JIRA tests or have provided input on why you disagree
