### PR TITLE
Un-ignoring vulnerability check

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Perform audit check for vulnerabilities
         env:
           RAILS_ENV: test
-        run: bundle exec bundle-audit check --update --ignore=CVE-2020-26247
+        run: bundle exec bundle-audit check --update
 
       - name: Set and run up overcommit
         run: |


### PR DESCRIPTION
Un-ignoring this vulnerability check, since we're now using a newer version of nokogiri