### PR TITLE
Parse unknown code system names from their uri

### DIFF
--- a/app/assets/javascripts/models/measure.js.coffee
+++ b/app/assets/javascripts/models/measure.js.coffee
@@ -104,7 +104,7 @@ class Thorax.Models.Measure extends Thorax.Model
     @get('cqmValueSets').forEach (valueSet) =>
       valueSet.compose?.include?.forEach (vsInclude) =>
         if !@_codeSystemMap.hasOwnProperty(vsInclude.system)
-          @_codeSystemMap[vsInclude.system] = vsInclude.system
+          @_codeSystemMap[vsInclude.system] = vsInclude.system.split('/').slice(-1)[0] || vsInclude.system
 
     # Add value sets from FHIR bindings
     Object.assign(@_codeSystemMap, FhirValueSets.bindingsCodeSystemMap())

--- a/app/assets/javascripts/views/patient_builder/inputs/code.js.coffee
+++ b/app/assets/javascripts/views/patient_builder/inputs/code.js.coffee
@@ -8,7 +8,7 @@ class Thorax.Views.InputCodeView extends Thorax.Views.BonnieView
   #   initialValue - code value - Optional. Initial value of code.
   #   cqmValueSets - List of CQM Value sets. Optional (FHIR JSON).
   #   allowNull - boolean - Optional. If a null or empty integer is allowed. Defaults to false.
-  #   isSystemFixed - boolean - Optiona. Default to false. If true, then the Custom system is always the first system from the list of systems.
+  #   isSystemFixed - boolean - Optional. Default to false. If true, then the Custom system is always the first system from the list of systems.
   #     It's used for a PrimitiveCode, when a system is implied for an attribute (see bindings).
   initialize: ->
     if @initialValue?
@@ -25,8 +25,7 @@ class Thorax.Views.InputCodeView extends Thorax.Views.BonnieView
       valueSet.compose?.include?.forEach (vsInclude) =>
         system = vsInclude.system
         if !@codeSystems.hasOwnProperty(system)
-          name = @codeSystemMap?[system] || system.split('/').slice(-1)[0]
-          @codeSystems[system] = name
+          @codeSystems[system] = @codeSystemMap?[system]
     @systemFixed = @cqmValueSets?[0]?.compose?.include?[0]?.system
 
   events:

--- a/app/assets/javascripts/views/patient_builder/inputs/coding.js.coffee
+++ b/app/assets/javascripts/views/patient_builder/inputs/coding.js.coffee
@@ -24,8 +24,7 @@ class Thorax.Views.InputCodingView extends Thorax.Views.BonnieView
       valueSet.compose?.include?.forEach (vsInclude) =>
         system = vsInclude.system
         if !@codeSystems.hasOwnProperty(system)
-          name = @codeSystemMap?[system] || system.split('/').slice(-1)[0]
-          @codeSystems[system] = name
+          @codeSystems[system] = @codeSystemMap?[system]
 
   events:
     'change input': 'handleCustomInputChange'
@@ -55,7 +54,7 @@ class Thorax.Views.InputCodingView extends Thorax.Views.BonnieView
           @handleValueSetChange()
           isCustomCodeSystem = !(@allCodeSystems.find (codeSystem) -> codeSystem.system == value?.system?.value)?
 
-          # if the code system is in the measure, select it, otherwise select custom and fillthat
+          # if the code system is in the measure, select it, otherwise select custom and fill that
           if !isCustomCodeSystem
             @$("select[name=\"custom_codesystem_select\"] > option[value=\"#{value?.system?.value}\"]").prop('selected', true)
           else


### PR DESCRIPTION
When building the contents for the value set / drc dropdowns, the logic  defers to the codeSystemMap before attempting to parse a human readable name from the uri. However, the codeSystemMap already generates entries for missing code systems. As a result, the logic in the input view to parse the human readable from the uri is never reached.

Moving the human readable parsing logic to the measure model when building the codeSystemMap.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] This PR is into the correct branch.
- [ ] JIRA ticket for this PR:
- [ ] JIRA ticket links to this PR
- [ ] Code diff has been done and been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [ ] If UI changes have been made, google WAVE plug-in has been executed to ensure no 508 issues were introduced.
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [ ] Test fixtures updated and documented as necessary ( see [internal wiki](https://gitlab.mitre.org/bonnie/internal-documentation/wikis/testing#test-fixtures) )
- [ ] Code coverage has not gone down and all code touched or added is covered. 
     * In rare situations, this may not be possible or applicable to a PR. In those situations:
         1. Note why this could not be done or is not applicable here: 
         2. Add TODOs in the code noting that it requires a test
         3. Add a JIRA task to add the test and link it here: 
- [ ] Automated regression test(s) pass

If JIRA tests were used to supplement or replace automated tests:
- [ ] JIRA test links:
- [ ] Justification for using JIRA tests:
- [ ] JIRA tests have been added to sprint


**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

If JIRA tests were used to supplement or replace automated tests:
- [ ] JIRA tests have been run and pass
- [ ] You agree with the justification for use of JIRA tests or have provided input on why you disagree


**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

If JIRA tests were used to supplement or replace automated tests:
- [ ] JIRA tests have been run and pass
- [ ] You agree with the justification for use of JIRA tests or have provided input on why you disagree
