### PR TITLE
remove cap version lock and set correct ruby version in local.rb

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,5 +1,4 @@
 # config valid only for Capistrano 3.1
-lock '3.14.1'
 
 set :application, 'bonnie'
 set :repo_url, 'https://github.com/MeasureAuthoringTool/bonnie.git'

--- a/config/deploy/local.rb
+++ b/config/deploy/local.rb
@@ -5,7 +5,7 @@
 set :stage, :production
 
 # Tell RVM to use the current ruby when running capistrano
-set :rvm1_ruby_version, '2.4.5'
+set :rvm1_ruby_version, '2.7.2'
 
 # Set the branch to the currently checked out branch
 set :branch, `git rev-parse --abbrev-ref HEAD`.chomp


### PR DESCRIPTION
This'll fix 2 problems w/ Capistrano: 
- Nix the cap version lock in deploy.rb
- Set Ruby version to 2.7.2 in cap's local.rb  